### PR TITLE
chore: bump version to 2026.5.15.0

### DIFF
--- a/DlcvDemo/Properties/AssemblyInfo.cs
+++ b/DlcvDemo/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.5.14.0")]
-[assembly: AssemblyFileVersion("2026.5.14.0")]
-[assembly: AssemblyInformationalVersion("2026.5.14.0a0")]
+[assembly: AssemblyVersion("2026.5.15.0")]
+[assembly: AssemblyFileVersion("2026.5.15.0")]
+[assembly: AssemblyInformationalVersion("2026.5.15.0")]
 [assembly: NeutralResourcesLanguage("zh-CN")]

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import shutil
 
 from setuptools import setup
 
-version = '2026.5.14.0a0'
+version = '2026.5.15.0'
 
 package_name = "dlcvpro_infer_csharp"  # 包名
 packages: list = [package_name]  # 需要打包的包


### PR DESCRIPTION
更新正式版版本号至 2026.5.15.0