### PR TITLE
fix: Linux ARM 下 dlcv_infer_cpp_dll 自动加载对应加密版本 so

### DIFF
--- a/dlcv_infer_cpp_dll/dlcv_infer.cpp
+++ b/dlcv_infer_cpp_dll/dlcv_infer.cpp
@@ -1167,8 +1167,8 @@ namespace dlcv_infer {
             dllName = "dlcv_infer.dll";
             dllPath = "C:\\dlcv\\Lib\\site-packages\\dlcvpro_infer\\dlcv_infer.dll";
 #else
-            dllName = "libdlcv_infer.so";
-            dllPath = "/root/dlcv/lib/python3.11/site-packages/dlcvpro_infer/libdlcv_infer.so";
+            dllName = "libdlcv_infer_s.so";
+            dllPath = "/root/dlcv/lib/python3.11/site-packages/dlcvpro_infer/libdlcv_infer_s.so";
 #endif
             break;
         case sntl_admin::DogProvider::Virbox:
@@ -1176,8 +1176,8 @@ namespace dlcv_infer {
             dllName = "dlcv_infer_v.dll";
             dllPath = "C:\\dlcv\\Lib\\site-packages\\dlcvpro_infer\\dlcv_infer_v.dll";
 #else
-            dllName = "libdlcv_infer.so";
-            dllPath = "/root/dlcv/lib/python3.11/site-packages/dlcvpro_infer/libdlcv_infer.so";
+            dllName = "libdlcv_infer_v.so";
+            dllPath = "/root/dlcv/lib/python3.11/site-packages/dlcvpro_infer/libdlcv_infer_v.so";
 #endif
             break;
         default:
@@ -1238,9 +1238,9 @@ namespace dlcv_infer {
         // 2. 当前工作目录
         candidates.push_back(dllCurrentPath);
         // 3. site-packages 候选路径（新环境）
-        candidates.push_back("/root/dlcv/lib/python3.11/site-packages/dlcvpro_infer/libdlcv_infer.so");
+        candidates.push_back(dllPath);
         // 4. site-packages 候选路径（旧环境兼容）
-        candidates.push_back("/root/miniconda3/lib/python3.11/site-packages/dlcvpro_infer/libdlcv_infer.so");
+        candidates.push_back("/root/miniconda3/lib/python3.11/site-packages/dlcvpro_infer/" + dllName);
 
         for (const auto& path : candidates) {
             if (path.empty()) continue;


### PR DESCRIPTION
﻿## 问题描述

在 Linux ARM 环境下，`DllLoader` 在不同 provider 下都固定加载同一未加密名称的 `.so`，未按实际产物区分加密版本，导致可能加载到错误库或找不到库。

## 修复方案

修改 `dlcv_infer_cpp_dll/dlcv_infer.cpp` 中 Linux ARM 分支的 SO 加载逻辑：

- 按检测到的 provider 类型加载对应命名规范的加密版本 `.so`
- 候选路径统一使用变量 `dllPath` / `dllName`，避免硬编码旧库名

变更范围仅影响非 Windows 分支，Windows 路径保持不变。

## 测试验证

- Windows 端完整解决方案编译通过
- RK3588 ARM Linux 端 `dlcv_infer` 完整编译通过，`libdlcv_infer_cpp_dll.so` 生成成功
- 3588 端运行 `dlcv_infer_cpp_dll` 推理验证通过（分类、实例分割模型均输出正确结果）
