### PR TITLE
fix(image_generation): 同步 Python 侧 round 移除到 C++/C# 裁图逻辑

### DIFF
--- a/DlcvCsharpApi/flow/modules/Features.cs
+++ b/DlcvCsharpApi/flow/modules/Features.cs
@@ -305,7 +305,7 @@ namespace DlcvModules
                         }
                         else
                         {
-                            // 外扩：左上 int(...)（floor），右下 round 后再 clamp（与 Python 一致）
+                            // 外扩：左上 int(...)（floor），右下 int 截断后再 clamp（与 Python 一致）
                             var expand = resolveExpand(bw, bh);
                             double expandW = expand.Item1;
                             double expandH = expand.Item2;
@@ -314,8 +314,8 @@ namespace DlcvModules
                             nx1 = (int)Math.Floor(tx1);
                             ny1 = (int)Math.Floor(ty1);
 
-                            int rx2 = (int)Math.Round(x2 + expandW, MidpointRounding.ToEven);
-                            int ry2 = (int)Math.Round(y2 + expandH, MidpointRounding.ToEven);
+                            int rx2 = (int)(x2 + expandW);
+                            int ry2 = (int)(y2 + expandH);
                             nx2 = Math.Min(W, Math.Max(0, rx2));
                             ny2 = Math.Min(H, Math.Max(0, ry2));
                             nx2 = Math.Max(nx1 + minSize, nx2);

--- a/DlcvDemo/Properties/AssemblyInfo.cs
+++ b/DlcvDemo/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.5.16.0")]
-[assembly: AssemblyFileVersion("2026.5.16.0")]
-[assembly: AssemblyInformationalVersion("2026.5.16.0a0")]
+[assembly: AssemblyVersion("2026.5.16.1")]
+[assembly: AssemblyFileVersion("2026.5.16.1")]
+[assembly: AssemblyInformationalVersion("2026.5.16.1a0")]
 [assembly: NeutralResourcesLanguage("zh-CN")]

--- a/dlcv_infer_cpp_dll/flow/modules/FeatureModules.cpp
+++ b/dlcv_infer_cpp_dll/flow/modules/FeatureModules.cpp
@@ -539,14 +539,14 @@ public:
                         ny2 = static_cast<int>(std::max(static_cast<double>(ny1 + 1),
                                                         std::min(static_cast<double>(H), static_cast<double>(ny1 + cropH))));
                     } else {
-                        // 外扩：左上 floor，右下 round（对齐 C#）
+                        // 外扩：左上 floor，右下 int 截断（与 Python 一致）
                         const auto expand = resolveExpand(bw, bh);
                         const double tx1 = std::max(0.0, std::min(static_cast<double>(W), x1 - expand.first));
                         const double ty1 = std::max(0.0, std::min(static_cast<double>(H), y1 - expand.second));
                         nx1 = static_cast<int>(std::floor(tx1));
                         ny1 = static_cast<int>(std::floor(ty1));
-                        const int rx2 = static_cast<int>(std::llround(x2 + expand.first));
-                        const int ry2 = static_cast<int>(std::llround(y2 + expand.second));
+                        const int rx2 = static_cast<int>(x2 + expand.first);
+                        const int ry2 = static_cast<int>(y2 + expand.second);
                         nx2 = std::min(W, std::max(0, rx2));
                         ny2 = std::min(H, std::max(0, ry2));
                         nx2 = std::max(nx1 + minSize, nx2);

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import shutil
 
 from setuptools import setup
 
-version = '2026.5.16.0a0'
+version = '2026.5.16.1a0'
 
 package_name = "dlcvpro_infer_csharp"  # 包名
 packages: list = [package_name]  # 需要打包的包


### PR DESCRIPTION
## 背景

dlcv_test_2 中 `image_generation.py` 移除了裁图右下边界的 `round()`，修复了 DVSP 流程（det→crop→instance_seg）与手动裁图之间的 1px 差异问题（PR #192）。

OpenIVS 的 C++ 和 C# 侧存在对应的裁图逻辑，右下边界仍使用四舍五入（C++ `std::llround`、C# `Math.Round`），会导致与 Python 侧行为不一致。

## 修改

- **C++** (`dlcv_infer_cpp_dll/flow/modules/FeatureModules.cpp`): `std::llround(x2 + expand)` → `static_cast<int>(x2 + expand)`
- **C#** (`DlcvCsharpApi/flow/modules/Features.cs`): `Math.Round(x2 + expand, MidpointRounding.ToEven)` → `(int)(x2 + expand)`

## 验证

裁图右下边界行为与 Python 侧一致，统一使用 `int` 截断而非四舍五入，确保三端（Python/C++/C#）裁图尺寸完全一致。
