### PR TITLE
fix: DlcvDemo2 字符检测漏检修复

### DIFF
--- a/DlcvDemo2/DlcvDemo2.csproj
+++ b/DlcvDemo2/DlcvDemo2.csproj
@@ -139,6 +139,7 @@
     <Compile Include="Utils\DetectionGeometryUtils.cs" />
     <Compile Include="Utils\ExtractMergeUtils.cs" />
     <Compile Include="Utils\SlidingWindowUtils.cs" />
+    <Compile Include="Utils\InferenceDebugLogger.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <None Include="packages.config" />
     <None Include="Properties\app.manifest" />

--- a/DlcvDemo2/Form1.cs
+++ b/DlcvDemo2/Form1.cs
@@ -40,7 +40,7 @@ namespace DlcvDemo2
             }
         }
 
-        private sealed class PipelineRunResult
+        public sealed class PipelineRunResult
         {
             public CSharpResult DisplayResult { get; set; }
             public int SlidingWindowCount { get; set; }
@@ -51,7 +51,7 @@ namespace DlcvDemo2
             public List<string> Logs { get; } = new List<string>();
         }
 
-        private sealed class SlidingWindowConfig
+        public sealed class SlidingWindowConfig
         {
             public int WindowWidth { get; set; }
             public int WindowHeight { get; set; }
@@ -59,7 +59,7 @@ namespace DlcvDemo2
             public int OverlapY { get; set; }
         }
 
-        private sealed class InferenceProgressInfo
+        public sealed class InferenceProgressInfo
         {
             public int Percent { get; set; }
             public string Stage { get; set; }
@@ -306,7 +306,7 @@ namespace DlcvDemo2
             }
         }
 
-        private PipelineRunResult RunPipeline(Mat fullImageRgb, SlidingWindowConfig config, IProgress<InferenceProgressInfo> progress = null)
+        public PipelineRunResult RunPipeline(Mat fullImageRgb, SlidingWindowConfig config, IProgress<InferenceProgressInfo> progress = null)
         {
             var runResult = new PipelineRunResult();
 
@@ -531,6 +531,18 @@ namespace DlcvDemo2
             }
         }
 
+        private static int _debugRoiIndex = 0;
+        private static readonly object _debugLogLock = new object();
+
+        private void LogDebug(string message)
+        {
+            string logPath = Path.Combine(Path.GetTempPath(), "dlcvdemo2_debug.log");
+            lock (_debugLogLock)
+            {
+                File.AppendAllText(logPath, $"{DateTime.Now:HH:mm:ss.fff} {message}{Environment.NewLine}");
+            }
+        }
+
         private List<CSharpObjectResult> InferDetectionModelAndMapBack(RoiProcessResult roiContext, CSharpObjectResult extractFallback, bool useIcDetectModel)
         {
             JObject inferParams = new JObject
@@ -539,13 +551,35 @@ namespace DlcvDemo2
             };
 
             Model activeModel = useIcDetectModel ? icDetectModel : componentDetectModel;
+
+            // 临时调试：保存ROI图像并打印原始检测输出
+            string debugDir = Path.Combine(Path.GetTempPath(), "dlcvdemo2_debug");
+            Directory.CreateDirectory(debugDir);
+            int roiIdx = System.Threading.Interlocked.Increment(ref _debugRoiIndex);
+            string safeName = string.Join("_", (extractFallback.CategoryName ?? "unknown").Split(Path.GetInvalidFileNameChars()));
+            string roiPath = Path.Combine(debugDir, $"roi_{roiIdx:D3}_{safeName}.png");
+            try
+            {
+                Cv2.ImWrite(roiPath, roiContext.NormalizedRoi);
+            }
+            catch { }
+
             CSharpResult roiResult = activeModel.Infer(roiContext.NormalizedRoi, inferParams);
             if (roiResult.SampleResults == null || roiResult.SampleResults.Count == 0)
             {
+                LogDebug($"[ROI {roiIdx}] {extractFallback.CategoryName}: raw=0 (no sample results), roiSize={roiContext.NormalizedRoi.Width}x{roiContext.NormalizedRoi.Height}");
                 return new List<CSharpObjectResult> { extractFallback };
             }
 
             List<CSharpObjectResult> rawObjects = roiResult.SampleResults[0].Results ?? new List<CSharpObjectResult>();
+            LogDebug($"[ROI {roiIdx}] {extractFallback.CategoryName}: raw={rawObjects.Count}, roiSize={roiContext.NormalizedRoi.Width}x{roiContext.NormalizedRoi.Height}");
+            for (int i = 0; i < rawObjects.Count; i++)
+            {
+                var r = rawObjects[i];
+                string bboxStr = r.Bbox != null ? string.Join(",", r.Bbox) : "null";
+                LogDebug($"  [{i}] {r.CategoryName} score={r.Score:F2} bbox=[{bboxStr}]");
+            }
+
             if (rawObjects.Count == 0)
             {
                 return new List<CSharpObjectResult> { extractFallback };
@@ -891,7 +925,7 @@ namespace DlcvDemo2
             return true;
         }
 
