### PR TITLE
feat: 缓存 Model::GetModelInfo() 避免重复推理开销

### DIFF
--- a/dlcv_infer_cpp_dll/dlcv_infer.cpp
+++ b/dlcv_infer_cpp_dll/dlcv_infer.cpp
@@ -1654,9 +1654,15 @@ namespace dlcv_infer {
     }
 
     json Model::GetModelInfo() {
+        if (_hasCachedModelInfo) {
+            return _cachedModelInfo;
+        }
+
         if (_isFlowGraphMode) {
             if (!_flowModel) throw std::runtime_error("dvs model not loaded");
-            return _flowModel->GetModelInfo();
+            _cachedModelInfo = _flowModel->GetModelInfo();
+            _hasCachedModelInfo = true;
+            return _cachedModelInfo;
         }
 
         json config;
@@ -1667,6 +1673,8 @@ namespace dlcv_infer {
         std::string resultJson = std::string(static_cast<const char*>(resultPtr));
         json resultObject = json::parse(resultJson);
         _dllLoader->GetFreeResultFunc()(resultPtr);
+        _cachedModelInfo = resultObject;
+        _hasCachedModelInfo = true;
         return resultObject;
     }
 

--- a/dlcv_infer_cpp_dll/dlcv_infer.h
+++ b/dlcv_infer_cpp_dll/dlcv_infer.h
@@ -246,6 +246,8 @@ namespace dlcv_infer {
         int _deviceId = 0;
         flow::FlowGraphModel* _flowModel = nullptr;
         int _expectedChCache = -2;
+        bool _hasCachedModelInfo = false;
+        json _cachedModelInfo;
         // DVS 模式：持有临时目录路径，确保在 Model 对象存活期间文件不被删除
         std::string _tempDir;
 

--- a/dlcv_infer_cpp_dll/flow/modules/ModelModules.cpp
+++ b/dlcv_infer_cpp_dll/flow/modules/ModelModules.cpp
@@ -87,48 +87,6 @@ void BaseModelModule::LoadModel() {
 
     _resolvedDeviceId = deviceId;
     _model = ModelPool::Instance().Acquire(_modelPathUtf8, deviceId);
-
-    try {
-        if (Context != nullptr) {
-            Json loadedMeta = Context->Get<Json>("loaded_model_meta", Json::array());
-            if (!loadedMeta.is_array()) {
-                loadedMeta = Json::array();
-            }
-
-            std::string originalPath = _modelPathUtf8;
-            std::string modelName;
-            try {
-                if (Properties.is_object()) {
-                    if (Properties.contains("model_path_original") && Properties.at("model_path_original").is_string()) {
-                        originalPath = Properties.at("model_path_original").get<std::string>();
-                    }
-                    if (Properties.contains("model_name") && Properties.at("model_name").is_string()) {
-                        modelName = Properties.at("model_name").get<std::string>();
-                    }
-                }
-            } catch (...) {}
-            if (modelName.empty()) {
-                modelName = GetFileNameOnlyLocal(originalPath);
-            }
-            if (modelName.empty()) {
-                modelName = originalPath;
-            }
-
-            Json entry = Json::object();
-            entry["node_id"] = NodeId;
-            entry["title"] = Title;
-            entry["model_path"] = _modelPathUtf8;
-            entry["model_path_original"] = originalPath;
-            entry["model_name"] = modelName;
-            try {
-                entry["model_info"] = _model->GetModelInfo();
-            } catch (...) {
-            }
-            loadedMeta.push_back(std::move(entry));
-            Context->Set<Json>("loaded_model_meta", loadedMeta);
-        }
-    } catch (...) {
-    }
 }
 
 static void TryAddParam(Json& p, const Json& props, const std::string& key) {


### PR DESCRIPTION
﻿## 背景与动机

Model::GetModelInfo() 在现有实现中每次调用都会重新触发底层推理或 JSON 解析。在 FlowGraph 执行流程里，模型模块频繁调用该方法，造成不必要的重复开销。本次改动在 Model 层引入缓存机制，首次调用后结果常驻内存，后续调用直接返回缓存值，消除重复开销。

## 改动内容

### 1. dlcv_infer.h
- 新增两个成员变量：
  - _hasCachedModelInfo（bool）：标记是否已有缓存
  - _cachedModelInfo（json）：缓存的模型信息 JSON

### 2. dlcv_infer.cpp
- GetModelInfo() 增加短路逻辑：
  - 若 _hasCachedModelInfo == true，直接返回 _cachedModelInfo
  - 首次调用时（普通模型或 FlowGraph 模型）写入缓存并置位标记

### 3. flow/modules/ModelModules.cpp
- 从 BaseModelModule::LoadModel() 中移除内联的 loaded_model_meta 收集逻辑
- 该逻辑在引入缓存后已显冗余；若调用方需要模型元信息列表，应通过上层显式管理，而非在加载时隐式写入上下文

## 验证方式

- 多次调用 GetModelInfo()，确认后续调用不再进入底层推理路径，返回结果与首次一致
- 验证 FlowGraph 模型加载与推理流程正常运行
