### PR TITLE
feat: OpenIVS C# API 支持 Sentinel/Virbox 授权检测与模型授权类型校验

### DIFF
--- a/C# API文档.md
+++ b/C# API文档.md
@@ -262,7 +262,7 @@ public class DllLoader
     // 全局单例
     public static DllLoader Instance { get; }
 
-    // 根据模型头中的 dog_provider 字段，确保加载正确的 DLL
+    // 根据模型头中的 dog_provider 字段，校验当前可用授权并确保加载正确的 DLL
     public static void EnsureForModel(string modelPath);
 
     // 委托类型与字段（底层 C API 代理）
@@ -289,7 +289,12 @@ public class DllLoader
 | Sentinel | `dlcv_infer.dll` | `C:\dlcv\Lib\site-packages\dlcvpro_infer\dlcv_infer.dll` |
 | Virbox | `dlcv_infer_v.dll` | `C:\dlcv\Lib\site-packages\dlcvpro_infer\dlcv_infer_v.dll` |
 
-**自动检测优先级**：先检测 Sentinel，再检测 Virbox；均未检测到则回退到 Sentinel。
+**自动检测优先级**：`Instance` 初始化时先检测 Sentinel，再检测 Virbox；均未检测到则回退到 Sentinel。
+
+**Provider 一致性校验**：`EnsureForModel` 在加载模型前，先读取模型头 `dog_provider` 得到所需 provider，再调用 `DogUtils.GetAvailableProviders()` 获取当前可用授权列表。若所需 provider 不在可用列表中，抛出异常：
+- 可用列表为空时提示 `未检测到授权`。
+- 否则提示 `当前使用的是 {current}，加载的模型是 {needed} 格式，类型错误`（`current` 为当前可用 provider 显示名，`needed` 为模型所需 provider）。
+- 校验通过后再创建对应 provider 的 `DllLoader`。
 
 **模型级 Provider 解析**：
 - `.dvt`/`.dvo` 文件：读取前两行（`DV` + header_json），解析 `dog_provider` 字段。
@@ -443,7 +448,7 @@ Console.WriteLine(info.ToString());
 
 ## 13. 工程结构
 
-`DlcvCsharpApi` 是一个 .NET Framework 4.7.2 的 C# 类库工程，`OutputType` 为 `Library`，程序集名称为 `DlcvCsharpApi`，默认生成 `DlcvCsharpApi.dll`。项目定义了 `Debug|x64` 与 `Release|x64` 两个主要构建配置，`PlatformTarget` 为 `x64`，`LangVersion` 为 `7.3`。程序集版本为 `1.0.0.0`，`ComVisible` 为 `false`。
+`DlcvCsharpApi` 是一个 .NET Framework 4.7.2 的 C# 类库工程，`OutputType` 为 `Library`，程序集名称为 `DlcvCsharpApi`，默认生成 `DlcvCsharpApi.dll`。项目定义了 `Debug|x64` 与 `Release|x64` 两个主要构建配置，`PlatformTarget` 为 `x64`，`LangVersion` 为 `7.3`。程序集版本为 `2026.6.14.0`，`ComVisible` 为 `false`。
 
 发布版输出路径为 `DlcvCsharpApi\bin\x64\Release\DlcvCsharpApi.dll`。
 

--- a/DlcvCsharpApi/DllLoader.cs
+++ b/DlcvCsharpApi/DllLoader.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -83,8 +84,50 @@ namespace dlcv_infer_csharp
             lock (_lock)
             {
                 if (_instance != null && _instance.LoadedDogProvider == needed.Value) return;
+
+                List<DogProvider> availableProviders = DogUtils.GetAvailableProviders();
+                if (!availableProviders.Contains(needed.Value))
+                {
+                    if (availableProviders.Count == 0)
+                    {
+                        throw new Exception("未检测到加密狗");
+                    }
+                    string current = FormatProviderNames(availableProviders);
+                    string neededName = ProviderToChineseName(needed.Value);
+                    throw new Exception($"当前使用的是 {current} 加密狗，加载的模型是 {neededName} 格式，加密狗类型错误");
+                }
+
                 _instance = CreateLoader(needed.Value);
             }
