### PR TITLE
fix: add multi-candidate DLL loading for new dlcv env

### DIFF
--- a/dlcv_infer_cpp_dll/dlcv_infer.cpp
+++ b/dlcv_infer_cpp_dll/dlcv_infer.cpp
@@ -1164,7 +1164,7 @@ namespace dlcv_infer {
             dllPath = "C:\\dlcv\\Lib\\site-packages\\dlcvpro_infer\\dlcv_infer.dll";
 #else
             dllName = "libdlcv_infer.so";
-            dllPath = "/root/miniconda3/lib/python3.11/site-packages/dlcvpro_infer/libdlcv_infer.so";
+            dllPath = "/root/dlcv/lib/python3.11/site-packages/dlcvpro_infer/libdlcv_infer.so";
 #endif
             break;
         case sntl_admin::DogProvider::Virbox:
@@ -1173,7 +1173,7 @@ namespace dlcv_infer {
             dllPath = "C:\\dlcv\\Lib\\site-packages\\dlcvpro_infer\\dlcv_infer_v.dll";
 #else
             dllName = "libdlcv_infer.so";
-            dllPath = "/root/miniconda3/lib/python3.11/site-packages/dlcvpro_infer/libdlcv_infer.so";
+            dllPath = "/root/dlcv/lib/python3.11/site-packages/dlcvpro_infer/libdlcv_infer.so";
 #endif
             break;
         default:
@@ -1226,21 +1226,26 @@ namespace dlcv_infer {
 
 #else
         const std::string dllCurrentPath = JoinPath(".", dllName);
+        std::vector<std::string> candidates;
         // 1. 开发环境路径（与当前模块同目录）
         if (!dllDevPath.empty()) {
-            hModule = dlopen(dllDevPath.c_str(), RTLD_LAZY | RTLD_LOCAL);
+            candidates.push_back(dllDevPath);
         }
         // 2. 当前工作目录
-        if (!hModule) {
-            hModule = dlopen(dllCurrentPath.c_str(), RTLD_LAZY | RTLD_LOCAL);
+        candidates.push_back(dllCurrentPath);
+        // 3. site-packages 候选路径（新环境）
+        candidates.push_back("/root/dlcv/lib/python3.11/site-packages/dlcvpro_infer/libdlcv_infer.so");
+        // 4. site-packages 候选路径（旧环境兼容）
+        candidates.push_back("/root/miniconda3/lib/python3.11/site-packages/dlcvpro_infer/libdlcv_infer.so");
+
+        for (const auto& path : candidates) {
+            if (path.empty()) continue;
+            hModule = dlopen(path.c_str(), RTLD_LAZY | RTLD_LOCAL);
+            if (hModule) break;
         }
-        // 3. 系统搜索路径（LD_LIBRARY_PATH / rpath 等）
+        // 5. 系统搜索路径（LD_LIBRARY_PATH / rpath 等）
         if (!hModule) {
             hModule = dlopen(dllName.c_str(), RTLD_LAZY | RTLD_LOCAL);
-        }
-        // 4. site-packages 固定路径
-        if (!hModule && !dllPath.empty() && dllPath != dllName) {
-            hModule = dlopen(dllPath.c_str(), RTLD_LAZY | RTLD_LOCAL);
         }
         if (hModule == nullptr)
         {


### PR DESCRIPTION
## 问题
环境从 `/root/miniconda3` 迁移到 `/root/dlcv`，原有的硬编码 miniconda3 路径导致运行时无法加载 `libdlcv_infer.so`。

## 修改
- 更新 `DllLoader::LoadDll()` Linux 逻辑，改为按候选路径列表逐个尝试：
  1. 模块同目录（dev 路径）
  2. 当前工作目录
  3. `/root/dlcv/lib/python3.11/site-packages/dlcvpro_infer/libdlcv_infer.so`
  4. `/root/miniconda3/lib/python3.11/site-packages/dlcvpro_infer/libdlcv_infer.so`（兼容旧环境）
  5. 系统搜索路径（LD_LIBRARY_PATH）
- 构造函数中的默认 `dllPath` 同步更新为新环境路径。

## 验证
- 本地编译通过，`libdlcv_infer_cpp_dll.so` 构建成功。