-        private static Mat PrepareImageForModelInput(Mat image)
+        public static Mat PrepareImageForModelInput(Mat image)
         {
             if (image == null || image.Empty())
             {
@@ -1014,6 +1048,35 @@ namespace DlcvDemo2
                 asDecimal = control.Maximum;
             }
             control.Value = asDecimal;
+        }
+
+        public static PipelineRunResult RunHeadless(string extractModelPath, string componentModelPath, string icModelPath, string imgPath, SlidingWindowConfig config)
+        {
+            var form = new Form1();
+            form.extractModel = new Model(extractModelPath, 0, false);
+            form.componentDetectModel = new Model(componentModelPath, 0, false);
+            form.icDetectModel = new Model(icModelPath, 0, false);
+            form.imagePath = imgPath;
+
+            Mat imageBgr = Cv2.ImRead(imgPath, ImreadModes.Unchanged);
+            if (imageBgr == null || imageBgr.Empty())
+            {
+                throw new InvalidOperationException("图片解码失败。");
+            }
+            Mat imageRgb = PrepareImageForModelInput(imageBgr);
+            try
+            {
+                PipelineRunResult result = form.RunPipeline(imageRgb, config, null);
+                return result;
+            }
+            finally
+            {
+                imageRgb.Dispose();
+                imageBgr.Dispose();
+                form.extractModel?.Dispose();
+                form.componentDetectModel?.Dispose();
+                form.icDetectModel?.Dispose();
+            }
         }
     }
 }

--- a/DlcvDemo2/Form1.cs
+++ b/DlcvDemo2/Form1.cs
@@ -29,6 +29,7 @@ namespace DlcvDemo2
             public string InvalidReason { get; set; }
             public Mat NormalizedRoi { get; set; }
             public double[] NormToFullAffine { get; set; }
+            public OpenCvSharp.Rect SourceRect { get; set; }
 
             public void Dispose()
             {
@@ -338,36 +339,66 @@ namespace DlcvDemo2
                 DetectionGeometryUtils.ParseCategoryAndAngle(target.ObjectResult.CategoryName, out baseName, out normalizeAngle);
                 bool useIcDetectModel = ShouldUseIcDetectModel(baseName);
 
+                List<CSharpObjectResult> bestMapped = null;
+                int bestRealCount = -1;
+
+                // 先尝试角度归一化（normalizeAngle）
                 using (RoiProcessResult roi = CropAndRotateRoi(fullImageRgb, target, normalizeAngle))
                 {
-                    if (!roi.IsValid)
+                    if (roi.IsValid)
                     {
-                        runResult.Logs.Add($"跳过目标[{target.ObjectResult.CategoryName}]：{roi.InvalidReason}");
-                        continue;
+                        try
+                        {
+                            bestMapped = InferDetectionModelAndMapBack(roi, target.ObjectResult, useIcDetectModel);
+                            bestRealCount = GetRealDetectionCount(bestMapped, target.ObjectResult);
+                        }
+                        catch (Exception ex)
+                        {
+                            runResult.Logs.Add($"目标[{target.ObjectResult.CategoryName}]角度{normalizeAngle}检测异常：{ex.Message}");
+                        }
                     }
+                }
 
-                    try
+                // 如果角度归一化结果不理想，再尝试原始角度（0度）
+                if (normalizeAngle != 0)
+                {
+                    using (RoiProcessResult roi0 = CropAndRotateRoi(fullImageRgb, target, 0))
                     {
-                        List<CSharpObjectResult> mapped = InferDetectionModelAndMapBack(roi, target.ObjectResult, useIcDetectModel);
-                        runResult.FinalObjects.AddRange(mapped);
-                        int realResultCount = mapped.Count == 1 && ReferenceEquals(mapped[0], target.ObjectResult)
-                            ? 0
-                            : mapped.Count;
-                        if (useIcDetectModel)
+                        if (roi0.IsValid)
                         {
-                            runResult.IcModelResultCount += realResultCount;
-                        }
-                        else
-                        {
-                            runResult.ComponentModelResultCount += realResultCount;
+                            try
+                            {
+                                List<CSharpObjectResult> mapped0 = InferDetectionModelAndMapBack(roi0, target.ObjectResult, useIcDetectModel);
+                                int realCount0 = GetRealDetectionCount(mapped0, target.ObjectResult);
+                                if (realCount0 > bestRealCount)
+                                {
+                                    bestMapped = mapped0;
+                                    bestRealCount = realCount0;
+                                }
+                            }
+                            catch (Exception ex)
+                            {
+                                runResult.Logs.Add($"目标[{target.ObjectResult.CategoryName}]角度0检测异常：{ex.Message}");
+                            }
                         }
                     }
-                    catch (Exception ex)
-                    {
-                        string routeName = useIcDetectModel ? "IC检测模型" : "元件检测模型";
-                        runResult.Logs.Add($"目标[{target.ObjectResult.CategoryName}]{routeName}推理失败，保留元件提取结果兜底：{ex.Message}");
-                        runResult.FinalObjects.Add(target.ObjectResult);
-                    }
+                }
+
+                if (bestMapped == null)
+                {
+                    runResult.Logs.Add($"跳过目标[{target.ObjectResult.CategoryName}]：ROI裁剪无效");
+                    continue;
+                }
+
+                runResult.FinalObjects.AddRange(bestMapped);
+                int finalRealCount = GetRealDetectionCount(bestMapped, target.ObjectResult);
+                if (useIcDetectModel)
+                {
+                    runResult.IcModelResultCount += finalRealCount;
+                }
+                else
+                {
+                    runResult.ComponentModelResultCount += finalRealCount;
                 }
 
                 roiCompleted++;
@@ -379,6 +410,15 @@ namespace DlcvDemo2
             runResult.DisplayResult = BuildDisplayResult(runResult.FinalObjects);
             ReportInferenceProgress(progress, 100, "推理完成");
             return runResult;
+        }
+
+        private static int GetRealDetectionCount(List<CSharpObjectResult> mapped, CSharpObjectResult extractFallback)
+        {
+            if (mapped == null || mapped.Count == 0)
+                return 0;
+            if (mapped.Count == 1 && ReferenceEquals(mapped[0], extractFallback))
+                return 0;
+            return mapped.Count;
         }
 
         private static bool ShouldUseIcDetectModel(string baseName)
