### PR TITLE
feat: BBoxIoU去重跨模型分组与模块重命名兼容

### DIFF
--- a/DlcvCsharpApi/flow/modules/Features.cs
+++ b/DlcvCsharpApi/flow/modules/Features.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
 using Newtonsoft.Json.Linq;
 using OpenCvSharp;
 
@@ -3344,6 +3347,7 @@ namespace DlcvModules
     /// - 仅处理 type == "local" 的条目
     /// - 从 sample_results 提取 bbox=[x,y,w,h]，内部转换为 xyxy 后按分组与面积从大到小去重
     /// - metric 支持 iou / ios；per_category 控制是否按类别分别去重
+    /// - cross_model 默认 true：跨不同模型分支按原图指纹 + transform 分组；false 时按 index/origin_index/transform 严格分组
     /// </summary>
     public class BBoxIoUDedup : BaseModule
     {
@@ -3374,6 +3378,18 @@ namespace DlcvModules
             string metric = NormalizeMetric(GetPropertyString("metric", "iou"));
             double threshold = Clamp01(GetPropertyDouble("iou_threshold", 0.5));
             bool perCategory = GetPropertyBool("per_category", true);
+            bool crossModel = GetPropertyBool("cross_model", true);
+            var imageGroups = crossModel ? BuildImageGroupsByIndex(images) : new Dictionary<int, string>();
+            string singleImageGroup = null;
+            if (imageGroups.Count > 0)
+            {
+                var uniqueGroups = new List<string>();
+                foreach (string group in imageGroups.Values)
+                {
+                    if (!uniqueGroups.Contains(group)) uniqueGroups.Add(group);
+                }
+                if (uniqueGroups.Count == 1) singleImageGroup = uniqueGroups[0];
+            }
 
             var keepFlags = new Dictionary<int, List<bool>>();
             var grouped = new Dictionary<string, List<Candidate>>(StringComparer.Ordinal);
@@ -3394,7 +3410,9 @@ namespace DlcvModules
                 int idx = SafeInt(entry["index"], -1);
                 int originIdx = SafeInt(entry["origin_index"], idx);
                 string transformSig = SerializeTokenCompact(entry["transform"]);
-                string entryGroupKey = string.Format("{0}|{1}|{2}", idx, originIdx, transformSig);
+                string entryGroupKey = crossModel
+                    ? BuildCrossModelGroupKey(entry, imageGroups, singleImageGroup)
+                    : BuildStrictGroupKey(idx, originIdx, transformSig);
 
                 for (int detIdx = 0; detIdx < dets.Count; detIdx++)
                 {
@@ -3537,6 +3555,109 @@ namespace DlcvModules
             return defaultValue;
         }
 
+        private static Dictionary<int, string> BuildImageGroupsByIndex(List<ModuleImage> images)
+        {
+            var groups = new Dictionary<int, string>();
+            if (images == null) return groups;
+
+            for (int i = 0; i < images.Count; i++)
+            {
+                string fingerprint = ImageFingerprint(images[i]);
+                if (!string.IsNullOrEmpty(fingerprint))
+                {
+                    groups[i] = fingerprint;
+                }
+            }
+            return groups;
+        }
+
+        private static string BuildCrossModelGroupKey(JObject entry, Dictionary<int, string> imageGroups, string singleImageGroup)
+        {
+            int idx = SafeInt(entry["index"], -1);
+            int originIdx = SafeInt(entry["origin_index"], idx);
+            string transformSig = SerializeTokenCompact(entry["transform"]);
+
+            string group;
+            if (imageGroups != null)
+            {
+                if (imageGroups.TryGetValue(originIdx, out group)) return "image|" + group + "|" + transformSig;
+                if (imageGroups.TryGetValue(idx, out group)) return "image|" + group + "|" + transformSig;
+            }
+
+            if (!string.IsNullOrEmpty(singleImageGroup)) return "image|" + singleImageGroup + "|" + transformSig;
+            return BuildStrictGroupKey(idx, originIdx, transformSig);
+        }
+
+        private static string BuildStrictGroupKey(int idx, int originIdx, string transformSig)
+        {
+            return string.Format("{0}|{1}|{2}", idx, originIdx, transformSig);
+        }
+
+        private static string ImageFingerprint(ModuleImage image)
+        {
+            try
+            {
+                if (image == null) return null;
+                Mat mat = image.OriginalImage;
+                if (mat == null || mat.Empty()) mat = image.ImageObject;
+                if (mat == null || mat.Empty()) return null;
+
+                using (var md5 = MD5.Create())
+                {
+                    string header = string.Format(
+                        "{0}x{1}x{2}:{3}",
+                        mat.Rows,
+                        mat.Cols,
+                        mat.Channels(),
+                        mat.Type());
+                    AppendBytes(md5, Encoding.UTF8.GetBytes(header));
+
+                    const int patchHeight = 8;
+                    const int patchWidth = 8;
+                    var coords = new[]
+                    {
+                        Tuple.Create(0, 0),
+                        Tuple.Create(0, Math.Max(0, mat.Cols - patchWidth)),
+                        Tuple.Create(Math.Max(0, mat.Rows - patchHeight), 0),
+                        Tuple.Create(Math.Max(0, mat.Rows - patchHeight), Math.Max(0, mat.Cols - patchWidth)),
+                        Tuple.Create(Math.Max(0, mat.Rows / 2 - patchHeight / 2), Math.Max(0, mat.Cols / 2 - patchWidth / 2))
+                    };
+
+                    foreach (var coord in coords)
+                    {
+                        int yy = coord.Item1;
+                        int xx = coord.Item2;
+                        int width = Math.Min(patchWidth, mat.Cols - xx);
+                        int height = Math.Min(patchHeight, mat.Rows - yy);
+                        if (width <= 0 || height <= 0) continue;
+
+                        using (var patch = new Mat(mat, new Rect(xx, yy, width, height)))
+                        using (var contiguous = patch.Clone())
+                        {
+                            long byteCountLong = contiguous.Total() * contiguous.ElemSize();
+                            if (byteCountLong <= 0 || byteCountLong > int.MaxValue) continue;
+                            var bytes = new byte[(int)byteCountLong];
+                            Marshal.Copy(contiguous.Data, bytes, 0, bytes.Length);
+                            AppendBytes(md5, bytes);
+                        }
+                    }
+
+                    md5.TransformFinalBlock(new byte[0], 0, 0);
+                    return BitConverter.ToString(md5.Hash).Replace("-", "").ToLowerInvariant();
+                }
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static void AppendBytes(HashAlgorithm hash, byte[] bytes)
+        {
+            if (bytes == null || bytes.Length == 0) return;
+            hash.TransformBlock(bytes, 0, bytes.Length, null, 0);
+        }
+
         private double GetPropertyDouble(string key, double defaultValue)
         {
             if (Properties != null && Properties.TryGetValue(key, out object v) && v != null)
@@ -3551,8 +3672,12 @@ namespace DlcvModules
             if (Properties != null && Properties.TryGetValue(key, out object v) && v != null)
             {
                 if (v is bool b) return b;
-                if (bool.TryParse(v.ToString(), out bool pb)) return pb;
-                if (int.TryParse(v.ToString(), out int pi)) return pi != 0;
+                string s = v.ToString();
+                if (bool.TryParse(s, out bool pb)) return pb;
+                if (int.TryParse(s, out int pi)) return pi != 0;
+                s = (s ?? string.Empty).Trim().ToLowerInvariant();
+                if (s == "yes" || s == "y" || s == "on") return true;
+                if (s == "no" || s == "n" || s == "off") return false;
             }
             return defaultValue;
         }

--- a/DlcvCsharpApi/flow/modules/Features.cs
+++ b/DlcvCsharpApi/flow/modules/Features.cs
@@ -19,6 +19,7 @@ namespace DlcvModules
     {
         static ImageGeneration()
         {
+            ModuleRegistry.Register("pre_process/image_generation", typeof(ImageGeneration));
             ModuleRegistry.Register("features/image_generation", typeof(ImageGeneration));
         }
 
@@ -304,7 +305,7 @@ namespace DlcvModules
                     var outEntry = new JObject
                     {
                         ["type"] = "local",
-                        ["originating_module"] = "features/image_generation",
+                        ["originating_module"] = "pre_process/image_generation",
                         ["index"] = outIndex,
                         ["origin_index"] = parentWrap != null ? parentWrap.OriginalIndex : originIndex,
                         ["transform"] = JObject.FromObject(childState.ToDict()),
@@ -408,6 +409,7 @@ namespace DlcvModules
     {
         static ImageFlip()
         {
+            ModuleRegistry.Register("pre_process/image_flip", typeof(ImageFlip));
             ModuleRegistry.Register("features/image_flip", typeof(ImageFlip));
         }
 
@@ -1762,6 +1764,7 @@ namespace DlcvModules
     {
         static ImageRotateByClassification()
         {
+            ModuleRegistry.Register("pre_process/image_rotate_by_cls", typeof(ImageRotateByClassification));
             ModuleRegistry.Register("features/image_rotate_by_cls", typeof(ImageRotateByClassification));
         }
 

--- a/DlcvCsharpApi/flow/modules/SlidingMerge.cs
+++ b/DlcvCsharpApi/flow/modules/SlidingMerge.cs
@@ -104,6 +104,7 @@ namespace DlcvModules
 
 		static SlidingMergeResults()
 		{
+			ModuleRegistry.Register("post_process/sliding_merge", typeof(SlidingMergeResults));
 			ModuleRegistry.Register("pre_process/sliding_merge", typeof(SlidingMergeResults));
 			ModuleRegistry.Register("features/sliding_merge", typeof(SlidingMergeResults));
 		}

--- a/Test/DlcvCSharpTest/Program.cs
+++ b/Test/DlcvCSharpTest/Program.cs
@@ -72,6 +72,11 @@ namespace DlcvCSharpTest
                     return RunMaskToRBoxSelfTest();
                 }
 
+                if (args != null && args.Length >= 1 && string.Equals(args[0], "bbox-iou-dedup-selftest", StringComparison.OrdinalIgnoreCase))
+                {
+                    return RunBBoxIoUDedupSelfTest();
+                }
+
                 if (args != null && args.Length >= 1 && string.Equals(args[0], "rect-image-correction-selftest", StringComparison.OrdinalIgnoreCase))
                 {
                     return RunRectImageCorrectionSelfTest();
@@ -1910,6 +1915,94 @@ namespace DlcvCSharpTest
                 Console.WriteLine("mask_to_rbox 自测通过");
                 return 0;
             }
+        }
+
+        private static int RunBBoxIoUDedupSelfTest()
+        {
+            Console.WriteLine("==== BBOX IoU 去重自测 ====");
+
+            using (var image = new Mat(320, 320, MatType.CV_8UC3, new Scalar(0, 255, 0)))
+            {
+                var state = new TransformationState(image.Width, image.Height);
+                var moduleImage = new ModuleImage(image, image, state, 0);
+                var images = new List<ModuleImage> { moduleImage };
+
+                var defaultModule = new BBoxIoUDedup(
+                    101,
+                    properties: new Dictionary<string, object>
+                    {
+                        ["iou_threshold"] = 0.5,
+                        ["per_category"] = true
+                    });
+                ModuleIO defaultOutput = defaultModule.Process(images, BuildBBoxDedupResults());
+                int defaultCount = CountBBoxDedupDetections(defaultOutput.ResultList);
+                if (defaultCount != 1)
+                {
+                    Console.WriteLine("默认 cross_model=true 应跨 index 去重，实际保留数量: " + defaultCount);
+                    return 1;
+                }
+
+                var strictModule = new BBoxIoUDedup(
+                    102,
+                    properties: new Dictionary<string, object>
+                    {
+                        ["iou_threshold"] = 0.5,
+                        ["per_category"] = true,
+                        ["cross_model"] = false
+                    });
+                ModuleIO strictOutput = strictModule.Process(images, BuildBBoxDedupResults());
+                int strictCount = CountBBoxDedupDetections(strictOutput.ResultList);
+                if (strictCount != 2)
+                {
+                    Console.WriteLine("cross_model=false 应恢复严格 index 分组，实际保留数量: " + strictCount);
+                    return 1;
+                }
+            }
+
+            Console.WriteLine("BBOX IoU 去重自测通过");
+            return 0;
+        }
+
+        private static JArray BuildBBoxDedupResults()
+        {
+            return new JArray
+            {
+                BuildBBoxDedupEntry(0, new JArray(10.0, 10.0, 100.0, 100.0)),
+                BuildBBoxDedupEntry(1, new JArray(20.0, 20.0, 80.0, 80.0))
+            };
+        }
+
+        private static JObject BuildBBoxDedupEntry(int index, JArray bbox)
+        {
+            return new JObject
+            {
+                ["type"] = "local",
+                ["index"] = index,
+                ["origin_index"] = index,
+                ["sample_results"] = new JArray
+                {
+                    new JObject
+                    {
+                        ["bbox"] = bbox,
+                        ["category_id"] = 1,
+                        ["category_name"] = "target",
+                        ["score"] = 0.9
+                    }
+                }
+            };
+        }
+
+        private static int CountBBoxDedupDetections(JArray results)
+        {
+            int count = 0;
+            if (results == null) return count;
+            foreach (JToken token in results)
+            {
+                var entry = token as JObject;
+                var dets = entry?["sample_results"] as JArray;
+                if (dets != null) count += dets.Count;
+            }
+            return count;
         }
 
         private static int RunDemo2RgbSelfTest(string[] args)

--- a/Test/dlcv_infer_cpp_test/main.cpp
+++ b/Test/dlcv_infer_cpp_test/main.cpp
@@ -1268,6 +1268,186 @@ int RunRectImageCorrectionSelfTest() {
     std::cout << "rect_image_correction 自测通过\n";
     return 0;
 }
+
+int CountBBoxDedupDetections(const json& results) {
+    if (!results.is_array()) return 0;
+    int count = 0;
+    for (const auto& entry : results) {
+        if (entry.is_object() && entry.contains("sample_results") && entry.at("sample_results").is_array()) {
+            count += static_cast<int>(entry.at("sample_results").size());
+            continue;
+        }
+        if (entry.is_object() && entry.contains("bbox")) {
+            count += 1;
+        }
+    }
+    return count;
+}
+
+json BuildBBoxDedupFlow(bool crossModel) {
+    json dedupProps = json::object({{"iou_threshold", 0.5}, {"per_category", true}});
+    if (!crossModel) dedupProps["cross_model"] = false;
+
+    return json::object({
+        {"nodes", json::array({
+            json::object({
+                {"id", 1},
+                {"order", 1},
+                {"type", "input/frontend_image"},
+                {"outputs", json::array({
+                    json::object({{"type", "image_chan"}, {"links", json::array({101})}}),
+                    json::object({{"type", "result_chan"}, {"links", json::array({102})}})
+                })}
+            }),
+            json::object({
+                {"id", 2},
+                {"order", 2},
+                {"type", "input/build_results"},
+                {"properties", json::object({
+                    {"category_id", 1},
+                    {"category_name", "target"},
+                    {"score", 0.99},
+                    {"bbox_x1", 10.0},
+                    {"bbox_y1", 10.0},
+                    {"bbox_x2", 110.0},
+                    {"bbox_y2", 110.0}
+                })},
+                {"inputs", json::array({
+                    json::object({{"type", "image_chan"}, {"link", 101}}),
+                    json::object({{"type", "result_chan"}, {"link", 102}})
+                })},
+                {"outputs", json::array({
+                    json::object({{"type", "image_chan"}, {"links", json::array({201})}}),
+                    json::object({{"type", "result_chan"}, {"links", json::array({202})}})
+                })}
+            }),
+            json::object({
+                {"id", 3},
+                {"order", 3},
+                {"type", "input/build_results"},
+                {"properties", json::object({
+                    {"category_id", 1},
+                    {"category_name", "target"},
+                    {"score", 0.88},
+                    {"bbox_x1", 20.0},
+                    {"bbox_y1", 20.0},
+                    {"bbox_x2", 100.0},
+                    {"bbox_y2", 100.0}
+                })},
+                {"inputs", json::array({
+                    json::object({{"type", "image_chan"}, {"link", 101}}),
+                    json::object({{"type", "result_chan"}, {"link", 102}})
+                })},
+                {"outputs", json::array({
+                    json::object({{"type", "image_chan"}, {"links", json::array({301})}}),
+                    json::object({{"type", "result_chan"}, {"links", json::array({302})}})
+                })}
+            }),
+            json::object({
+                {"id", 4},
+                {"order", 4},
+                {"type", "post_process/merge_results"},
+                {"inputs", json::array({
+                    json::object({{"type", "image_chan"}, {"link", 201}}),
+                    json::object({{"type", "result_chan"}, {"link", 202}}),
+                    json::object({{"type", "image_chan"}, {"link", 301}}),
+                    json::object({{"type", "result_chan"}, {"link", 302}})
+                })},
+                {"outputs", json::array({
+                    json::object({{"type", "image_chan"}, {"links", json::array({401})}}),
+                    json::object({{"type", "result_chan"}, {"links", json::array({402})}})
+                })}
+            }),
+            json::object({
+                {"id", 5},
+                {"order", 5},
+                {"type", "post_process/bbox_iou_dedup"},
+                {"properties", dedupProps},
+                {"inputs", json::array({
+                    json::object({{"type", "image_chan"}, {"link", 401}}),
+                    json::object({{"type", "result_chan"}, {"link", 402}})
+                })},
+                {"outputs", json::array({
+                    json::object({{"type", "image_chan"}, {"links", json::array({501})}}),
+                    json::object({{"type", "result_chan"}, {"links", json::array({502})}})
+                })}
+            }),
+            json::object({
+                {"id", 6},
+                {"order", 6},
+                {"type", "output/return_json"},
+                {"inputs", json::array({
+                    json::object({{"type", "image_chan"}, {"link", 501}}),
+                    json::object({{"type", "result_chan"}, {"link", 502}})
+                })},
+                {"outputs", json::array()}
+            })
+        })}
+    });
+}
+
+bool RunBBoxIoUDedupFlowCase(bool crossModel, int expectedCount, std::string& error) {
+    const std::string tempDir = BuildTempRectCorrectionDir();
+    const std::string flowPath = JoinPathA(tempDir, crossModel ? "bbox_dedup_cross.json" : "bbox_dedup_strict.json");
+    {
+        std::ofstream ofs(flowPath, std::ios::binary);
+        if (!ofs) {
+            error = "无法写入临时流程文件";
+            return false;
+        }
+        ofs << BuildBBoxDedupFlow(crossModel).dump(2);
+    }
+
+    try {
+        dlcv_infer::flow::FlowGraphModel model;
+        const json loadReport = model.Load(flowPath, kGpuDeviceId);
+        if (!loadReport.is_object() || loadReport.value("code", 1) != 0) {
+            error = std::string("流程加载失败: ") + loadReport.dump();
+            DeleteFileA(flowPath.c_str());
+            return false;
+        }
+
+        cv::Mat image(320, 320, CV_8UC3, cv::Scalar(0, 255, 0));
+        const json inferRoot = model.InferInternal(std::vector<cv::Mat>{image}, json::object());
+        if (!inferRoot.is_object() || inferRoot.value("code", 1) != 0) {
+            error = std::string("流程执行失败: ") + inferRoot.dump();
+            DeleteFileA(flowPath.c_str());
+            return false;
+        }
+
+        const json results = inferRoot.contains("result_list") ? inferRoot.at("result_list") : json::array();
+        const int kept = CountBBoxDedupDetections(results);
+        if (kept != expectedCount) {
+            error = std::string(crossModel ? "默认 cross_model=true" : "cross_model=false") +
+                " 保留数量不符合预期，actual=" + std::to_string(kept) +
+                ", expected=" + std::to_string(expectedCount) +
+                ", root=" + inferRoot.dump();
+            DeleteFileA(flowPath.c_str());
+            return false;
+        }
+    } catch (const std::exception& ex) {
+        error = std::string("异常: ") + ex.what();
+        DeleteFileA(flowPath.c_str());
+        return false;
+    }
+
+    DeleteFileA(flowPath.c_str());
+    return true;
+}
+
+int RunBBoxIoUDedupSelfTest() {
+    auto fail = [](const std::string& message) -> int {
+        std::cout << "bbox_iou_dedup 自测失败: " << message << "\n";
+        return 1;
+    };
+
+    std::string error;
+    if (!RunBBoxIoUDedupFlowCase(true, 1, error)) return fail(error);
+    if (!RunBBoxIoUDedupFlowCase(false, 2, error)) return fail(error);
+
+    std::cout << "bbox_iou_dedup 自测通过\n";
+    return 0;
+}
 }  // namespace
 
 int main(int argc, char* argv[]) {
@@ -1311,6 +1491,10 @@ int main(int argc, char* argv[]) {
 
     if (argc >= 2 && std::string(argv[1]) == "rect-image-correction-selftest") {
         return RunRectImageCorrectionSelfTest();
+    }
+
+    if (argc >= 2 && std::string(argv[1]) == "bbox-iou-dedup-selftest") {
+        return RunBBoxIoUDedupSelfTest();
     }
 
     if (argc >= 2 && std::string(argv[1]) == "flow-instance-seg-filter-selftest") {

--- a/dlcv_infer_cpp_dll/flow/modules/FeatureModules.cpp
+++ b/dlcv_infer_cpp_dll/flow/modules/FeatureModules.cpp
@@ -489,7 +489,7 @@ public:
 
                 Json outEntry = Json::object();
                 outEntry["type"] = "local";
-                outEntry["originating_module"] = "features/image_generation";
+                outEntry["originating_module"] = "pre_process/image_generation";
                 outEntry["index"] = outIndex;
                 outEntry["origin_index"] = parentWrap.OriginalIndex;
                 outEntry["transform"] = childState.ToJson();
@@ -1013,13 +1013,16 @@ public:
 };
 
 // 注册
+DLCV_FLOW_REGISTER_MODULE("pre_process/image_generation", ImageGenerationModule)
 DLCV_FLOW_REGISTER_MODULE("features/image_generation", ImageGenerationModule)
+DLCV_FLOW_REGISTER_MODULE("pre_process/image_flip", ImageFlipModule)
 DLCV_FLOW_REGISTER_MODULE("features/image_flip", ImageFlipModule)
 DLCV_FLOW_REGISTER_MODULE("pre_process/rect_image_correction", RectImageCorrectionModule)
 DLCV_FLOW_REGISTER_MODULE("pre_process/coordinate_crop", CoordinateCropModule)
 DLCV_FLOW_REGISTER_MODULE("features/coordinate_crop", CoordinateCropModule)
 DLCV_FLOW_REGISTER_MODULE("pre_process/image_rescale", ImageRescaleModule)
 DLCV_FLOW_REGISTER_MODULE("features/image_rescale", ImageRescaleModule)
+DLCV_FLOW_REGISTER_MODULE("pre_process/image_rotate_by_cls", ImageRotateByClsModule)
 DLCV_FLOW_REGISTER_MODULE("features/image_rotate_by_cls", ImageRotateByClsModule)
 DLCV_FLOW_REGISTER_MODULE("post_process/result_label_merge", ResultLabelMergeModule)
 DLCV_FLOW_REGISTER_MODULE("features/result_label_merge", ResultLabelMergeModule)

--- a/dlcv_infer_cpp_dll/flow/modules/PostProcessModules.cpp
+++ b/dlcv_infer_cpp_dll/flow/modules/PostProcessModules.cpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "opencv2/imgproc.hpp"
@@ -1134,6 +1135,18 @@ public:
         std::string metric = NormalizeMetric(ReadString("metric", "iou"));
         const double threshold = Clamp01(ReadDouble("iou_threshold", 0.5));
         const bool perCategory = ReadBool("per_category", true);
+        const bool crossModel = ReadBool("cross_model", true);
+        const std::unordered_map<int, std::string> imageGroups = crossModel ? BuildImageGroupsByIndex(images) : std::unordered_map<int, std::string>();
+        std::string singleImageGroup;
+        if (!imageGroups.empty()) {
+            std::vector<std::string> uniqueGroups;
+            for (const auto& kv : imageGroups) {
+                if (std::find(uniqueGroups.begin(), uniqueGroups.end(), kv.second) == uniqueGroups.end()) {
+                    uniqueGroups.push_back(kv.second);
+                }
+            }
+            if (uniqueGroups.size() == 1) singleImageGroup = uniqueGroups.front();
+        }
 
         std::unordered_map<int, std::vector<bool>> keepFlags;
         std::unordered_map<std::string, std::vector<Candidate>> grouped;
@@ -1150,7 +1163,9 @@ public:
             const int idx = entry.contains("index") ? SafeIntFromJson(entry.at("index"), -1) : -1;
             const int originIdx = entry.contains("origin_index") ? SafeIntFromJson(entry.at("origin_index"), idx) : idx;
             const std::string transformSig = entry.contains("transform") ? SerializeTokenCompact(entry.at("transform")) : "null";
-            const std::string entryGroupKey = std::to_string(idx) + "|" + std::to_string(originIdx) + "|" + transformSig;
+            const std::string entryGroupKey = crossModel
+                ? BuildCrossModelGroupKey(entry, imageGroups, singleImageGroup)
+                : BuildStrictGroupKey(idx, originIdx, transformSig);
 
             for (int detIdx = 0; detIdx < static_cast<int>(dets.size()); detIdx++) {
                 const Json& det = dets.at(static_cast<size_t>(detIdx));
@@ -1257,6 +1272,82 @@ public:
     }
 
 private:
+    static std::unordered_map<int, std::string> BuildImageGroupsByIndex(const std::vector<ModuleImage>& images) {
+        std::unordered_map<int, std::string> groups;
+        for (int i = 0; i < static_cast<int>(images.size()); ++i) {
+            const std::string fingerprint = ImageFingerprint(images[static_cast<size_t>(i)]);
+            if (!fingerprint.empty()) {
+                groups[i] = fingerprint;
+            }
+        }
+        return groups;
+    }
+
+    static std::string BuildCrossModelGroupKey(const Json& entry,
+                                               const std::unordered_map<int, std::string>& imageGroups,
+                                               const std::string& singleImageGroup) {
+        const int idx = entry.contains("index") ? SafeIntFromJson(entry.at("index"), -1) : -1;
+        const int originIdx = entry.contains("origin_index") ? SafeIntFromJson(entry.at("origin_index"), idx) : idx;
+        const std::string transformSig = entry.contains("transform") ? SerializeTokenCompact(entry.at("transform")) : "null";
+
+        auto it = imageGroups.find(originIdx);
+        if (it != imageGroups.end()) return std::string("image|") + it->second + "|" + transformSig;
+        it = imageGroups.find(idx);
+        if (it != imageGroups.end()) return std::string("image|") + it->second + "|" + transformSig;
+
+        if (!singleImageGroup.empty()) return std::string("image|") + singleImageGroup + "|" + transformSig;
+        return BuildStrictGroupKey(idx, originIdx, transformSig);
+    }
+
+    static std::string BuildStrictGroupKey(int idx, int originIdx, const std::string& transformSig) {
+        return std::to_string(idx) + "|" + std::to_string(originIdx) + "|" + transformSig;
+    }
+
+    static std::string ImageFingerprint(const ModuleImage& image) {
+        const cv::Mat* mat = !image.OriginalImage.empty() ? &image.OriginalImage : &image.ImageObject;
+        if (mat == nullptr || mat->empty()) return std::string();
+
+        uint64_t hash = 1469598103934665603ULL;
+        const std::string header = std::to_string(mat->rows) + "x" +
+            std::to_string(mat->cols) + "x" +
+            std::to_string(mat->channels()) + ":" +
+            std::to_string(mat->type());
+        UpdateHash(hash, reinterpret_cast<const unsigned char*>(header.data()), header.size());
+
+        constexpr int patchH = 8;
+        constexpr int patchW = 8;
+        const std::array<std::pair<int, int>, 5> coords = {
+            std::make_pair(0, 0),
+            std::make_pair(0, std::max(0, mat->cols - patchW)),
+            std::make_pair(std::max(0, mat->rows - patchH), 0),
+            std::make_pair(std::max(0, mat->rows - patchH), std::max(0, mat->cols - patchW)),
+            std::make_pair(std::max(0, mat->rows / 2 - patchH / 2), std::max(0, mat->cols / 2 - patchW / 2))
+        };
+
+        for (const auto& coord : coords) {
+            const int yy = coord.first;
+            const int xx = coord.second;
+            const int width = std::min(patchW, mat->cols - xx);
+            const int height = std::min(patchH, mat->rows - yy);
+            if (width <= 0 || height <= 0) continue;
+
+            cv::Mat patch = (*mat)(cv::Rect(xx, yy, width, height)).clone();
+            if (patch.empty()) continue;
+            const size_t byteCount = patch.total() * patch.elemSize();
+            UpdateHash(hash, patch.ptr<unsigned char>(0), byteCount);
+        }
+
+        return std::to_string(hash);
+    }
+
+    static void UpdateHash(uint64_t& hash, const unsigned char* data, size_t size) {
+        if (data == nullptr || size == 0) return;
+        for (size_t i = 0; i < size; ++i) {
+            hash ^= static_cast<uint64_t>(data[i]);
+            hash *= 1099511628211ULL;
+        }
+    }
+
     static bool TryExtractBboxXyxy(const Json& det, std::array<double, 4>& bbox) {
         if (!det.is_object() || !det.contains("bbox") || !det.at("bbox").is_array()) return false;
         const Json& arr = det.at("bbox");

--- a/dlcv_infer_cpp_dll/flow/modules/SlidingModules.cpp
+++ b/dlcv_infer_cpp_dll/flow/modules/SlidingModules.cpp
@@ -1110,6 +1110,7 @@ public:
 // 注册
 DLCV_FLOW_REGISTER_MODULE("pre_process/sliding_window", SlidingWindowModule)
 DLCV_FLOW_REGISTER_MODULE("features/sliding_window", SlidingWindowModule)
+DLCV_FLOW_REGISTER_MODULE("post_process/sliding_merge", SlidingMergeModule)
 DLCV_FLOW_REGISTER_MODULE("pre_process/sliding_merge", SlidingMergeModule)
 DLCV_FLOW_REGISTER_MODULE("features/sliding_merge", SlidingMergeModule)
 


### PR DESCRIPTION
## 1. BBoxIoU 去重跨模型分组（C++ / C#）

为 `post_process/bbox_iou_dedup` 模块新增 `cross_model` 参数（默认 `true`），解决多模型分支汇入同一张原图时的去重分组问题。

### 行为说明
- **cross_model = true（默认）**：按原图指纹 + transform 分组。即使不同模型分支产生的检测结果 index/origin_index 不同，只要来源于同一张原图，就会进入同一组进行 IoU/IoS 去重。
- **cross_model = false**：恢复严格的 `index|origin_index|transform` 分组，仅对完全同一路径的结果去重。

### 图像指纹算法
- C++：FNV-1a 64bit hash，采样原图 5 个 8×8 patch（四角 + 中心）+ 图像头信息（高×宽×通道×类型）。
- C#：MD5，采样策略与 C++ 对齐。

### 代码位置
- C++：`dlcv_infer_cpp_dll/flow/modules/PostProcessModules.cpp` — `BBoxIoUDedupModule`
- C#：`DlcvCsharpApi/flow/modules/Features.cs` — `BBoxIoUDedup`

## 2. 模块重命名兼容（C++ / C#）

参照 dlcv_test_2 的 `417ff442` 提交，为流程模块新增主路径注册，保留旧路径别名：

| 模块 | 新的主路径 | 保留的兼容路径 |
|---|---|---|
| ImageGeneration | `pre_process/image_generation` | `features/image_generation` |
| ImageFlip | `pre_process/image_flip` | `features/image_flip` |
| ImageRotateByClassification | `pre_process/image_rotate_by_cls` | `features/image_rotate_by_cls` |
| SlidingMergeResults | `post_process/sliding_merge` | `pre_process/sliding_merge`, `features/sliding_merge` |

同时更新 `ImageGeneration` 输出结果中的 `originating_module` 为新的主路径 `pre_process/image_generation`，与 Python 后端行为保持一致。

## 3. 测试覆盖

- **C++ 自测**：`Test/dlcv_infer_cpp_test/main.cpp` 新增 `bbox-iou-dedup-selftest`
  - `cross_model=true` 场景：同图不同 index 的重复框应去重至 1 个。
  - `cross_model=false` 场景：严格分组应保留 2 个。
- **C# 自测**：`Test/DlcvCSharpTest/Program.cs` 新增 `bbox-iou-dedup-selftest`
  - 断言逻辑与 C++ 对齐。

## 修改文件
- `dlcv_infer_cpp_dll/flow/modules/PostProcessModules.cpp`
- `dlcv_infer_cpp_dll/flow/modules/FeatureModules.cpp`
- `dlcv_infer_cpp_dll/flow/modules/SlidingModules.cpp`
- `DlcvCsharpApi/flow/modules/Features.cs`
- `DlcvCsharpApi/flow/modules/SlidingMerge.cs`
- `Test/dlcv_infer_cpp_test/main.cpp`
- `Test/DlcvCSharpTest/Program.cs`