+        }
+
+        private static string ProviderToChineseName(DogProvider provider)
+        {
+            switch (provider)
+            {
+                case DogProvider.Sentinel:
+                    return "深盾";
+                case DogProvider.Virbox:
+                    return "Virbox";
+                default:
+                    return provider.ToString();
+            }
+        }
+
+        private static string FormatProviderNames(List<DogProvider> providers)
+        {
+            if (providers == null || providers.Count == 0)
+                return "无";
+            if (providers.Count == 1)
+                return ProviderToChineseName(providers[0]);
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < providers.Count; i++)
+            {
+                if (i > 0)
+                    sb.Append("、");
+                sb.Append(ProviderToChineseName(providers[i]));
+            }
+            return sb.ToString();
         }
 
         private static DllLoader CreateLoader(DogProvider provider)

--- a/DlcvCsharpApi/DllLoader.cs
+++ b/DlcvCsharpApi/DllLoader.cs
@@ -90,25 +90,25 @@ namespace dlcv_infer_csharp
                 {
                     if (availableProviders.Count == 0)
                     {
-                        throw new Exception("未检测到加密狗");
+                        throw new Exception("未检测到授权");
                     }
                     string current = FormatProviderNames(availableProviders);
-                    string neededName = ProviderToChineseName(needed.Value);
-                    throw new Exception($"当前使用的是 {current} 加密狗，加载的模型是 {neededName} 格式，加密狗类型错误");
+                    string neededName = ProviderToDisplayName(needed.Value);
+                    throw new Exception($"当前使用的是 {current}，加载的模型是 {neededName} 格式，类型错误");
                 }
 
                 _instance = CreateLoader(needed.Value);
             }
         }
 
-        private static string ProviderToChineseName(DogProvider provider)
+        private static string ProviderToDisplayName(DogProvider provider)
         {
             switch (provider)
             {
                 case DogProvider.Sentinel:
                     return "Sentinel";
                 case DogProvider.Virbox:
-                    return "Virbox（深盾）";
+                    return "Virbox";
                 default:
                     return provider.ToString();
             }
@@ -119,13 +119,13 @@ namespace dlcv_infer_csharp
             if (providers == null || providers.Count == 0)
                 return "无";
             if (providers.Count == 1)
-                return ProviderToChineseName(providers[0]);
+                return ProviderToDisplayName(providers[0]);
             StringBuilder sb = new StringBuilder();
             for (int i = 0; i < providers.Count; i++)
             {
                 if (i > 0)
                     sb.Append("、");
-                sb.Append(ProviderToChineseName(providers[i]));
+                sb.Append(ProviderToDisplayName(providers[i]));
             }
             return sb.ToString();
         }

--- a/DlcvCsharpApi/DllLoader.cs
+++ b/DlcvCsharpApi/DllLoader.cs
@@ -106,9 +106,9 @@ namespace dlcv_infer_csharp
             switch (provider)
             {
                 case DogProvider.Sentinel:
-                    return "深盾";
+                    return "Sentinel";
                 case DogProvider.Virbox:
-                    return "Virbox";
+                    return "Virbox（深盾）";
                 default:
                     return provider.ToString();
             }

--- a/DlcvCsharpApi/Properties/AssemblyInfo.cs
+++ b/DlcvCsharpApi/Properties/AssemblyInfo.cs
@@ -29,6 +29,6 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.6.3.0")]
-[assembly: AssemblyFileVersion("2026.6.3.0")]
-[assembly: AssemblyInformationalVersion("2026.6.3.0a0")]
+[assembly: AssemblyVersion("2026.6.12.1")]
+[assembly: AssemblyFileVersion("2026.6.12.1")]
+[assembly: AssemblyInformationalVersion("2026.6.12.1a0")]

--- a/DlcvCsharpApi/Properties/AssemblyInfo.cs
+++ b/DlcvCsharpApi/Properties/AssemblyInfo.cs
@@ -29,6 +29,6 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.6.12.1")]
-[assembly: AssemblyFileVersion("2026.6.12.1")]
-[assembly: AssemblyInformationalVersion("2026.6.12.1a0")]
+[assembly: AssemblyVersion("2026.6.14.0")]
+[assembly: AssemblyFileVersion("2026.6.14.0")]
+[assembly: AssemblyInformationalVersion("2026.6.14.0")]

--- a/DlcvDemo/Properties/AssemblyInfo.cs
+++ b/DlcvDemo/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.6.12.0")]
-[assembly: AssemblyFileVersion("2026.6.12.0")]
-[assembly: AssemblyInformationalVersion("2026.6.12.0a0")]
+[assembly: AssemblyVersion("2026.6.12.1")]
+[assembly: AssemblyFileVersion("2026.6.12.1")]
+[assembly: AssemblyInformationalVersion("2026.6.12.1a0")]
 [assembly: NeutralResourcesLanguage("zh-CN")]

