### PR TITLE
同步 dlcv_test_2 0515 分支关键修复到 C++/C# 流程推理

### DIFF
--- a/DlcvCsharpApi/flow/modules/Features.cs
+++ b/DlcvCsharpApi/flow/modules/Features.cs
@@ -1102,19 +1102,6 @@ namespace DlcvModules
             return rawIndex % imageCount;
         }
 
-        private static Dictionary<int, int> BuildReindexMap(bool[] flags)
-        {
-            var mp = new Dictionary<int, int>();
-            int newIdx = 0;
-            for (int i = 0; i < flags.Length; i++)
-            {
-                if (flags[i])
-                {
-                    mp[i] = newIdx++;
-                }
-            }
-            return mp;
-        }
     }
 
     /// <summary>
@@ -1311,18 +1298,18 @@ namespace DlcvModules
             foreach (var e in passEntries)
             {
                 int imgIdx = e["index"]?.Value<int?>() ?? -1;
-                if (imgIdx >= 0 && passReindex.TryGetValue(imgIdx, out int newIdx))
+                if (imgIdx >= 0 && passReindex.TryGetValue(imgIdx, out int pNewIdx))
                 {
-                    e["index"] = newIdx;
+                    e["index"] = pNewIdx;
                 }
                 mainResults.Add(e);
             }
             foreach (var e in failEntries)
             {
                 int imgIdx = e["index"]?.Value<int?>() ?? -1;
-                if (imgIdx >= 0 && failReindex.TryGetValue(imgIdx, out int newIdx))
+                if (imgIdx >= 0 && failReindex.TryGetValue(imgIdx, out int fNewIdx))
                 {
-                    e["index"] = newIdx;
+                    e["index"] = fNewIdx;
                 }
                 altResults.Add(e);
             }
@@ -1643,6 +1630,20 @@ namespace DlcvModules
             if (imageCount <= 0) return rawIndex >= 0 ? rawIndex : 0;
             if (rawIndex < 0) return 0;
             return rawIndex % imageCount;
+        }
+
+        private static Dictionary<int, int> BuildReindexMap(bool[] flags)
+        {
+            var mp = new Dictionary<int, int>();
+            int newIdx = 0;
+            for (int i = 0; i < flags.Length; i++)
+            {
+                if (flags[i])
+                {
+                    mp[i] = newIdx++;
+                }
+            }
+            return mp;
         }
     }
 

--- a/DlcvCsharpApi/flow/modules/Features.cs
+++ b/DlcvCsharpApi/flow/modules/Features.cs
@@ -1899,7 +1899,7 @@ namespace DlcvModules
             var images = imageList ?? new List<ModuleImage>();
             var results = resultList ?? new JArray();
             double scale = ReadDoubleLike("scale", 1.0);
-            if (scale <= 0) scale = 1.0;
+            scale = Math.Max(0.01, Math.Min(10.0, scale));
             var outImages = new List<ModuleImage>();
 
             foreach (var wrap in images)

--- a/DlcvCsharpApi/flow/modules/Features.cs
+++ b/DlcvCsharpApi/flow/modules/Features.cs
@@ -1101,6 +1101,20 @@ namespace DlcvModules
             if (rawIndex < 0) return 0;
             return rawIndex % imageCount;
         }
+
+        private static Dictionary<int, int> BuildReindexMap(bool[] flags)
+        {
+            var mp = new Dictionary<int, int>();
+            int newIdx = 0;
+            for (int i = 0; i < flags.Length; i++)
+            {
+                if (flags[i])
+                {
+                    mp[i] = newIdx++;
+                }
+            }
+            return mp;
+        }
     }
 
     /// <summary>
@@ -1186,8 +1200,13 @@ namespace DlcvModules
             var altImages = new List<ModuleImage>();
             var altResults = new JArray();
 
-            // 构建 image 映射：优先 index/origin_index（折回 batch 槽位），transform+origin 兜底
+            // 精确标记哪些图像有通过/未通过结果，避免 transform 相同导致串图
             int imageCount = inImages.Count;
+            var passFlags = new bool[imageCount];
+            var failFlags = new bool[imageCount];
+            var passEntries = new List<JObject>();
+            var failEntries = new List<JObject>();
+
             var indexToImageObj = new Dictionary<int, ModuleImage>();
             var originToImageObj = new Dictionary<int, ModuleImage>();
             var keyToImageObj = new Dictionary<string, ModuleImage>();