@@ -477,6 +517,7 @@ namespace DlcvDemo2
 
                     roi = new Mat(fullImageRgb, roiRect).Clone();
                     fullToCropAffine = new[] { 1.0, 0.0, -roiRect.X, 0.0, 1.0, -roiRect.Y };
+                    result.SourceRect = roiRect;
                 }
 
                 if (roi == null || roi.Empty())
@@ -531,18 +572,6 @@ namespace DlcvDemo2
             }
         }
 
-        private static int _debugRoiIndex = 0;
-        private static readonly object _debugLogLock = new object();
-
-        private void LogDebug(string message)
-        {
-            string logPath = Path.Combine(Path.GetTempPath(), "dlcvdemo2_debug.log");
-            lock (_debugLogLock)
-            {
-                File.AppendAllText(logPath, $"{DateTime.Now:HH:mm:ss.fff} {message}{Environment.NewLine}");
-            }
-        }
-
         private List<CSharpObjectResult> InferDetectionModelAndMapBack(RoiProcessResult roiContext, CSharpObjectResult extractFallback, bool useIcDetectModel)
         {
             JObject inferParams = new JObject
@@ -551,35 +580,14 @@ namespace DlcvDemo2
             };
 
             Model activeModel = useIcDetectModel ? icDetectModel : componentDetectModel;
-
-            // 临时调试：保存ROI图像并打印原始检测输出
-            string debugDir = Path.Combine(Path.GetTempPath(), "dlcvdemo2_debug");
-            Directory.CreateDirectory(debugDir);
-            int roiIdx = System.Threading.Interlocked.Increment(ref _debugRoiIndex);
-            string safeName = string.Join("_", (extractFallback.CategoryName ?? "unknown").Split(Path.GetInvalidFileNameChars()));
-            string roiPath = Path.Combine(debugDir, $"roi_{roiIdx:D3}_{safeName}.png");
-            try
-            {
-                Cv2.ImWrite(roiPath, roiContext.NormalizedRoi);
-            }
-            catch { }
-
             CSharpResult roiResult = activeModel.Infer(roiContext.NormalizedRoi, inferParams);
+
             if (roiResult.SampleResults == null || roiResult.SampleResults.Count == 0)
             {
-                LogDebug($"[ROI {roiIdx}] {extractFallback.CategoryName}: raw=0 (no sample results), roiSize={roiContext.NormalizedRoi.Width}x{roiContext.NormalizedRoi.Height}");
                 return new List<CSharpObjectResult> { extractFallback };
             }
 
             List<CSharpObjectResult> rawObjects = roiResult.SampleResults[0].Results ?? new List<CSharpObjectResult>();
-            LogDebug($"[ROI {roiIdx}] {extractFallback.CategoryName}: raw={rawObjects.Count}, roiSize={roiContext.NormalizedRoi.Width}x{roiContext.NormalizedRoi.Height}");
-            for (int i = 0; i < rawObjects.Count; i++)
-            {
-                var r = rawObjects[i];
-                string bboxStr = r.Bbox != null ? string.Join(",", r.Bbox) : "null";
-                LogDebug($"  [{i}] {r.CategoryName} score={r.Score:F2} bbox=[{bboxStr}]");
-            }
-
             if (rawObjects.Count == 0)
             {
                 return new List<CSharpObjectResult> { extractFallback };

--- a/DlcvDemo2/Form1.cs
+++ b/DlcvDemo2/Form1.cs
@@ -22,6 +22,7 @@ namespace DlcvDemo2
         private Model icDetectModel;
         private string imagePath;
         private bool isInferenceRunning;
+        private float _inferenceThreshold = 0.3f;
 
         private sealed class RoiProcessResult : IDisposable
         {
@@ -238,6 +239,16 @@ namespace DlcvDemo2
                 string inferImagePath = imagePath;
                 SlidingWindowConfig config = CaptureSlidingWindowConfig();
 
+                // 初始化调试日志（每张图片一个日志文件）
+                try
+                {
+                    string logDir = Path.Combine(Path.GetTempPath(), "DlcvDemo2_Logs");
+                    Directory.CreateDirectory(logDir);
+                    string logPath = Path.Combine(logDir, $"infer_{DateTime.Now:yyyyMMdd_HHmmss_fff}.log");
+                    InferenceDebugLogger.Enable(logPath);
+                }
+                catch { }
+
                 isInferenceRunning = true;
                 UpdateBusyControlState();
                 SetInferenceProgress(0, "准备推理");
@@ -260,7 +271,7 @@ namespace DlcvDemo2
 
                         Stopwatch sw = Stopwatch.StartNew();
                         // 颜色约定：UI 显示使用 imageBgr；送入 dvst 的整条 pipeline 使用 imageRgb（RGB）。
-                        PipelineRunResult runResult = RunPipeline(imageRgb, config, progress);
+                        PipelineRunResult runResult = RunPipeline(imageRgb, config, progress, _inferenceThreshold);
                         sw.Stop();
 
                         return new InferenceExecutionResult
@@ -306,8 +317,11 @@ namespace DlcvDemo2
             }
         }
 
