### PR TITLE
feat(DlcvDemo2): 更新 IC 检测模型分流规则，新增 IC-排阻支持

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -415,3 +415,6 @@ FodyWeavers.xsd
 .remember/memory/self.md
 .remember/memory/project.md
 MiniAreaDemo/ExternalCallExample.cs
+
+# Release packages
+*.zip

--- a/DlcvDemo2/Form1.cs
+++ b/DlcvDemo2/Form1.cs
@@ -384,7 +384,8 @@ namespace DlcvDemo2
         private static bool ShouldUseIcDetectModel(string baseName)
         {
             return string.Equals(baseName, "IC", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(baseName, "BGA", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(baseName, "IC-BGA", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(baseName, "IC-排阻", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(baseName, "座子", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(baseName, "开关", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(baseName, "晶振", StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION
## 变更内容

- 将 ShouldUseIcDetectModel 中的 BGA 匹配规则更新为 IC-BGA，与业务命名保持一致。
- 新增 IC-排阻 类别走 IC 检测模型，支持最新元件分类规则。

## 规则映射

| 检测模型 | 覆盖类别 |
|---------|---------|
| 元件检测 | 电阻、电容、电感、电解电容、LED、二极管、三极管、晶体二极管、晶振、钽电容 |
| IC 检测 | IC、IC-BGA、IC-排阻、晶振、座子、开关 |

## 验证

- Release 编译通过
- 打包产物 DlcvDemo2-Release.zip 已生成（排除 dll 文件夹与 pdb）