@@ -1216,6 +1235,15 @@ namespace DlcvModules
                 string key = SerializeTransformOnly(stDict, originIndex);
                 ModuleImage imgObj = null;
 
+                if (!indexToImageObj.TryGetValue(idx, out imgObj))
+                {
+                    if (!originToImageObj.TryGetValue(originIndex, out imgObj))
+                    {
+                        keyToImageObj.TryGetValue(key, out imgObj);
+                    }
+                }
+                if (imgObj == null) continue;
+
                 var srsArray = r["sample_results"] as JArray;
                 JArray failArray = null;
                 if (!noFilter && srsArray != null && srsArray.Count > 0)
@@ -1243,41 +1271,60 @@ namespace DlcvModules
                         out failArray);
                 }
 
-                if (!indexToImageObj.TryGetValue(idx, out imgObj))
+                if ((srsArray != null && srsArray.Count > 0) || srsArray == null)
                 {
-                    if (!originToImageObj.TryGetValue(originIndex, out imgObj))
+                    passFlags[idx] = true;
+                    var e = new JObject
                     {
-                        keyToImageObj.TryGetValue(key, out imgObj);
-                    }
+                        ["type"] = "local",
+                        ["index"] = idx,
+                        ["origin_index"] = originIndex,
+                        ["transform"] = stDict != null ? (JToken)stDict.DeepClone() : null,
+                        ["sample_results"] = srsArray ?? new JArray()
+                    };
+                    passEntries.Add(e);
                 }
+                if (failArray != null && failArray.Count > 0)
+                {
+                    failFlags[idx] = true;
+                    var e2 = new JObject
+                    {
+                        ["type"] = "local",
+                        ["index"] = idx,
+                        ["origin_index"] = originIndex,
+                        ["transform"] = stDict != null ? (JToken)stDict.DeepClone() : null,
+                        ["sample_results"] = failArray
+                    };
+                    failEntries.Add(e2);
+                }
+            }
 
-                if (imgObj != null)
+            var passReindex = BuildReindexMap(passFlags);
+            var failReindex = BuildReindexMap(failFlags);
+
+            for (int i = 0; i < imageCount; i++)
+            {
+                if (passFlags[i]) mainImages.Add(inImages[i]);
+                if (failFlags[i]) altImages.Add(inImages[i]);
+            }
+
+            foreach (var e in passEntries)
+            {
+                int imgIdx = e["index"]?.Value<int?>() ?? -1;
+                if (imgIdx >= 0 && passReindex.TryGetValue(imgIdx, out int newIdx))
                 {
-                    if ((srsArray != null && srsArray.Count > 0) || srsArray == null)
-                    {
-                        mainImages.Add(imgObj);
-                        r["type"] = "local";
-                        r["index"] = mainResults.Count;
-                        r["origin_index"] = originIndex;
-                        if (srsArray == null) r["sample_results"] = new JArray();
-                        else if (!ReferenceEquals(r["sample_results"], srsArray)) r["sample_results"] = srsArray;
-                        // 先从输入数组摘除，再加入输出，避免 JToken 因 Parent 存在而被隐式 DeepClone。
-                        inResults[ri] = null;
-                        mainResults.Add(r);
-                    }
-                    if (failArray != null && failArray.Count > 0)
-                    {
-                        altImages.Add(imgObj);
-                        altResults.Add(new JObject
-                        {
-                            ["type"] = "local",
-                            ["index"] = altResults.Count,
-                            ["origin_index"] = originIndex,
-                            ["transform"] = stDict != null ? stDict.DeepClone() : null,
-                            ["sample_results"] = failArray
-                        });
-                    }
+                    e["index"] = newIdx;
                 }
+                mainResults.Add(e);
+            }
+            foreach (var e in failEntries)
+            {
+                int imgIdx = e["index"]?.Value<int?>() ?? -1;
+                if (imgIdx >= 0 && failReindex.TryGetValue(imgIdx, out int newIdx))
+                {
+                    e["index"] = newIdx;
+                }
+                altResults.Add(e);
             }
 
             // 通过 extra output 暴露第二路（未通过项）