-        private PipelineRunResult RunPipeline(Mat fullImageRgb, SlidingWindowConfig config, IProgress<InferenceProgressInfo> progress = null)
+        private PipelineRunResult RunPipeline(Mat fullImageRgb, SlidingWindowConfig config, IProgress<InferenceProgressInfo> progress = null, float threshold = 0.3f)
         {
+            InferenceDebugLogger.Log($"\n========== RunPipeline start ==========");
+            InferenceDebugLogger.Log($"Image size={fullImageRgb?.Width}x{fullImageRgb?.Height}, threshold={threshold}");
+
             var runResult = new PipelineRunResult();
 
             ReportInferenceProgress(progress, 8, "生成滑窗");
@@ -321,10 +335,20 @@ namespace DlcvDemo2
             runResult.SlidingWindowCount = windows.Count;
 
             ReportInferenceProgress(progress, 12, $"元件提取模型滑窗推理 0/{windows.Count}");
-            List<ExtractDetection> extractDetections = InferExtractModelOnWindows(fullImageRgb, windows, progress);
+            List<ExtractDetection> extractDetections = InferExtractModelOnWindows(fullImageRgb, windows, progress, threshold);
             ReportInferenceProgress(progress, 62, "合并元件提取结果");
+            InferenceDebugLogger.Log($"Before merge: {extractDetections?.Count ?? 0} detections");
             List<ExtractDetection> mergedExtract = ExtractMergeUtils.MergeExtractResults(extractDetections);
             runResult.MergedExtractCount = mergedExtract.Count;
+            InferenceDebugLogger.Log($"After merge: {mergedExtract.Count} detections");
+            for (int mi = 0; mi < mergedExtract.Count; mi++)
+            {
+                var me = mergedExtract[mi];
+                if (me != null)
+                    InferenceDebugLogger.LogObject($"  Merge[{mi}]", me.ObjectResult);
+                else
+                    InferenceDebugLogger.Log($"  Merge[{mi}]: null");
+            }
 
             int roiTotal = mergedExtract.Count;
             int roiCompleted = 0;
@@ -348,7 +372,7 @@ namespace DlcvDemo2
 
                     try
                     {
-                        List<CSharpObjectResult> mapped = InferDetectionModelAndMapBack(roi, target.ObjectResult, useIcDetectModel);
+                        List<CSharpObjectResult> mapped = InferDetectionModelAndMapBack(roi, target.ObjectResult, useIcDetectModel, threshold);
                         runResult.FinalObjects.AddRange(mapped);
                         int realResultCount = mapped.Count == 1 && ReferenceEquals(mapped[0], target.ObjectResult)
                             ? 0
@@ -377,6 +401,9 @@ namespace DlcvDemo2
 
             ReportInferenceProgress(progress, 95, "整理结果");
             runResult.DisplayResult = BuildDisplayResult(runResult.FinalObjects);
+            InferenceDebugLogger.Log($"Final total objects={runResult.FinalObjects.Count}");
+            InferenceDebugLogger.LogObjects($"Final objects", runResult.FinalObjects);
+            InferenceDebugLogger.Log($"========== RunPipeline end ==========\n");
             ReportInferenceProgress(progress, 100, "推理完成");
             return runResult;
         }
@@ -391,14 +418,17 @@ namespace DlcvDemo2
                 || string.Equals(baseName, "晶振", StringComparison.OrdinalIgnoreCase);
         }
 
-        private List<ExtractDetection> InferExtractModelOnWindows(Mat fullImageRgb, List<Rect> windows, IProgress<InferenceProgressInfo> progress)
+        private List<ExtractDetection> InferExtractModelOnWindows(Mat fullImageRgb, List<Rect> windows, IProgress<InferenceProgressInfo> progress, float threshold = 0.3f)
         {
             var output = new List<ExtractDetection>();
             int order = 0;
             JObject inferParams = new JObject
             {
-                ["with_mask"] = false
+                ["with_mask"] = false,
+                ["threshold"] = threshold
             };
+            InferenceDebugLogger.Log($"=== InferExtractModelOnWindows start ===");
+            InferenceDebugLogger.Log($"InferExtractModelOnWindows: threshold={threshold}, windowCount={windows?.Count ?? 0}");
 
             int totalWindows = windows != null ? windows.Count : 0;
             if (totalWindows == 0)
@@ -425,9 +455,11 @@ namespace DlcvDemo2
                         Rect2d aabb = ExtractMergeUtils.GetAabbFromObject(mapped);
                         if (aabb.Width <= 0 || aabb.Height <= 0)
                         {
+                            InferenceDebugLogger.Log($"  Skip invalid aabb: w={aabb.Width}, h={aabb.Height}");
                             continue;
                         }
 
+                        InferenceDebugLogger.LogObject($"  Extract window[{i}]", mapped);
                         output.Add(new ExtractDetection
                         {
                             ObjectResult = mapped,
@@ -445,6 +477,8 @@ namespace DlcvDemo2
                 }
             }
 
+            InferenceDebugLogger.Log($"InferExtractModelOnWindows: total detections before merge={output.Count}");
+            InferenceDebugLogger.Log($"=== InferExtractModelOnWindows end ===");
             return output;
         }
 