--- a/DlcvDemo/Properties/AssemblyInfo.cs
+++ b/DlcvDemo/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.6.12.1")]
-[assembly: AssemblyFileVersion("2026.6.12.1")]
-[assembly: AssemblyInformationalVersion("2026.6.12.1a0")]
+[assembly: AssemblyVersion("2026.6.14.0")]
+[assembly: AssemblyFileVersion("2026.6.14.0")]
+[assembly: AssemblyInformationalVersion("2026.6.14.0")]
 [assembly: NeutralResourcesLanguage("zh-CN")]

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import shutil
 
 from setuptools import setup
 
-version = '2026.6.12.0a0'
+version = '2026.6.12.1a0'
 
 package_name = "dlcvpro_infer_csharp"  # 包名
 packages: list = [package_name]  # 需要打包的包

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import shutil
 
 from setuptools import setup
 
-version = '2026.6.12.1a0'
+version = '2026.6.14.0'
 
 package_name = "dlcvpro_infer_csharp"  # 包名
 packages: list = [package_name]  # 需要打包的包

--- a/sync_assembly_version.py
+++ b/sync_assembly_version.py
@@ -101,18 +101,24 @@ def _sync_assembly_info(assembly_info_path: str, version: str, numeric_version: 
 def main() -> int:
     repo_root = os.path.dirname(os.path.abspath(__file__))
     setup_py = os.path.join(repo_root, "setup.py")
-    assembly_info = os.path.join(repo_root, "DlcvDemo", "Properties", "AssemblyInfo.cs")
+    assembly_infos = [
+        os.path.join(repo_root, "DlcvDemo", "Properties", "AssemblyInfo.cs"),
+        os.path.join(repo_root, "DlcvCsharpApi", "Properties", "AssemblyInfo.cs"),
+    ]
 
     version, numeric_version = _extract_version_from_setup_py(setup_py)
 
-    if not os.path.exists(assembly_info):
-        print(f"[sync_assembly_version] 未找到目标文件: {assembly_info}", file=sys.stderr)
-        return 2
+    all_changed = False
+    for assembly_info in assembly_infos:
+        if not os.path.exists(assembly_info):
+            print(f"[sync_assembly_version] 未找到目标文件: {assembly_info}", file=sys.stderr)
+            return 2
 
-    changed = _sync_assembly_info(assembly_info, version, numeric_version)
-    print(
-        f"[sync_assembly_version] DlcvDemo AssemblyInfo 版本已{'更新' if changed else '确认一致'} -> {version} (numeric: {numeric_version})"
-    )
+        changed = _sync_assembly_info(assembly_info, version, numeric_version)
+        all_changed = all_changed or changed
+        print(
+            f"[sync_assembly_version] {os.path.basename(os.path.dirname(assembly_info))} AssemblyInfo 版本已{'更新' if changed else '确认一致'} -> {version} (numeric: {numeric_version})"
+        )
     return 0
 
 


### PR DESCRIPTION
﻿## 问题描述
OpenIVS C# API 原先未接入 Virbox 加密狗检测，加载 SDK 模型时无法识别模型对应的授权类型，可能导致在错误授权环境下加载模型。

## 修复方案
- `DlcvCsharpApi/DllLoader.cs` 的 `EnsureForModel()` 增加模型头授权类型解析。
- 先获取当前可用授权 providers 列表，若模型所需 provider 不在列表中，抛出明确异常。
- 校验通过后再创建对应 DLL loader。
- 用户可见提示统一使用 Sentinel / Virbox，不出现中文别名。

## 测试验证
- 更新版本号至 `2026.6.14.0` 正式版，同步更新 `setup.py`、`sync_assembly_version.py`、`DlcvDemo/Properties/AssemblyInfo.cs`、`DlcvCsharpApi/Properties/AssemblyInfo.cs`。
- Release x64 重新编译 OpenIVS 全解决方案成功。
- 重新打包 `dlcvpro_infer_csharp-2026.6.14.0-cp311-none-win_amd64.whl` 并安装到本地环境成功。
- 本地安装 `DlcvCsharpApi` 测试包成功。
- 更新 `C# API文档.md`：修正 `DlcvCsharpApi` 程序集版本号为 `2026.6.14.0`，补充 `DllLoader.EnsureForModel` 的 provider 一致性校验说明。
- 当前环境仅 Sentinel 狗，Sentinel 模型加载路径正常。
- Virbox 回退分支需在真实 Virbox 环境进一步验证。