--- a/DlcvDemo/Properties/AssemblyInfo.cs
+++ b/DlcvDemo/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.5.15.0")]
-[assembly: AssemblyFileVersion("2026.5.15.0")]
-[assembly: AssemblyInformationalVersion("2026.5.15.0")]
+[assembly: AssemblyVersion("2026.5.16.0")]
+[assembly: AssemblyFileVersion("2026.5.16.0")]
+[assembly: AssemblyInformationalVersion("2026.5.16.0a0")]
 [assembly: NeutralResourcesLanguage("zh-CN")]

--- a/dlcv_infer_cpp_dll/flow/modules/FeatureModules.cpp
+++ b/dlcv_infer_cpp_dll/flow/modules/FeatureModules.cpp
@@ -794,7 +794,7 @@ public:
         const std::vector<ModuleImage>& images = imageList;
         const Json results = resultList.is_array() ? resultList : Json::array();
         double scale = GetDoubleProp(Properties, "scale", 1.0);
-        if (scale <= 0.0) scale = 1.0;
+        scale = std::max(0.01, std::min(10.0, scale));
 
         std::vector<ModuleImage> outImages;
         for (const auto& wrap : images) {

--- a/dlcv_infer_cpp_dll/flow/modules/PostProcessModules.cpp
+++ b/dlcv_infer_cpp_dll/flow/modules/PostProcessModules.cpp
@@ -759,6 +759,11 @@ private:
             return ModuleIO(std::move(mainImages), std::move(mainResults), Json::array());
         }
 
+        std::vector<bool> passFlags(inImages.size(), false);
+        std::vector<bool> failFlags(inImages.size(), false);
+        std::vector<Json> passEntries;
+        std::vector<Json> failEntries;
+
         for (const auto& token : inResults) {
             if (!token.is_object()) continue;
             const Json& entry = token;
@@ -772,8 +777,6 @@ private:
             if (imgIdx < 0 && originToIdx.count(originIndex)) imgIdx = originToIdx[originIndex];
             if (imgIdx < 0 && !sig.empty() && sigToIdx.count(sig)) imgIdx = sigToIdx[sig];
             if (imgIdx < 0 || imgIdx >= static_cast<int>(inImages.size())) continue;
-
-            const ModuleImage imgObj = inImages[static_cast<size_t>(imgIdx)];
 
             Json passArr = Json::array();
             Json failArr = emitFailBranch ? Json::array() : Json();
@@ -799,25 +802,67 @@ private:
             }
 
             if (!passArr.empty()) {
-                mainImages.push_back(imgObj);
+                passFlags[imgIdx] = true;
                 Json e = Json::object();
                 e["type"] = "local";
-                e["index"] = static_cast<int>(mainResults.size());
+                e["index"] = imgIdx;
                 e["origin_index"] = originIndex;
                 e["transform"] = transformOut;
                 e["sample_results"] = std::move(passArr);
-                mainResults.push_back(e);
+                passEntries.push_back(std::move(e));
             }
             if (emitFailBranch && !failArr.empty()) {
-                altImages.push_back(imgObj);
+                failFlags[imgIdx] = true;
                 Json e2 = Json::object();
                 e2["type"] = "local";
-                e2["index"] = static_cast<int>(altResults.size());
+                e2["index"] = imgIdx;
                 e2["origin_index"] = originIndex;
                 e2["transform"] = transformOut;
                 e2["sample_results"] = std::move(failArr);
-                altResults.push_back(e2);
+                failEntries.push_back(std::move(e2));
             }