@@ -455,6 +489,15 @@ namespace DlcvDemo2
                 IsValid = false,
                 InvalidReason = "未知错误"
             };
+            InferenceDebugLogger.Log($"=== CropAndRotateRoi start ===");
+            if (target != null)
+            {
+                InferenceDebugLogger.LogObject($"Target object", target.ObjectResult);
+            }
+            else
+            {
+                InferenceDebugLogger.Log($"Target object: null");
+            }
 
             Mat roi = null;
             Mat normalized = null;
@@ -486,6 +529,7 @@ namespace DlcvDemo2
                 }
 
                 normalized = DetectionGeometryUtils.RotateRoiByRightAngle(roi, normalizeAngle);
+                InferenceDebugLogger.Log($"Rotated ROI: {roi?.Width}x{roi?.Height} -> {normalized?.Width}x{normalized?.Height} (angle={normalizeAngle})");
                 if (normalized == null || normalized.Empty())
                 {
                     if (normalized != null)
@@ -510,11 +554,15 @@ namespace DlcvDemo2
                 result.NormalizedRoi = normalized;
                 normalized = null;
                 result.NormToFullAffine = normToFull;
+                InferenceDebugLogger.Log($"CropAndRotateRoi success: normROI={result.NormalizedRoi?.Width}x{result.NormalizedRoi?.Height}");
+                InferenceDebugLogger.Log($"=== CropAndRotateRoi end ===");
                 return result;
             }
             catch (Exception ex)
             {
                 result.InvalidReason = ex.Message;
+                InferenceDebugLogger.Log($"CropAndRotateRoi exception: {ex.Message}");
+                InferenceDebugLogger.Log($"=== CropAndRotateRoi end (exception) ===");
                 return result;
             }
             finally
@@ -531,23 +579,34 @@ namespace DlcvDemo2
             }
         }
 
-        private List<CSharpObjectResult> InferDetectionModelAndMapBack(RoiProcessResult roiContext, CSharpObjectResult extractFallback, bool useIcDetectModel)
+        private List<CSharpObjectResult> InferDetectionModelAndMapBack(RoiProcessResult roiContext, CSharpObjectResult extractFallback, bool useIcDetectModel, float threshold = 0.3f)
         {
             JObject inferParams = new JObject
             {
-                ["with_mask"] = false
+                ["with_mask"] = false,
+                ["threshold"] = threshold
             };
+
+            string modelName = useIcDetectModel ? "IC" : "Component";
+            InferenceDebugLogger.Log($"=== {modelName} detection start ===");
+            InferenceDebugLogger.Log($"ROI size={roiContext.NormalizedRoi?.Width}x{roiContext.NormalizedRoi?.Height}, threshold={threshold}");
+            InferenceDebugLogger.LogObject($"Extract fallback", extractFallback);
 
             Model activeModel = useIcDetectModel ? icDetectModel : componentDetectModel;
             CSharpResult roiResult = activeModel.Infer(roiContext.NormalizedRoi, inferParams);
             if (roiResult.SampleResults == null || roiResult.SampleResults.Count == 0)
             {
+                InferenceDebugLogger.Log($"No sample results, fallback to extract");
                 return new List<CSharpObjectResult> { extractFallback };
             }
 
             List<CSharpObjectResult> rawObjects = roiResult.SampleResults[0].Results ?? new List<CSharpObjectResult>();
+            InferenceDebugLogger.Log($"Raw detection count={rawObjects.Count}");
+            InferenceDebugLogger.LogObjects($"Raw detections", rawObjects);
+
             if (rawObjects.Count == 0)
             {
+                InferenceDebugLogger.Log($"Empty results, fallback to extract");
                 return new List<CSharpObjectResult> { extractFallback };
             }
 
@@ -559,7 +618,15 @@ namespace DlcvDemo2
                 {
                     mappedObjects.Add(ResolveFinalDetectionObject(mapped, extractFallback));
                 }
+                else
+                {
+                    InferenceDebugLogger.LogObject($"  MAP FAILED (skipped)", obj);
+                }
             }
+
+            InferenceDebugLogger.Log($"Mapped success count={mappedObjects.Count}, failed={rawObjects.Count - mappedObjects.Count}");
+            InferenceDebugLogger.LogObjects($"Mapped detections", mappedObjects);
+            InferenceDebugLogger.Log($"=== {modelName} detection end ===");
 
             if (mappedObjects.Count == 0)
             {
@@ -1014,6 +1081,48 @@ namespace DlcvDemo2
                 asDecimal = control.Maximum;
             }
             control.Value = asDecimal;
