### PR TITLE
fix: 同步更新版本号并重新编译 C# 测试程序

### DIFF
--- a/1_编译打包.bat
+++ b/1_编译打包.bat
@@ -8,6 +8,7 @@ mkdir dlcvpro_infer_csharp
 xcopy DlcvDemo\bin\*.exe dlcvpro_infer_csharp\ /Y
 xcopy DlcvDemo\bin\*.config dlcvpro_infer_csharp\ /Y
 xcopy DlcvDemo\bin\*.dll dlcvpro_infer_csharp\ /Y
+xcopy hasp_26146.ini dlcvpro_infer_csharp\ /Y
 
 
 C:\sign-tool\signtool.exe sign /n 深度视觉（广东）人工智能研究有限公司 /t http://time.certum.pl /fd sha256 /v  "dlcvpro_infer_csharp\C# 测试程序.exe"

--- a/hasp_26146.ini
+++ b/hasp_26146.ini
@@ -1,0 +1,2 @@
+serveraddr=127.0.0.1
+broadcastsearch=0

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import shutil
 
 from setuptools import setup
 
-version = '2026.6.3.0a0'
+version = '2026.6.8.0a0'
 
 package_name = "dlcvpro_infer_csharp"  # 包名
 packages: list = [package_name]  # 需要打包的包
@@ -33,6 +33,10 @@ def main():
 
 if __name__ == "__main__":
     import warnings
+
+    # 构建前同步 hasp 配置文件到包目录
+    if os.path.exists("hasp_26146.ini"):
+        shutil.copy("hasp_26146.ini", os.path.join(package_name, "hasp_26146.ini"))
 
     egg_info_path = f'{package_name}.egg-info'
 

--- a/setup.py
+++ b/setup.py
@@ -34,10 +34,6 @@ def main():
 if __name__ == "__main__":
     import warnings
 
-    # 构建前同步 hasp 配置文件到包目录
-    if os.path.exists("hasp_26146.ini"):
-        shutil.copy("hasp_26146.ini", os.path.join(package_name, "hasp_26146.ini"))
-
     egg_info_path = f'{package_name}.egg-info'
 
     path_list = ['build', 'dist', 'whl', egg_info_path]


### PR DESCRIPTION
﻿## 问题描述
同步 dlcv_infer/dlcv_deploy 的 hasp 配置修复，重新编译 C# 测试程序并更新版本号。

## 修复方案
- 更新版本号至 `2026.6.8.0a0`
- 重新编译 Release x64 C# API 与测试程序

## 测试验证
- [x] OpenIVS Release x64 编译通过
- [x] whl 打包安装验证通过