+        }
+
+        auto buildReindexMap = [](const std::vector<bool>& flags) -> std::unordered_map<int, int> {
+            std::unordered_map<int, int> mp;
+            int newIdx = 0;
+            for (int i = 0; i < static_cast<int>(flags.size()); ++i) {
+                if (flags[i]) {
+                    mp[i] = newIdx++;
+                }
+            }
+            return mp;
+        };
+
+        auto passReindex = buildReindexMap(passFlags);
+        auto failReindex = buildReindexMap(failFlags);
+
+        for (int i = 0; i < static_cast<int>(inImages.size()); ++i) {
+            if (passFlags[i]) mainImages.push_back(inImages[i]);
+            if (failFlags[i]) altImages.push_back(inImages[i]);
+        }
+
+        for (auto& e : passEntries) {
+            int imgIdx = -1;
+            try { if (e.contains("index")) imgIdx = e.at("index").get<int>(); } catch (...) {}
+            if (imgIdx >= 0) {
+                auto it = passReindex.find(imgIdx);
+                if (it != passReindex.end()) {
+                    e["index"] = it->second;
+                }
+            }
+            mainResults.push_back(std::move(e));
+        }
+        for (auto& e : failEntries) {
+            int imgIdx = -1;
+            try { if (e.contains("index")) imgIdx = e.at("index").get<int>(); } catch (...) {}
+            if (imgIdx >= 0) {
+                auto it = failReindex.find(imgIdx);
+                if (it != failReindex.end()) {
+                    e["index"] = it->second;
+                }
+            }
+            altResults.push_back(std::move(e));
         }
 
         if (emitFailBranch) {

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import shutil
 
 from setuptools import setup
 
-version = '2026.5.15.0'
+version = '2026.5.16.0a0'
 
 package_name = "dlcvpro_infer_csharp"  # 包名
 packages: list = [package_name]  # 需要打包的包


### PR DESCRIPTION
## 背景

同步 dlcv_test_2 项目 `0515测试平台优化` 分支中的关键 bug 修复到 OpenIVS C++/C# 流程推理层，确保 C++/C# 侧的图编辑器模块（Flow）行为与 Python 侧保持一致。

## Commit 列表

### 1. `2c98764` fix(ResultFilterAdvanced): 修复过滤后串图导致凭空产生大量无效结果的问题

**问题根因**：`ResultFilterAdvanced` 慢路径（非对齐批次）在过滤后，使用 transform 签名字符串对图像进行分组重排。当多个图像共享相同 transform（如 sliding_window 切图后的平移矩阵）时，签名字符串相同会导致图像被错误地合并到同一组，产生"串图"现象——过滤后的结果条目 index 指向错误的图像，导致凭空产生大量无效检测结果。

**修复方式**：参考 Python 侧修复，C++ 和 C# 均改为：
- 使用 `passFlags`/`failFlags` 布尔数组标记每个输入图像索引是否通过过滤
- 引入 `BuildReindexMap` 构建旧索引到新索引的映射
- 按 flags 重新组装 `mainImages`/`altImages`
- 通过 reindex map 更新结果条目的 `index` 字段

**涉及文件**：
- `dlcv_infer_cpp_dll/flow/modules/PostProcessModules.cpp`
- `DlcvCsharpApi/flow/modules/Features.cs`

### 2. `5ba6709` fix(ImageRescale): 限制 scale 有效范围为 [0.01, 10.0]

**同步内容**：Python 侧 `ImageRescale` 已对 `scale` 参数进行 clamp 限制（防止用户输入极端值导致图像过大/过小或内存溢出）。C++ 和 C# 侧补充相同限制。

**涉及文件**：
- `dlcv_infer_cpp_dll/flow/modules/FeatureModules.cpp`
- `DlcvCsharpApi/flow/modules/Features.cs`

### 3. `f75f7f6` fix(ResultFilterAdvanced): 修复 BuildReindexMap 作用域和 out 变量编译错误

**修复内容**：
- `BuildReindexMap` 原定义在 `ResultFilter` 类中，但 `ResultFilterAdvanced` 调用时因 `private` 作用域导致编译失败（CS0103）
- `out int newIdx` 在 `&&` 条件中触发 CS0165（C# 7.3 确定性赋值分析限制）
- 将方法移至 `ResultFilterAdvanced` 类内部，重命名 out 变量为 `pNewIdx`/`fNewIdx`

### 4. `173ca83` chore: bump version to 2026.5.16.0a0

**内容**：
- `setup.py` 版本号更新为 `2026.5.16.0a0`
- `DlcvDemo/Properties/AssemblyInfo.cs` 同步更新（AssemblyVersion/FileVersion `2026.5.16.0`，InformationalVersion `2026.5.16.0a0`）

## 测试验证

- [x] 编译通过：`OpenIVS.sln` Release x64 构建成功
- [x] DVST 模型加载与推理正常
- [x] 单图推理：batch=1，59 个检测结果
- [x] 批量推理：batch=4，4 张图均为 59 个结果，数量完全一致
- [x] DVS RGB 自测：Model 与 DvsModel 直连 flow 结果签名一致
- [x] 测试版 wheel 构建并安装成功：`dlcvpro_infer_csharp-2026.5.16.0a0`