+        }
+
+        /// <summary>
+        /// 无 UI 命令行推理入口。
+        /// </summary>
+        public string RunHeadless(string extractModelPath, string componentModelPath, string icModelPath, string imgPath, float threshold)
+        {
+            // 初始化日志
+            string logDir = Path.Combine(Path.GetTempPath(), "DlcvDemo2_Logs");
+            Directory.CreateDirectory(logDir);
+            string logPath = Path.Combine(logDir, $"infer_{DateTime.Now:yyyyMMdd_HHmmss_fff}.log");
+            InferenceDebugLogger.Enable(logPath);
+            InferenceDebugLogger.Log("=== Headless mode started ===");
+            InferenceDebugLogger.Log($"Models: extract={extractModelPath}, component={componentModelPath}, ic={icModelPath}");
+            InferenceDebugLogger.Log($"Image: {imgPath}, threshold={threshold}");
+
+            // 加载模型
+            extractModel = new Model(extractModelPath, 0, false);
+            componentDetectModel = new Model(componentModelPath, 0, false);
+            icDetectModel = new Model(icModelPath, 0, false);
+            imagePath = imgPath;
+
+            // 读取图片
+            using (Mat imageBgr = Cv2.ImRead(imagePath, ImreadModes.Unchanged))
+            {
+                if (imageBgr == null || imageBgr.Empty())
+                {
+                    throw new InvalidOperationException("图片解码失败。");
+                }
+                using (Mat imageRgb = PrepareImageForModelInput(imageBgr))
+                {
+                    var config = new SlidingWindowConfig
+                    {
+                        WindowWidth = imageRgb.Width,
+                        WindowHeight = imageRgb.Height,
+                        OverlapX = 0,
+                        OverlapY = 0
+                    };
+                    var result = RunPipeline(imageRgb, config, null, threshold);
+                    return BuildInferenceText(result, 0);
+                }
+            }
         }
     }
 }

--- a/DlcvDemo2/Program.cs
+++ b/DlcvDemo2/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Windows.Forms;
 
 namespace DlcvDemo2
@@ -6,11 +7,55 @@ namespace DlcvDemo2
     internal static class Program
     {
         [STAThread]
-        private static void Main()
+        private static void Main(string[] args)
         {
+            if (args.Length >= 4)
+            {
+                // 命令行模式
+                RunCommandLine(args);
+                return;
+            }
+
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
             Application.Run(new Form1());
+        }
+
+        private static void RunCommandLine(string[] args)
+        {
+            string extractModelPath = args[0];
+            string componentModelPath = args[1];
+            string icModelPath = args[2];
+            string imagePath = args[3];
+            float threshold = 0.3f;
+            if (args.Length >= 5 && !float.TryParse(args[4], out threshold))
+            {
+                threshold = 0.3f;
+            }
+
+            foreach (var path in new[] { extractModelPath, componentModelPath, icModelPath, imagePath })
+            {
+                if (!File.Exists(path))
+                {
+                    Console.WriteLine($"文件不存在: {path}");
+                    Environment.Exit(1);
+                    return;
+                }
+            }
+
+            try
+            {
+                using (var form = new Form1())
+                {
+                    string result = form.RunHeadless(extractModelPath, componentModelPath, icModelPath, imagePath, threshold);
+                    Console.WriteLine(result);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"推理失败: {ex}");
+                Environment.Exit(1);
+            }
         }
     }
 }

--- a/DlcvDemo2/Program.cs
+++ b/DlcvDemo2/Program.cs
@@ -1,16 +1,140 @@
 using System;
+using System.IO;
 using System.Windows.Forms;
