### PR TITLE
fix: Linux 跳过加密狗检测及平台适配

### DIFF
--- a/dlcv_infer_cpp_dll/dlcv_infer.cpp
+++ b/dlcv_infer_cpp_dll/dlcv_infer.cpp
@@ -1350,6 +1350,11 @@ namespace dlcv_infer {
     }
 
     void DllLoader::EnsureForModel(const std::string& modelPath) {
+#ifndef _WIN32
+        // Linux 默认认为有加密狗，跳过 sntl_adminapi 检测
+        (void)modelPath;
+        return;
+#endif
         std::wstring wpath = convertUtf8ToWstring(modelPath);
 #ifdef _WIN32
         std::ifstream file(wpath);
@@ -1378,6 +1383,11 @@ namespace dlcv_infer {
     }
 
     void DllLoader::EnsureForModel(const std::wstring& modelPath) {
+#ifndef _WIN32
+        // Linux 默认认为有加密狗，跳过 sntl_adminapi 检测
+        (void)modelPath;
+        return;
+#endif
 #ifdef _WIN32
         std::ifstream file(modelPath);
 #else


### PR DESCRIPTION
同步 fix/linux-dog-skip 分支代码，包含 Linux 平台移植、加密狗检测跳过、C 语言接口层等修改。