### PR TITLE
fix: Linux 下 dlcv_infer_cpp_dll 推理结果文本乱码

### DIFF
--- a/dlcv_infer_cpp_dll/dlcv_infer.cpp
+++ b/dlcv_infer_cpp_dll/dlcv_infer.cpp
@@ -1127,7 +1127,7 @@ namespace dlcv_infer {
 #ifdef _WIN32
         return Win32WideToMultiByte(inputWstring, 936);
 #else
-        return ConvertEncodingPortable(WideToUtf8Portable(inputWstring), "UTF-8", "GBK");
+        return WideToUtf8Portable(inputWstring);
 #endif
     }
 
@@ -1135,7 +1135,7 @@ namespace dlcv_infer {
 #ifdef _WIN32
         return Win32MultiByteToWide(inputGbk, 936);
 #else
-        return Utf8ToWidePortable(ConvertEncodingPortable(inputGbk, "GBK", "UTF-8"));
+        return Utf8ToWidePortable(inputGbk);
 #endif
     }
 


### PR DESCRIPTION
## 问题
在 Windows 上推理结果文本显示正常，但在 Linux 上 气球检测 等中文类别名称出现乱码。

## 根因
dlcv_infer_cpp_dll 在解析推理结果时，将 JSON 中的 category_name 等字符串通过 convertUtf8ToGbk 转为 GBK。Windows 中文控制台默认 GBK，显示正常；Linux 系统原生使用 UTF-8，GBK 字节流在 UTF-8 环境下呈现乱码。

## 修复
让 Linux 平台下的 GBK 转换函数直接透传 UTF-8：
- convertWstringToGbk → WideToUtf8Portable
- convertGbkToWstring → Utf8ToWidePortable

Windows 分支保持原有行为不变。

## 验证
使用 气球检测 dvt 模型 + balloon.jpg，在 Linux x64 环境实测：
- 模型加载与推理正常
- 类别名称：气球 显示正常，无乱码
- bbox、mask 数值正确