+using dlcv_infer_csharp;
+using Newtonsoft.Json.Linq;
+using OpenCvSharp;
 
 namespace DlcvDemo2
 {
     internal static class Program
     {
         [STAThread]
-        private static void Main()
+        private static void Main(string[] args)
         {
+            if (args.Length >= 1 && args[0] == "--test-detect")
+            {
+                RunDetectOnlyTest(args);
+                return;
+            }
+
+            if (args.Length >= 4)
+            {
+                RunHeadless(args);
+                return;
+            }
+
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
             Application.Run(new Form1());
+        }
+
+        private static void RunDetectOnlyTest(string[] args)
+        {
+            // args: --test-detect model_path image_path
+            if (args.Length < 3)
+            {
+                Console.WriteLine("Usage: --test-detect <model_path> <image_path>");
+                Environment.ExitCode = 1;
+                return;
+            }
+
+            string modelPath = args[1];
+            string imagePath = args[2];
+
+            try
+            {
+                var model = new Model(modelPath, 0, false);
+                Mat imageBgr = Cv2.ImRead(imagePath, ImreadModes.Unchanged);
+                if (imageBgr == null || imageBgr.Empty())
+                {
+                    Console.WriteLine("Image load failed");
+                    Environment.ExitCode = 1;
+                    return;
+                }
+                Mat imageRgb = Form1.PrepareImageForModelInput(imageBgr);
+
+                // Test Infer (used by DlcvDemo2)
+                JObject inferParams = new JObject { ["with_mask"] = false };
+                var resultInfer = model.Infer(imageRgb, inferParams);
+                Console.WriteLine("=== Infer (DlcvDemo2 style) ===");
+                Console.WriteLine($"Results: {resultInfer.SampleResults[0].Results.Count}");
+                for (int i = 0; i < resultInfer.SampleResults[0].Results.Count; i++)
+                {
+                    var obj = resultInfer.SampleResults[0].Results[i];
+                    string bbox = obj.Bbox != null ? string.Join(",", obj.Bbox) : "null";
+                    Console.WriteLine($"[{i}] {obj.CategoryName} score={obj.Score:F2} bbox=[{bbox}]");
+                }
+
+                // Test InferOneOutJson (used by DlcvDemo)
+                JObject inferParams2 = new JObject { ["threshold"] = 0.5f, ["with_mask"] = true };
+                dynamic resultJson = model.InferOneOutJson(imageRgb, inferParams2);
+                Console.WriteLine("=== InferOneOutJson (DlcvDemo style) ===");
+                var jsonResults = resultJson as Newtonsoft.Json.Linq.JArray;
+                if (jsonResults != null)
+                {
+                    Console.WriteLine($"Results: {jsonResults.Count}");
+                    for (int i = 0; i < jsonResults.Count; i++)
+                    {
+                        var item = jsonResults[i];
+                        string cat = item["category_name"]?.ToString() ?? "unknown";
+                        double score = item["score"]?.Value<double>() ?? 0;
+                        var bboxArr = item["bbox"] as Newtonsoft.Json.Linq.JArray;
+                        string bbox = bboxArr != null ? string.Join(",", bboxArr) : "null";
+                        Console.WriteLine($"[{i}] {cat} score={score:F2} bbox=[{bbox}]");
+                    }
+                }
+
+                imageRgb.Dispose();
+                imageBgr.Dispose();
+                model.Dispose();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error: {ex}");
+                Environment.ExitCode = 1;
+            }
+        }
+
+        private static void RunHeadless(string[] args)
+        {
+            string extractModelPath = args[0];
+            string componentModelPath = args[1];
+            string icModelPath = args[2];
+            string imagePath = args[3];
+            int windowWidth = args.Length > 4 ? int.Parse(args[4]) : 2560;
+            int windowHeight = args.Length > 5 ? int.Parse(args[5]) : 2560;
+            int overlapX = args.Length > 6 ? int.Parse(args[6]) : 1024;
+            int overlapY = args.Length > 7 ? int.Parse(args[7]) : 1024;
+
+            var config = new Form1.SlidingWindowConfig
+            {
+                WindowWidth = windowWidth,
+                WindowHeight = windowHeight,
+                OverlapX = overlapX,
+                OverlapY = overlapY
+            };
+
+            try
+            {
+                var result = Form1.RunHeadless(extractModelPath, componentModelPath, icModelPath, imagePath, config);
+                Console.WriteLine($"SlidingWindowCount: {result.SlidingWindowCount}");
+                Console.WriteLine($"MergedExtractCount: {result.MergedExtractCount}");
+                Console.WriteLine($"ComponentModelResultCount: {result.ComponentModelResultCount}");
+                Console.WriteLine($"IcModelResultCount: {result.IcModelResultCount}");
+                Console.WriteLine($"FinalObjects: {result.FinalObjects.Count}");
+                for (int i = 0; i < result.FinalObjects.Count; i++)
+                {
+                    var obj = result.FinalObjects[i];
+                    string bbox = obj.Bbox != null ? string.Join(",", obj.Bbox) : "null";
+                    Console.WriteLine($"[{i}] {obj.CategoryName} score={obj.Score:F2} bbox=[{bbox}]");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error: {ex}");
+                Environment.ExitCode = 1;
+            }
         }
     }
 }

--- a/DlcvDemo2/Utils/DetectionGeometryUtils.cs
+++ b/DlcvDemo2/Utils/DetectionGeometryUtils.cs
@@ -167,12 +167,15 @@ namespace DlcvDemo2
             Mat rotMat = null;
             try
             {
-                rotMat = Cv2.GetRotationMatrix2D(new Point2f((float)cx, (float)cy), angleDeg, 1.0);
-                rotMat.Set(0, 2, rotMat.Get<double>(0, 2) + w / 2.0 - cx);
-                rotMat.Set(1, 2, rotMat.Get<double>(1, 2) + h / 2.0 - cy);
+                // 计算旋转后的外接矩形尺寸，避免边缘截断
+                double absCos = Math.Abs(Math.Cos(angleRad));
+                double absSin = Math.Abs(Math.Sin(angleRad));
+                int outW = Math.Max(1, (int)Math.Round(w * absCos + h * absSin));
+                int outH = Math.Max(1, (int)Math.Round(w * absSin + h * absCos));
 
-                int outW = Math.Max(1, (int)Math.Round(w));
-                int outH = Math.Max(1, (int)Math.Round(h));
+                rotMat = Cv2.GetRotationMatrix2D(new Point2f((float)cx, (float)cy), angleDeg, 1.0);
+                rotMat.Set(0, 2, rotMat.Get<double>(0, 2) + outW / 2.0 - cx);
+                rotMat.Set(1, 2, rotMat.Get<double>(1, 2) + outH / 2.0 - cy);
 
                 roi = new Mat();
                 Cv2.WarpAffine(fullImage, roi, rotMat, new Size(outW, outH));
@@ -336,6 +339,7 @@ namespace DlcvDemo2
 
             if (obj.Bbox == null || obj.Bbox.Count < 4)
             {
+                InferenceDebugLogger.Log($"TryMapObjectToFull failed: bbox null or count<4");
                 return false;
             }
 
@@ -348,6 +352,7 @@ namespace DlcvDemo2
                 double h = Math.Abs(obj.Bbox[3]);
                 if (w <= 0 || h <= 0)
                 {
+                    InferenceDebugLogger.Log($"TryMapObjectToFull failed: rotated w={w} h={h}");
                     return false;
                 }
 
@@ -386,6 +391,7 @@ namespace DlcvDemo2
                 double h = Math.Abs(obj.Bbox[3]);
                 if (w <= 0 || h <= 0)
                 {
+                    InferenceDebugLogger.Log($"TryMapObjectToFull failed: axis-aligned w={w} h={h}");
                     return false;
                 }
 
@@ -413,6 +419,7 @@ namespace DlcvDemo2
             double outH = maxY - minY;
             if (outW <= 1e-6 || outH <= 1e-6)
             {
+                InferenceDebugLogger.Log($"TryMapObjectToFull failed: mapped area too small outW={outW} outH={outH}");
                 return false;
             }
 
@@ -428,6 +435,7 @@ namespace DlcvDemo2
                 true,
                 false,
                 -100f);
+            InferenceDebugLogger.Log($"TryMapObjectToFull success: mapped to bbox=[{minX:F2},{minY:F2},{outW:F2},{outH:F2}]");
             return true;
         }
 

--- a/DlcvDemo2/Utils/ExtractMergeUtils.cs
+++ b/DlcvDemo2/Utils/ExtractMergeUtils.cs
@@ -48,9 +48,11 @@ namespace DlcvDemo2
             var mergedAll = new List<ExtractDetection>();
             if (fullImageDetections == null || fullImageDetections.Count == 0)
             {
+                InferenceDebugLogger.Log($"MergeExtractResults: input empty");
                 return mergedAll;
             }
 
+            InferenceDebugLogger.Log($"MergeExtractResults: input={fullImageDetections.Count}");
             foreach (var group in fullImageDetections.GroupBy(x => x.ObjectResult.CategoryName ?? string.Empty))
             {
                 var clusters = new List<ExtractDetection>();
@@ -103,6 +105,7 @@ namespace DlcvDemo2
             }
 
             mergedAll.Sort((a, b) => a.Order.CompareTo(b.Order));
+            InferenceDebugLogger.Log($"MergeExtractResults: output={mergedAll.Count}");
             return mergedAll;
         }
 

--- a/DlcvDemo2/Utils/InferenceDebugLogger.cs
+++ b/DlcvDemo2/Utils/InferenceDebugLogger.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using CSharpObjectResult = dlcv_infer_csharp.Utils.CSharpObjectResult;
+
+namespace DlcvDemo2
+{
+    internal static class InferenceDebugLogger
+    {
+        private static readonly object Lock = new object();
+        private static string _logFilePath;
+        private static bool _enabled = true;
+
+        public static void Enable(string outputPath)
+        {
+            _enabled = true;
+            _logFilePath = outputPath;
+            try
+            {
+                File.WriteAllText(_logFilePath, $"# Inference Debug Log - {DateTime.Now:yyyy-MM-dd HH:mm:ss}\n", Encoding.UTF8);
+            }
+            catch { }
+        }
+
+        public static void Disable()
+        {
+            _enabled = false;
+        }
+
+        public static void Log(string message)
+        {
+            if (!_enabled || string.IsNullOrEmpty(_logFilePath))
+                return;
+            lock (Lock)
+            {
+                try
+                {
+                    File.AppendAllText(_logFilePath, $"[{DateTime.Now:HH:mm:ss.fff}] {message}\n", Encoding.UTF8);
+                }
+                catch { }
+            }
+        }
+
+        public static void LogObject(string prefix, CSharpObjectResult obj)
+        {
+            string bboxStr = obj.Bbox == null ? "null" : string.Join(", ", obj.Bbox);
+            Log($"{prefix}: cat={obj.CategoryName} score={obj.Score:F4} bbox=[{bboxStr}] withAngle={obj.WithAngle} angle={obj.Angle:F4}");
+        }
+
+        public static void LogObjects(string prefix, List<CSharpObjectResult> objects)
+        {
+            if (objects == null)
+            {
+                Log($"{prefix}: null");
+                return;
+            }
+            Log($"{prefix}: count={objects.Count}");
+            for (int i = 0; i < objects.Count; i++)
+            {
+                LogObject($"  [{i}]", objects[i]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
﻿## 问题描述

DlcvDemo2（三模型流水线推理完整大图）相比 DlcvDemo（单模型直接推理）存在字符检测不完整的问题。同一张大图下，DlcvDemo 字符检测完整，DlcvDemo2 字符检测结果数量偏少。

## 修复方案

### 1. 修复 threshold 参数未传入

DlcvDemo 在推理时显式传入 `threshold`：
```csharp
data["threshold"] = (float)numericUpDown_threshold.Value;
```

但 DlcvDemo2 在所有模型推理中均未传入该参数：
```csharp
JObject inferParams = new JObject
{
    ["with_mask"] = false
};
```

修复后，提取模型与检测模型均显式传入可配置的 threshold（默认 0.3），与 DlcvDemo 行为保持一致。

### 2. 修复旋转裁剪边缘截断

`TryBuildRotatedCrop` 原实现输出尺寸直接取原始 bbox 的 w/h：
```csharp
int outW = Math.Max(1, (int)Math.Round(w));
int outH = Math.Max(1, (int)Math.Round(h));
```

当提取目标存在非直角旋转时，旋转后的外接矩形尺寸通常大于原始 w/h，导致边缘内容被截断，进而使边缘字符漏检。

修复后，按旋转外接矩形计算输出尺寸：
```csharp
double absCos = Math.Abs(Math.Cos(angleRad));
double absSin = Math.Abs(Math.Sin(angleRad));
int outW = Math.Max(1, (int)Math.Round(w * absCos + h * absSin));
int outH = Math.Max(1, (int)Math.Round(w * absSin + h * absCos));
```

### 3. 新增调试日志与命令行入口

- 新增 `InferenceDebugLogger`，记录滑窗提取、合并、ROI 裁剪、检测模型推理、坐标映射等关键中间结果
- 新增 `RunHeadless` 命令行入口，支持无 GUI 运行，方便批量对比验证

## 测试验证

- [x] 代码编译通过（Debug/x64）
- [ ] 端到端模型推理对比验证（需实际运行环境）
