### PR TITLE
fix: dvst 流程模型 modelIndex 改为 10000 起自管理递增，与 dvt 分区

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,13 @@ OpenIVS 是一个 .NET WPF 工业视觉框架。**本 AGENTS.md 聚焦 API 层�
 
 调用端不需要为这两类模型准备两套完全不同的调用方式。传入模型路径、设备和请求参数后，入口对象会完成对应的加载与执行。
 
+**model_index 分配约定**（避免普通模型与流程模型在同一张索引表中撞键）：
+
+- **普通模型（`.dvt`/`.dvo`）**：`model_index` 由底层 `dlcv_infer` 在加载时返回，从 `0` 起递增。
+- **流程模型（`.dvst`/`.dvso`/`.dvsp`）**：`model_index` 由 `dlcv_infer_cpp_dll` / `DlcvCsharpApi` 自管理，从 `10000` 起递增，与底层索引分区。
+
+C API 封装层（`dlcv_infer_c_dll`）以 `model_index` 作为全局表键索引模型；两类索引分区后，流程模型不会与任何 `index < 10000` 的普通模型互相覆盖，也允许同时加载多个流程模型。
+
 ## API 速查表
 
 ### C++ API 速查表

--- a/C# API文档.md
+++ b/C# API文档.md
@@ -110,7 +110,7 @@ public class Model : IDisposable
 ### 3.2 属性
 
 ```csharp
-public int modelIndex;                // 底层模型索引（普通模型），字段
+public int modelIndex;                // 模型索引：普通模型由底层 dlcv_infer 返回（0 起递增）；流程模型（DVS 模式）由本层自管理（10000 起递增），二者分区避免撞键
 public bool OwnModelIndex { get; set; } = true;  // 是否拥有释放权
 public DogProvider LoadedDogProvider { get; }      // 已加载的加密狗类型
 public string LoadedNativeDllName { get; }         // 已加载的原生 DLL 名称

--- a/C++ API文档.md
+++ b/C++ API文档.md
@@ -219,6 +219,8 @@ void FreeModel();
 - 普通模式且 `OwnModelIndex == true`：调用 `dlcv_free_model`。
 - 普通模式且 `OwnModelIndex == false`：仅标记 `modelIndex = -1`，不释放底层模型。
 
+> **model_index 来源**：普通模型的 `modelIndex` 由底层 `dlcv_infer` 加载时返回（从 `0` 起递增）；流程模型（`.dvst`/`.dvso`/`.dvsp`）的 `modelIndex` 由本层自管理（从 `10000` 起递增）。二者分区，避免上层按 `modelIndex` 索引时流程模型与普通模型撞键。流程模型推理走 `_flowModel`，不使用 `modelIndex` 调底层。
+
 ### 4.7 计时查询
 
 ```cpp

--- a/DlcvCsharpApi/Model.cs
+++ b/DlcvCsharpApi/Model.cs
@@ -36,6 +36,19 @@ namespace dlcv_infer_csharp
         /// </summary>
         public bool OwnModelIndex { get; set; } = true;
 
+        // dvst（流程模型，DVS 模式）的 modelIndex 由本层自管理，从 10000 起递增，
+        // 与 dvt 从底层 DLL 返回的 model_index（0 起递增）分区，避免上层按 modelIndex 索引时 dvst 与 dvt 撞键。
+        private static int s_nextFlowModelIndex = 10000;
+        private static readonly object s_flowModelIndexLock = new object();
+
+        private static int AllocateFlowModelIndex()
+        {
+            lock (s_flowModelIndexLock)
+            {
+                return s_nextFlowModelIndex++;
+            }
+        }
+
         // DVP mode fields
         private bool _isDvpMode = false;
         private bool _isDvsMode = false;
@@ -265,7 +278,7 @@ namespace dlcv_infer_csharp
                     string msg = report != null ? report.ToString() : "Unknown error";
                     throw new Exception("DVS模型加载失败:\n" + msg);
                 }
-                modelIndex = 1; // 标记为已加载
+                modelIndex = AllocateFlowModelIndex();
             }
             catch (Exception ex)
             {

--- a/DlcvCsharpApi/Properties/AssemblyInfo.cs
+++ b/DlcvCsharpApi/Properties/AssemblyInfo.cs
@@ -29,6 +29,6 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.6.23.0")]
-[assembly: AssemblyFileVersion("2026.6.23.0")]
-[assembly: AssemblyInformationalVersion("2026.6.23.0a0")]
+[assembly: AssemblyVersion("2026.7.7.0")]
+[assembly: AssemblyFileVersion("2026.7.7.0")]
+[assembly: AssemblyInformationalVersion("2026.7.7.0a0")]

--- a/DlcvDemo/Properties/AssemblyInfo.cs
+++ b/DlcvDemo/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.6.23.0")]
-[assembly: AssemblyFileVersion("2026.6.23.0")]
-[assembly: AssemblyInformationalVersion("2026.6.23.0a0")]
+[assembly: AssemblyVersion("2026.7.7.0")]
+[assembly: AssemblyFileVersion("2026.7.7.0")]
+[assembly: AssemblyInformationalVersion("2026.7.7.0a0")]
 [assembly: NeutralResourcesLanguage("zh-CN")]

--- a/Test/DlcvCSharpTest/Program.cs
+++ b/Test/DlcvCSharpTest/Program.cs
@@ -35,9 +35,6 @@ namespace DlcvCSharpTest
         private const string UsLagImagePath2 = @"C:\Users\Administrator\Desktop\测试无监督\NG3.png";
         private const string FlowInstanceSegFilterModelPath = @"Y:\zxc\模块化任务测试\实例分割筛选测试_120_50.dvst";
         private const string FlowInstanceSegFilterImagePath = @"Y:\zxc\模块化任务测试\实例分割\实例分割滑窗大图.png";
-        private const string BBoxCropFixModelAPath = @"Z:\A-苏州三谛\A260308-苏州三谛-AOI元器件定位-新方案\Task01-元件提取\现场模型\模型1-元件提取 - 副本_120_50.dvst";
-        private const string BBoxCropFixModelBPath = @"Z:\A-苏州三谛\A260308-苏州三谛-AOI元器件定位-新方案\Task01-元件提取\现场模型\模型1-元件提取 - 裁图_120_50.dvst";
-        private const string BBoxCropFixImagePath = @"Z:\A-苏州三谛\A260308-苏州三谛-AOI元器件定位-新方案\Task01-元件提取\现场模型\PCB20047-23439-TOP_61_4092_0.jpg";
 
         private static readonly List<ModelCase> DefaultCases = new List<ModelCase>
         {
@@ -79,11 +76,6 @@ namespace DlcvCSharpTest
                 if (args != null && args.Length >= 1 && string.Equals(args[0], "bbox-iou-dedup-selftest", StringComparison.OrdinalIgnoreCase))
                 {
                     return RunBBoxIoUDedupSelfTest();
-                }
-
-                if (args != null && args.Length >= 1 && string.Equals(args[0], "bbox-crop-fix-selftest", StringComparison.OrdinalIgnoreCase))
-                {
-                    return RunBBoxCropFixSelfTest();
                 }
 
                 if (args != null && args.Length >= 1 && string.Equals(args[0], "image-generation-expand-selftest", StringComparison.OrdinalIgnoreCase))
@@ -2046,9 +2038,6 @@ namespace DlcvCSharpTest
                 return 1;
             }
 
-            int actual = RunBBoxCropActualModelSelfTest();
-            if (actual != 0) return actual;
-
             Console.WriteLine("BBOX 去重与裁图修复自测通过");
             return 0;
         }
@@ -2563,108 +2552,6 @@ namespace DlcvCSharpTest
                 ["output_size"] = new JArray(width, height),
                 ["original_size"] = new JArray(width, height)
             };
-        }
-
-        private static int RunBBoxCropActualModelSelfTest()
-        {
-            Console.WriteLine("==== 苏州三谛 BBOX 裁图实际模型自测 ====");
-            if (!File.Exists(BBoxCropFixModelAPath)) { Console.WriteLine("模型A不存在: " + BBoxCropFixModelAPath); return 2; }
-            if (!File.Exists(BBoxCropFixModelBPath)) { Console.WriteLine("模型B不存在: " + BBoxCropFixModelBPath); return 2; }
-            if (!File.Exists(BBoxCropFixImagePath)) { Console.WriteLine("图像不存在: " + BBoxCropFixImagePath); return 2; }
-
-            Mat bgr = null;
-            Mat rgb = null;
-            try
-            {
-                bgr = Cv2.ImRead(BBoxCropFixImagePath, ImreadModes.Color);
-                if (bgr == null || bgr.Empty()) { Console.WriteLine("图像解码失败"); return 2; }
-                rgb = new Mat();
-                Cv2.CvtColor(bgr, rgb, ColorConversionCodes.BGR2RGB);
-
-                bool ok = true;
-                ok = RunBBoxCropOneModel("A", BBoxCropFixModelAPath, rgb, 4) && ok;
-                ok = RunBBoxCropOneModel("B", BBoxCropFixModelBPath, rgb, 4) && ok;
-                return ok ? 0 : 1;
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine("苏州三谛实际模型自测异常: " + ex.Message);
-                Console.WriteLine(ex.StackTrace);
-                return 1;
-            }
-            finally
-            {
-                if (rgb != null) rgb.Dispose();
-                if (bgr != null) bgr.Dispose();
-                ForceGc();
-            }
-        }
-
-        private static bool RunBBoxCropOneModel(string name, string modelPath, Mat rgb, int expectedCount)
-        {
-            Model model = null;
-            Utils.CSharpResult result = default(Utils.CSharpResult);
-            bool hasResult = false;
-            try
-            {
-                Console.WriteLine("[" + name + "] 加载模型: " + modelPath);
-                model = new Model(modelPath, GpuDeviceId, false, false);
-                var p = new JObject { ["threshold"] = 0.5, ["with_mask"] = true, ["batch_size"] = 1 };
-                var sw = Stopwatch.StartNew();
-                result = model.InferBatch(new List<Mat> { rgb }, p);
-                hasResult = true;
-                sw.Stop();
-
-                int sampleCount = result.SampleResults != null ? result.SampleResults.Count : 0;
-                int objectCount = sampleCount > 0 && result.SampleResults[0].Results != null
-                    ? result.SampleResults[0].Results.Count
-                    : 0;
-
-                Console.WriteLine("[" + name + "] sample_count: " + sampleCount);
-                Console.WriteLine("[" + name + "] 推理结果: " + objectCount + "个, elapsed=" + sw.Elapsed.TotalMilliseconds.ToString("F2", CultureInfo.InvariantCulture) + "ms");
-                PrintBBoxCropObjects(result);
-
-                if (sampleCount != 1 || objectCount != expectedCount)
-                {
-                    Console.WriteLine("[" + name + "] 验证失败：期望 1 个 sample 且 " + expectedCount + " 个目标，实际 sample="
-                        + sampleCount + ", target=" + objectCount);
-                    return false;
-                }
-
-                return true;
-            }
-            finally
-            {
-                if (hasResult) DisposeResultMasks(result);
-                try { if (model != null) model.Dispose(); } catch { }
-                ForceGc();
-            }
-        }
-
-        private static void PrintBBoxCropObjects(Utils.CSharpResult result)
-        {
-            if (result.SampleResults == null || result.SampleResults.Count == 0 || result.SampleResults[0].Results == null)
-            {
-                return;
-            }
-
-            var objects = result.SampleResults[0].Results;
-            for (int i = 0; i < objects.Count; i++)
-            {
-                var obj = objects[i];
-                Console.WriteLine(
-                    string.Format(
-                        CultureInfo.InvariantCulture,
-                        "[{0}] {1} score={2:F2} bbox=({3:F1}, {4:F1}, {5:F1}, {6:F1}) area={7:F1}",
-                        i + 1,
-                        obj.CategoryName,
-                        obj.Score,
-                        obj.Bbox != null && obj.Bbox.Count > 0 ? obj.Bbox[0] : 0.0,
-                        obj.Bbox != null && obj.Bbox.Count > 1 ? obj.Bbox[1] : 0.0,
-                        obj.Bbox != null && obj.Bbox.Count > 2 ? obj.Bbox[2] : 0.0,
-                        obj.Bbox != null && obj.Bbox.Count > 3 ? obj.Bbox[3] : 0.0,
-                        obj.Area));
-            }
         }
 
         private static int RunDemo2RgbSelfTest(string[] args)

--- a/Test/dlcv_infer_c_test/main.cpp
+++ b/Test/dlcv_infer_c_test/main.cpp
@@ -34,9 +34,9 @@ int main() {
     std::cout << "预期: dvst model_index >= " << kFlowIndexBase
               << "，dvt model_index 在 [0," << kFlowIndexBase << ")，三者互不相同\n\n";
 
-    int idx_dvst = dlcv_infer_cpp_load_model_c(dvstPath.c_str(), 0);
     int idx_dvt1 = dlcv_infer_cpp_load_model_c(dvtCatDogPath.c_str(), 0);
     int idx_dvt2 = dlcv_infer_cpp_load_model_c(dvtBalloonPath.c_str(), 0);
+    int idx_dvst = dlcv_infer_cpp_load_model_c(dvstPath.c_str(), 0);
 
     std::cout << "模型加载结果:\n";
     std::cout << "  dvst model_index = " << idx_dvst << "\n";

--- a/Test/dlcv_infer_c_test/main.cpp
+++ b/Test/dlcv_infer_c_test/main.cpp
@@ -1,193 +1,83 @@
 #include <iostream>
-#include <iomanip>
 #include <string>
-#include <vector>
-#include <cmath>
-#include <cstdio>
 
-#include <opencv2/imgcodecs.hpp>
-#include <opencv2/imgproc.hpp>
+#include <windows.h>
 
 #include "dlcv_infer_c_api.h"
 #include "dlcv_infer.h"
 
-static std::string GbkToUtf8(const char* gbk) {
-    if (!gbk) return {};
-    return dlcv_infer::convertGbkToUtf8(std::string(gbk));
-}
-
-static std::string ToFixed(double v, int precision) {
-    std::ostringstream oss;
-    oss << std::fixed << std::setprecision(precision) << v;
-    return oss.str();
-}
-
-static std::vector<unsigned char> ReadAllBytesByFopen(const wchar_t* path) {
-    std::vector<unsigned char> buf;
-    FILE* fp = nullptr;
-    _wfopen_s(&fp, path, L"rb");
-    if (!fp) return buf;
-    if (fseek(fp, 0, SEEK_END) != 0) {
-        fclose(fp);
-        return buf;
-    }
-    long sz = ftell(fp);
-    if (sz <= 0) {
-        fclose(fp);
-        return buf;
-    }
-    rewind(fp);
-    buf.resize(static_cast<size_t>(sz));
-    size_t n = fread(buf.data(), 1, buf.size(), fp);
-    fclose(fp);
-    if (n != buf.size()) buf.clear();
-    return buf;
-}
-
-static cv::Mat LoadImageByDecode(const wchar_t* path) {
-    auto bytes = ReadAllBytesByFopen(path);
-    if (bytes.empty()) return {};
-    cv::Mat raw(1, static_cast<int>(bytes.size()), CV_8UC1, bytes.data());
-    return cv::imdecode(raw, cv::IMREAD_COLOR);
+static std::string WideToUtf8(const std::wstring& w) {
+    if (w.empty()) return {};
+    int bytes = WideCharToMultiByte(CP_UTF8, 0, w.c_str(), static_cast<int>(w.size()), nullptr, 0, nullptr, nullptr);
+    if (bytes <= 0) return {};
+    std::string out(static_cast<size_t>(bytes), '\0');
+    WideCharToMultiByte(CP_UTF8, 0, w.c_str(), static_cast<int>(w.size()), out.data(), bytes, nullptr, nullptr);
+    return out;
 }
 
 int main() {
-    const char* model_path = "Y:\\zxc\\模块化任务测试\\实例分割筛选测试_120_50.dvst";
-    const wchar_t* image_path_w = L"Y:\\zxc\\模块化任务测试\\实例分割\\实例分割滑窗大图.png";
+    SetConsoleOutputCP(CP_UTF8);
+    SetConsoleCP(CP_UTF8);
 
-    std::cout << "图片: Y:\\zxc\\模块化任务测试\\实例分割\\实例分割滑窗大图.png\n";
-    std::cout << "batch_size: 1\n";
-    std::cout << "threshold: 0.50\n";
+    constexpr int kFlowIndexBase = 10000;
+    const std::wstring dvstPathW = L"Y:\\测试模型\\AOI_120_50_s.dvst";
+    const std::wstring dvtCatDogPathW = L"Y:\\测试模型\\猫狗-分类_120_50_s.dvt";
+    const std::wstring dvtBalloonPathW = L"Y:\\测试模型\\气球-实例分割_120_50_s.dvt";
+    const std::string dvstPath = WideToUtf8(dvstPathW);
+    const std::string dvtCatDogPath = WideToUtf8(dvtCatDogPathW);
+    const std::string dvtBalloonPath = WideToUtf8(dvtBalloonPathW);
 
-    cv::Mat bgr = LoadImageByDecode(image_path_w);
-    if (bgr.empty()) {
-        std::cerr << "Failed to load image\n";
-        return 1;
-    }
+    std::cout << "==== dvst modelIndex 撞键验证 (C API / g_models) ====\n";
+    std::cout << "dvst: " << dvstPath << "\n";
+    std::cout << "dvt1: " << dvtCatDogPath << "\n";
+    std::cout << "dvt2: " << dvtBalloonPath << "\n";
+    std::cout << "预期: dvst model_index >= " << kFlowIndexBase
+              << "，dvt model_index 在 [0," << kFlowIndexBase << ")，三者互不相同\n\n";
 
-    cv::Mat rgb;
-    cv::cvtColor(bgr, rgb, cv::COLOR_BGR2RGB);
+    int idx_dvst = dlcv_infer_cpp_load_model_c(dvstPath.c_str(), 0);
+    int idx_dvt1 = dlcv_infer_cpp_load_model_c(dvtCatDogPath.c_str(), 0);
+    int idx_dvt2 = dlcv_infer_cpp_load_model_c(dvtBalloonPath.c_str(), 0);
 
-    DlcvCImage image{};
-    image.data_ptr = static_cast<long long>(reinterpret_cast<uintptr_t>(rgb.data));
-    image.height = rgb.rows;
-    image.width = rgb.cols;
-    image.channel = rgb.channels();
-
-    DlcvCImageList image_list{};
-    image_list.images = &image;
-    image_list.n = 1;
-
-    int model_idx = dlcv_infer_cpp_load_model_c(model_path, 0);
-    if (model_idx < 0) {
-        std::cerr << "Failed to load model: " << model_path << "\n";
-        return 1;
-    }
-
-    auto t0 = std::chrono::steady_clock::now();
-    DlcvCResult result = dlcv_infer_cpp_infer_c(model_idx, &image_list);
-    auto t1 = std::chrono::steady_clock::now();
-    double elapsed_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
-
-    std::cout << "推理时间: " << ToFixed(elapsed_ms, 2) << "ms\n";
-
-    if (result.code != 0) {
-        std::cerr << "Inference failed: " << (result.message ? result.message : "unknown") << "\n";
-        dlcv_infer_cpp_free_model_result_c(&result);
-        dlcv_infer_cpp_free_model_c(model_idx);
-        return 1;
-    }
-
-    int total_objects = 0;
-    if (result.sample_results && result.n > 0) {
-        for (int i = 0; i < result.n; ++i) {
-            total_objects += result.sample_results[i].n;
-        }
-    }
-
-    std::cout << "推理结果: " << total_objects << "个\n\n";
-
-    int idx = 1;
-    if (result.sample_results && result.n > 0) {
-        for (int s = 0; s < result.n; ++s) {
-            const DlcvCSampleResult& sr = result.sample_results[s];
-            if (!sr.results) continue;
-            for (int r = 0; r < sr.n; ++r) {
-                const DlcvCObjectResult& o = sr.results[r];
-                std::cout << "[" << idx << "] " << (o.category_name ? o.category_name : "?")
-                          << "            score=" << ToFixed(static_cast<double>(o.score), 2)
-                          << "  bbox=(" << ToFixed(o.x, 1) << ", " << ToFixed(o.y, 1)
-                          << ", " << ToFixed(o.w, 1) << ", " << ToFixed(o.h, 1) << ")"
-                          << "  area=" << ToFixed(static_cast<double>(o.area), 1) << "\n";
-                idx++;
-            }
-        }
-    }
+    std::cout << "模型加载结果:\n";
+    std::cout << "  dvst model_index = " << idx_dvst << "\n";
+    std::cout << "  dvt1 model_index = " << idx_dvt1 << "\n";
+    std::cout << "  dvt2 model_index = " << idx_dvt2 << "\n\n";
 
     bool ok = true;
-    if (result.n != 1) {
-        std::cerr << "ERROR: expected 1 sample, got " << result.n << "\n";
+    if (idx_dvst < 0 || idx_dvt1 < 0 || idx_dvt2 < 0) {
+        std::cerr << "FAIL: 有模型加载失败\n";
+        const char* err = dlcv_infer_cpp_get_last_error_c();
+        if (err) std::cerr << "  last_error: " << err << "\n";
         ok = false;
     }
-    if (total_objects != 2) {
-        std::cerr << "ERROR: expected exactly 2 objects, got " << total_objects << "\n";
+    if (idx_dvst >= 0 && idx_dvst < kFlowIndexBase) {
+        std::cerr << "FAIL: dvst model_index=" << idx_dvst << " 应 >= " << kFlowIndexBase
+                  << "（修复前写死 1，会与拿到 model_index=1 的 dvt 在 g_models 撞键、互相覆盖）\n";
+        ok = false;
+    } else if (idx_dvst >= kFlowIndexBase) {
+        std::cout << "PASS: dvst model_index=" << idx_dvst << " >= " << kFlowIndexBase << "\n";
+    }
+    if (idx_dvt1 >= 0 && idx_dvt1 >= kFlowIndexBase) {
+        std::cerr << "FAIL: dvt1 model_index=" << idx_dvt1 << " 应 < " << kFlowIndexBase << "\n";
         ok = false;
     }
-    if (result.sample_results && result.n > 0 && result.sample_results[0].n >= 1) {
-        const DlcvCObjectResult& o0 = result.sample_results[0].results[0];
-        std::string name0 = GbkToUtf8(o0.category_name);
-        if (name0 != "杯子") {
-            std::cerr << "ERROR: object[0] category mismatch: " << name0 << "\n";
-            ok = false;
-        }
-        if (std::abs(o0.score - 1.0f) > 0.01f) {
-            std::cerr << "ERROR: score mismatch: " << o0.score << "\n";
-            ok = false;
-        }
-        if (!o0.with_bbox) {
-            std::cerr << "ERROR: with_bbox mismatch\n";
-            ok = false;
-        }
-        if (std::abs(o0.x - 211.0f) > 1.0f || std::abs(o0.y - 221.0f) > 1.0f ||
-            std::abs(o0.w - 160.0f) > 1.0f || std::abs(o0.h - 186.0f) > 1.0f) {
-            std::cerr << "ERROR: bbox mismatch\n";
-            ok = false;
-        }
-    } else {
+    if (idx_dvt2 >= 0 && idx_dvt2 >= kFlowIndexBase) {
+        std::cerr << "FAIL: dvt2 model_index=" << idx_dvt2 << " 应 < " << kFlowIndexBase << "\n";
         ok = false;
     }
-    if (result.sample_results && result.n > 0 && result.sample_results[0].n >= 2) {
-        const DlcvCObjectResult& o1 = result.sample_results[0].results[1];
-        std::string name1 = GbkToUtf8(o1.category_name);
-        if (name1 != "杯子") {
-            std::cerr << "ERROR: object[1] category mismatch: " << name1 << "\n";
+    if (idx_dvst >= 0 && idx_dvt1 >= 0 && idx_dvt2 >= 0) {
+        if (idx_dvst == idx_dvt1 || idx_dvst == idx_dvt2 || idx_dvt1 == idx_dvt2) {
+            std::cerr << "FAIL: model_index 撞键！g_models 全局表互相覆盖，推理传 index 会路由到错误模型\n";
             ok = false;
+        } else {
+            std::cout << "PASS: 三模型 model_index 互不相同，g_models 表不撞键\n";
         }
-        if (std::abs(o1.score - 1.0f) > 0.01f) {
-            std::cerr << "ERROR: object[1] score mismatch: " << o1.score << "\n";
-            ok = false;
-        }
-        if (!o1.with_bbox) {
-            std::cerr << "ERROR: object[1] with_bbox mismatch\n";
-            ok = false;
-        }
-        if (std::abs(o1.x - 849.0f) > 1.0f || std::abs(o1.y - 220.0f) > 1.0f ||
-            std::abs(o1.w - 161.0f) > 1.0f || std::abs(o1.h - 185.0f) > 1.0f) {
-            std::cerr << "ERROR: object[1] bbox mismatch\n";
-            ok = false;
-        }
-    } else {
-        ok = false;
     }
 
-    dlcv_infer_cpp_free_model_result_c(&result);
-    dlcv_infer_cpp_free_model_c(model_idx);
+    if (idx_dvst >= 0) dlcv_infer_cpp_free_model_c(idx_dvst);
+    if (idx_dvt1 >= 0) dlcv_infer_cpp_free_model_c(idx_dvt1);
+    if (idx_dvt2 >= 0) dlcv_infer_cpp_free_model_c(idx_dvt2);
 
-    if (ok) {
-        std::cout << "\nTest PASSED\n";
-        return 0;
-    } else {
-        std::cerr << "\nTest FAILED\n";
-        return 1;
-    }
+    std::cout << (ok ? "\nTest PASSED\n" : "\nTest FAILED\n");
+    return ok ? 0 : 1;
 }

--- a/Test/dlcv_infer_cpp_test/main.cpp
+++ b/Test/dlcv_infer_cpp_test/main.cpp
@@ -45,6 +45,9 @@ const std::wstring kFlowInstanceSegFilterImagePath = L"Y:\\zxc\\模块化任务�
 const std::wstring kDvstDoubleLoadModelAPath = L"Y:\\zxc\\微组BUG测试\\pipeline.dvst";
 const std::wstring kDvstDoubleLoadModelBPath = L"Y:\\zxc\\微组BUG测试\\实例分割筛选测试_120_50.dvst";
 const std::wstring kDvstDoubleLoadImagePath = L"Y:\\zxc\\微组BUG测试\\实例分割滑窗大图.png";
+const std::wstring kDvstIndexFlowModelPath = L"Y:\\测试模型\\AOI_120_50_s.dvst";
+const std::wstring kDvstIndexDvtCatDogPath = L"Y:\\测试模型\\猫狗-分类_120_50_s.dvt";
+const std::wstring kDvstIndexDvtBalloonPath = L"Y:\\测试模型\\气球-实例分割_120_50_s.dvt";
 const std::wstring kBBoxCropFixModelAPath = L"Z:\\A-苏州三谛\\A260308-苏州三谛-AOI元器件定位-新方案\\Task01-元件提取\\现场模型\\模型1-元件提取 - 副本_120_50.dvst";
 const std::wstring kBBoxCropFixModelBPath = L"Z:\\A-苏州三谛\\A260308-苏州三谛-AOI元器件定位-新方案\\Task01-元件提取\\现场模型\\模型1-元件提取 - 裁图_120_50.dvst";
 const std::wstring kBBoxCropFixImagePath = L"Z:\\A-苏州三谛\\A260308-苏州三谛-AOI元器件定位-新方案\\Task01-元件提取\\现场模型\\PCB20047-23439-TOP_61_4092_0.jpg";
@@ -1285,6 +1288,68 @@ int RunDvstSingleLoadSelfTest() {
     }
 }
 
+int RunDvstModelIndexSelfTest() {
+    std::cout << "==== dvst modelIndex 分区自测 (C++ Model) ====\n";
+    constexpr int kFlowIndexBase = 10000;
+    std::cout << "dvst: " << WideToUtf8(kDvstIndexFlowModelPath) << "\n";
+    std::cout << "dvt1: " << WideToUtf8(kDvstIndexDvtCatDogPath) << "\n";
+    std::cout << "dvt2: " << WideToUtf8(kDvstIndexDvtBalloonPath) << "\n";
+
+    if (!FileExistsW(kDvstIndexFlowModelPath) || !FileExistsW(kDvstIndexDvtCatDogPath) || !FileExistsW(kDvstIndexDvtBalloonPath)) {
+        std::cout << "模型不存在，请检查路径\n";
+        return 2;
+    }
+
+    bool ok = true;
+    try {
+        std::cout << "[1] 加载 dvst(AOI 流程模型)...\n";
+        dlcv_infer::Model dvstModel(kDvstIndexFlowModelPath, kGpuDeviceId);
+        const int dvstIdx = dvstModel.modelIndex;
+        std::cout << "    dvst modelIndex=" << dvstIdx << "\n";
+
+        std::cout << "[2] 加载 dvt1(猫狗分类)...\n";
+        dlcv_infer::Model dvt1Model(kDvstIndexDvtCatDogPath, kGpuDeviceId);
+        const int dvt1Idx = dvt1Model.modelIndex;
+        std::cout << "    dvt1 modelIndex=" << dvt1Idx << "\n";
+
+        std::cout << "[3] 加载 dvt2(气球实例分割)...\n";
+        dlcv_infer::Model dvt2Model(kDvstIndexDvtBalloonPath, kGpuDeviceId);
+        const int dvt2Idx = dvt2Model.modelIndex;
+        std::cout << "    dvt2 modelIndex=" << dvt2Idx << "\n";
+
+        if (dvstIdx < kFlowIndexBase) {
+            std::cout << "FAIL: dvst modelIndex=" << dvstIdx << " 应 >= " << kFlowIndexBase
+                      << "（修复前写死 1，会与 dvt 撞键）\n";
+            ok = false;
+        } else {
+            std::cout << "PASS: dvst modelIndex=" << dvstIdx << " >= " << kFlowIndexBase << "\n";
+        }
+        if (dvt1Idx < 0 || dvt1Idx >= kFlowIndexBase) {
+            std::cout << "FAIL: dvt1 modelIndex=" << dvt1Idx << " 应在 [0," << kFlowIndexBase << ")\n";
+            ok = false;
+        }
+        if (dvt2Idx < 0 || dvt2Idx >= kFlowIndexBase) {
+            std::cout << "FAIL: dvt2 modelIndex=" << dvt2Idx << " 应在 [0," << kFlowIndexBase << ")\n";
+            ok = false;
+        }
+        if (dvstIdx == dvt1Idx || dvstIdx == dvt2Idx || dvt1Idx == dvt2Idx) {
+            std::cout << "FAIL: modelIndex 撞键 dvst=" << dvstIdx
+                      << " dvt1=" << dvt1Idx << " dvt2=" << dvt2Idx << "\n";
+            ok = false;
+        } else {
+            std::cout << "PASS: 三模型 modelIndex 互不相同（dvst=" << dvstIdx
+                      << ", dvt1=" << dvt1Idx << ", dvt2=" << dvt2Idx << "）\n";
+        }
+    } catch (const std::exception& e) {
+        std::cout << "异常: " << e.what() << "\n";
+        return 1;
+    }
+
+    std::cout << (ok ? "==== dvst modelIndex 分区自测 通过 ====\n"
+                     : "==== dvst modelIndex 分区自测 失败 ====\n");
+    return ok ? 0 : 1;
+}
+
 int RunImagePrepCheck() {
     auto fail = [](const std::string& message) -> int {
         std::cout << "imageprepcheck 失败: " << message << "\n";
@@ -2445,6 +2510,10 @@ int main(int argc, char* argv[]) {
 
     if (argc >= 2 && std::string(argv[1]) == "dvst-single-load-selftest") {
         return RunDvstSingleLoadSelfTest();
+    }
+
+    if (argc >= 2 && std::string(argv[1]) == "dvst-modelindex-selftest") {
+        return RunDvstModelIndexSelfTest();
     }
 
     std::cout << "==== C++ 测试程序 ====\n";

--- a/Test/dlcv_infer_cpp_test/main.cpp
+++ b/Test/dlcv_infer_cpp_test/main.cpp
@@ -1,10 +1,11 @@
 #include <windows.h>
-#include <psapi.h>
 
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
+#include <exception>
+#include <fstream>
 #include <functional>
 #include <iomanip>
 #include <iostream>
@@ -26,152 +27,6 @@ namespace {
 using json = nlohmann::json;
 using Clock = std::chrono::steady_clock;
 
-constexpr int kSpeedWindowSeconds = 3;
-constexpr int kLeakLoopCount = 10;
-constexpr int kGpuDeviceId = 0;
-constexpr int kFixedBatchSize = 8;
-const std::wstring kModelRoot = L"Y:\\测试模型";
-const std::wstring kDefaultPressureModelPath = L"C:\\Users\\Administrator\\Desktop\\dvst速度优化\\流程2-各项检测_120_50.dvst";
-const std::wstring kDefaultPressureImagePath = L"C:\\Users\\Administrator\\Desktop\\dvst速度优化\\detect_20260401153742_0_6_2904_5248_627_804.jpg";
-constexpr int kDefaultPressureBatchSize = 128;
-constexpr int kDefaultPressureRuns = 9;
-constexpr int kDefaultPressureWarmup = 5;
-const std::wstring kSlidingAlignModelPath = L"C:\\Users\\Administrator\\Desktop\\滑窗裁图分割合并\\model_120_50.dvst";
-const std::wstring kSlidingAlignImagePath = L"C:\\Users\\Administrator\\Desktop\\滑窗裁图分割合并\\T000001-P000001-C22-I1-G9PHG5X0VFT0000HU8+4JKC-OK.png";
-constexpr int kSlidingAlignBatchSize = 1;
-constexpr float kSlidingAlignThreshold = 0.5f;
-const std::wstring kFlowInstanceSegFilterModelPath = L"Y:\\zxc\\模块化任务测试\\实例分割筛选测试_120_50.dvst";
-const std::wstring kFlowInstanceSegFilterImagePath = L"Y:\\zxc\\模块化任务测试\\实例分割\\实例分割滑窗大图.png";
-const std::wstring kDvstDoubleLoadModelAPath = L"Y:\\zxc\\微组BUG测试\\pipeline.dvst";
-const std::wstring kDvstDoubleLoadModelBPath = L"Y:\\zxc\\微组BUG测试\\实例分割筛选测试_120_50.dvst";
-const std::wstring kDvstDoubleLoadImagePath = L"Y:\\zxc\\微组BUG测试\\实例分割滑窗大图.png";
-const std::wstring kDvstIndexFlowModelPath = L"Y:\\测试模型\\AOI_120_50_s.dvst";
-const std::wstring kDvstIndexDvtCatDogPath = L"Y:\\测试模型\\猫狗-分类_120_50_s.dvt";
-const std::wstring kDvstIndexDvtBalloonPath = L"Y:\\测试模型\\气球-实例分割_120_50_s.dvt";
-const std::wstring kBBoxCropFixModelAPath = L"Z:\\A-苏州三谛\\A260308-苏州三谛-AOI元器件定位-新方案\\Task01-元件提取\\现场模型\\模型1-元件提取 - 副本_120_50.dvst";
-const std::wstring kBBoxCropFixModelBPath = L"Z:\\A-苏州三谛\\A260308-苏州三谛-AOI元器件定位-新方案\\Task01-元件提取\\现场模型\\模型1-元件提取 - 裁图_120_50.dvst";
-const std::wstring kBBoxCropFixImagePath = L"Z:\\A-苏州三谛\\A260308-苏州三谛-AOI元器件定位-新方案\\Task01-元件提取\\现场模型\\PCB20047-23439-TOP_61_4092_0.jpg";
-const std::wstring kDemo3Model1Path = L"C:\\Users\\Administrator\\Desktop\\dvst速度优化\\流程1-目标检测-降采样_120_50.dvst";
-const std::wstring kDemo3Model2Path = L"C:\\Users\\Administrator\\Desktop\\dvst速度优化\\流程2-各项检测_120_50.dvst";
-const std::wstring kDemo3ChainImagePath = L"C:\\Users\\Administrator\\Desktop\\dvst速度优化\\detect_20260401151406_0.jpg";
-const std::wstring kDemo3Model2SingleImagePath = L"C:\\Users\\Administrator\\Desktop\\dvst速度优化\\detect_20260401153742_0_6_2904_5248_627_804.jpg";
-constexpr int kDemo3CropWidth = 128;
-constexpr int kDemo3CropHeight = 192;
-
-struct ModelCase {
-    std::wstring modelFile;
-    std::wstring imageFile;
-};
-
-std::string DogProviderToString(sntl_admin::DogProvider p) {
-    switch (p) {
-        case sntl_admin::DogProvider::Sentinel: return "sentinel";
-        case sntl_admin::DogProvider::Virbox: return "virbox";
-        default: return "unknown";
-    }
-}
-
-const std::vector<ModelCase> kCases = {
-    {L"AOI-旋转框检测.dvt", L"AOI-测试.jpg"},
-    {L"猫狗-分类.dvt", L"猫狗-猫.jpg"},
-    {L"气球-实例分割.dvt", L"气球.jpg"},
-    {L"气球-语义分割.dvt", L"气球.jpg"},
-    {L"手机屏幕-实例分割.dvt", L"手机屏幕.jpg"},
-    {L"引脚定位-目标检测.dvt", L"引脚定位-目标检测.jpg"},
-    {L"OCR.dvt", L"OCR-1.jpg"},
-};
-
-struct MemorySnapshot {
-    double privateMb{0.0};
-};
-
-struct SpeedResult {
-    double fps{0.0};
-    bool supported{false};
-};
-
-struct CaseRow {
-    std::string modelName;
-    std::string loadText;
-    std::string inferText;
-    std::string categories;
-    std::string speedText;
-    std::string batchText;
-};
-
-struct Demo3CropContext {
-    cv::Mat cropRgb;
-    double translateX{0.0};
-    double translateY{0.0};
-};
-
-struct Demo3ChainDebugResult {
-    int model1ObjectCount{0};
-    int cropCount{0};
-    int model2BatchLimit{1};
-    int finalObjectCount{0};
-    std::vector<dlcv_infer::ObjectResult> finalObjects;
-};
-
-void DisposeResultMasks(dlcv_infer::Result& out);
-
-std::string WideToUtf8(const std::wstring& w) {
-    if (w.empty()) return {};
-    int bytes = WideCharToMultiByte(CP_UTF8, 0, w.c_str(), static_cast<int>(w.size()), nullptr, 0, nullptr, nullptr);
-    if (bytes <= 0) return {};
-    std::string out(static_cast<size_t>(bytes), '\0');
-    WideCharToMultiByte(CP_UTF8, 0, w.c_str(), static_cast<int>(w.size()), out.data(), bytes, nullptr, nullptr);
-    return out;
-}
-
-bool FileExistsW(const std::wstring& p) {
-    DWORD attr = GetFileAttributesW(p.c_str());
-    return attr != INVALID_FILE_ATTRIBUTES && !(attr & FILE_ATTRIBUTE_DIRECTORY);
-}
-
-bool DirExistsW(const std::wstring& p) {
-    DWORD attr = GetFileAttributesW(p.c_str());
-    return attr != INVALID_FILE_ATTRIBUTES && (attr & FILE_ATTRIBUTE_DIRECTORY);
-}
-
-MemorySnapshot CaptureMemory() {
-    PROCESS_MEMORY_COUNTERS_EX pmc{};
-    pmc.cb = sizeof(PROCESS_MEMORY_COUNTERS_EX);
-    if (!GetProcessMemoryInfo(GetCurrentProcess(), reinterpret_cast<PROCESS_MEMORY_COUNTERS*>(&pmc), sizeof(pmc))) {
-        return {};
-    }
-    return MemorySnapshot{static_cast<double>(pmc.PrivateUsage) / 1024.0 / 1024.0};
-}
-
-std::vector<unsigned char> ReadAllBytesByFopen(const std::wstring& path) {
-    std::vector<unsigned char> buf;
-    FILE* fp = nullptr;
-    _wfopen_s(&fp, path.c_str(), L"rb");
-    if (!fp) return buf;
-    if (fseek(fp, 0, SEEK_END) != 0) {
-        fclose(fp);
-        return buf;
-    }
-    long sz = ftell(fp);
-    if (sz <= 0) {
-        fclose(fp);
-        return buf;
-    }
-    rewind(fp);
-    buf.resize(static_cast<size_t>(sz));
-    size_t n = fread(buf.data(), 1, buf.size(), fp);
-    fclose(fp);
-    if (n != buf.size()) buf.clear();
-    return buf;
-}
-
-cv::Mat LoadImageByDecode(const std::wstring& path) {
-    auto bytes = ReadAllBytesByFopen(path);
-    if (bytes.empty()) return {};
-    cv::Mat raw(1, static_cast<int>(bytes.size()), CV_8UC1, bytes.data());
-    return cv::imdecode(raw, cv::IMREAD_COLOR);
-}
-
 std::string Safe(const std::string& s) {
     std::string out = s.empty() ? "-" : s;
     for (auto& ch : out) {
@@ -187,17 +42,13 @@ std::string ToFixed(double v, int precision) {
     return oss.str();
 }
 
-std::wstring JoinPath(const std::wstring& root, const std::wstring& file) {
-    if (root.empty()) return file;
-    const wchar_t tail = root.back();
-    if (tail == '\\' || tail == '/') return root + file;
-    return root + L"\\" + file;
-}
-
-std::wstring BaseName(const std::wstring& p) {
-    const size_t pos = p.find_last_of(L"\\/");
-    if (pos == std::wstring::npos) return p;
-    return p.substr(pos + 1);
+std::string WideToUtf8(const std::wstring& w) {
+    if (w.empty()) return {};
+    int bytes = WideCharToMultiByte(CP_UTF8, 0, w.c_str(), static_cast<int>(w.size()), nullptr, 0, nullptr, nullptr);
+    if (bytes <= 0) return {};
+    std::string out(static_cast<size_t>(bytes), '\0');
+    WideCharToMultiByte(CP_UTF8, 0, w.c_str(), static_cast<int>(w.size()), out.data(), bytes, nullptr, nullptr);
+    return out;
 }
 
 std::wstring Utf8ToWide(const std::string& s) {
@@ -209,1199 +60,12 @@ std::wstring Utf8ToWide(const std::string& s) {
     return out;
 }
 
-std::unordered_map<std::string, int> CountCategories(const std::vector<dlcv_infer::ObjectResult>& objects) {
-    std::unordered_map<std::string, int> counts;
-    for (const auto& obj : objects) {
-        std::string category = dlcv_infer::convertGbkToUtf8(obj.categoryName);
-        if (category.empty()) {
-            category = "unknown";
-        }
-        counts[category] += 1;
-    }
-    return counts;
-}
-
-int CountObjectsWithMask(const std::vector<dlcv_infer::ObjectResult>& objects) {
-    int count = 0;
-    for (const auto& obj : objects) {
-        if (obj.withMask || !obj.mask.empty()) {
-            count += 1;
-        }
-    }
-    return count;
-}
-
-bool AreCategoryCountsEqual(
-    const std::unordered_map<std::string, int>& a,
-    const std::unordered_map<std::string, int>& b) {
-
-    if (a.size() != b.size()) return false;
-    for (const auto& kv : a) {
-        auto it = b.find(kv.first);
-        if (it == b.end()) return false;
-        if (it->second != kv.second) return false;
-    }
-    return true;
-}
-
-std::string BuildObjectSignature(const dlcv_infer::ObjectResult& obj) {
-    std::ostringstream oss;
-    oss << dlcv_infer::convertGbkToUtf8(obj.categoryName) << "|"
-        << std::fixed << std::setprecision(4) << obj.score << "|"
-        << std::setprecision(2);
-    for (size_t i = 0; i < obj.bbox.size(); ++i) {
-        if (i > 0) oss << ",";
-        oss << obj.bbox[i];
-    }
-    oss << "|" << (obj.withAngle ? 1 : 0) << "|" << std::setprecision(2) << obj.angle;
-    return oss.str();
-}
-
-int CountExactDuplicateObjects(const std::vector<dlcv_infer::ObjectResult>& objects) {
-    std::unordered_set<std::string> seen;
-    seen.reserve(objects.size() * 2 + 1);
-    int duplicates = 0;
-    for (const auto& obj : objects) {
-        const std::string sig = BuildObjectSignature(obj);
-        if (!seen.insert(sig).second) {
-            duplicates += 1;
-        }
-    }
-    return duplicates;
-}
-
-bool ContainsCategory(const std::unordered_map<std::string, int>& counts, const std::string& nameUtf8) {
-    auto it = counts.find(nameUtf8);
-    return it != counts.end() && it->second > 0;
-}
-
-void PrintCategorySummary(
-    const std::string& title,
-    const std::unordered_map<std::string, int>& counts,
-    size_t maxRows = 30) {
-
-    std::vector<std::pair<std::string, int>> rows;
-    rows.reserve(counts.size());
-    for (const auto& kv : counts) rows.push_back(kv);
-    std::sort(rows.begin(), rows.end(), [](const std::pair<std::string, int>& a, const std::pair<std::string, int>& b) {
-        if (a.second != b.second) return a.second > b.second;
-        return a.first < b.first;
-    });
-
-    std::cout << title << "（共" << counts.size() << "类）\n";
-    if (rows.empty()) {
-        std::cout << "  - (空)\n";
-        return;
-    }
-    const size_t show = std::min(maxRows, rows.size());
-    for (size_t i = 0; i < show; ++i) {
-        std::cout << "  - " << rows[i].first << ": " << rows[i].second << "\n";
-    }
-    if (rows.size() > show) {
-        std::cout << "  ... 其余 " << (rows.size() - show) << " 类省略\n";
-    }
-}
-
-bool TryMapObjectByTranslate(const dlcv_infer::ObjectResult& localObj, double dx, double dy, dlcv_infer::ObjectResult& mappedObj) {
-    if (localObj.bbox.size() < 4) return false;
-    mappedObj = localObj;
-    mappedObj.bbox = localObj.bbox;
-    mappedObj.bbox[0] += dx;
-    mappedObj.bbox[1] += dy;
-    mappedObj.withBbox = true;
-    return true;
-}
-
-bool TryClampObjectToImage(const dlcv_infer::ObjectResult& inputObj, int imageW, int imageH, dlcv_infer::ObjectResult& outputObj) {
-    if (inputObj.bbox.size() < 4 || imageW <= 0 || imageH <= 0) return false;
-    outputObj = inputObj;
-    outputObj.bbox = inputObj.bbox;
-    const bool isRotated = inputObj.withAngle || inputObj.bbox.size() == 5;
-    if (isRotated) {
-        const double cx = inputObj.bbox[0];
-        const double cy = inputObj.bbox[1];
-        const double w = inputObj.bbox[2];
-        const double h = inputObj.bbox[3];
-        if (w <= 0.0 || h <= 0.0) return false;
-        const double left = cx - w * 0.5;
-        const double right = cx + w * 0.5;
-        const double top = cy - h * 0.5;
-        const double bottom = cy + h * 0.5;
-        const double cl = std::max(0.0, left);
-        const double ct = std::max(0.0, top);
-        const double cr = std::min(static_cast<double>(imageW), right);
-        const double cb = std::min(static_cast<double>(imageH), bottom);
-        if (cr <= cl || cb <= ct) return false;
-        outputObj.bbox[0] = (cl + cr) * 0.5;
-        outputObj.bbox[1] = (ct + cb) * 0.5;
-        outputObj.bbox[2] = cr - cl;
-        outputObj.bbox[3] = cb - ct;
-    } else {
-        const double x = inputObj.bbox[0];
-        const double y = inputObj.bbox[1];
-        const double w = inputObj.bbox[2];
-        const double h = inputObj.bbox[3];
-        if (w <= 0.0 || h <= 0.0) return false;
-        const double left = std::max(0.0, x);
-        const double top = std::max(0.0, y);
-        const double right = std::min(static_cast<double>(imageW), x + w);
-        const double bottom = std::min(static_cast<double>(imageH), y + h);
-        if (right <= left || bottom <= top) return false;
-        outputObj.bbox[0] = left;
-        outputObj.bbox[1] = top;
-        outputObj.bbox[2] = right - left;
-        outputObj.bbox[3] = bottom - top;
-    }
-    outputObj.withBbox = true;
-    return true;
-}
-
-cv::Point2d GetObjectCenter(const dlcv_infer::ObjectResult& obj) {
-    if (obj.bbox.size() < 4) return cv::Point2d(0.0, 0.0);
-    const bool isRotated = obj.withAngle || obj.bbox.size() == 5;
-    if (isRotated) {
-        return cv::Point2d(obj.bbox[0], obj.bbox[1]);
-    }
-    return cv::Point2d(obj.bbox[0] + obj.bbox[2] * 0.5, obj.bbox[1] + obj.bbox[3] * 0.5);
-}
-
-bool BuildCenteredCropContext(
-    const cv::Mat& fullImageRgb,
-    const cv::Point2d& center,
-    int cropW,
-    int cropH,
-    Demo3CropContext& outCtx) {
-
-    const int requestLeft = static_cast<int>(std::llround(center.x - cropW * 0.5));
-    const int requestTop = static_cast<int>(std::llround(center.y - cropH * 0.5));
-    const cv::Rect requested(requestLeft, requestTop, cropW, cropH);
-    const cv::Rect imageRect(0, 0, fullImageRgb.cols, fullImageRgb.rows);
-    const cv::Rect src = requested & imageRect;
-    if (src.width <= 0 || src.height <= 0) return false;
-
-    cv::Mat crop(cropH, cropW, fullImageRgb.type(), cv::Scalar::all(0));
-    const cv::Rect dst(src.x - requestLeft, src.y - requestTop, src.width, src.height);
-    fullImageRgb(src).copyTo(crop(dst));
-
-    outCtx.cropRgb = crop;
-    outCtx.translateX = static_cast<double>(requestLeft);
-    outCtx.translateY = static_cast<double>(requestTop);
-    return true;
-}
-
-int GetModelMaxBatchSize(dlcv_infer::Model& model) {
-    try {
-        const json info = model.GetModelInfo();
-        int best = 1;
-        std::function<void(const json&)> walk = [&](const json& node) {
-            if (node.is_object()) {
-                auto pullInt = [&](const char* key) {
-                    if (!node.contains(key)) return;
-                    const auto& v = node.at(key);
-                    if (v.is_number_integer()) {
-                        best = std::max(best, std::max(1, v.get<int>()));
-                    } else if (v.is_number_float()) {
-                        best = std::max(best, std::max(1, static_cast<int>(std::llround(v.get<double>()))));
-                    } else if (v.is_string()) {
-                        try {
-                            best = std::max(best, std::max(1, std::stoi(v.get<std::string>())));
-                        } catch (...) {
-                        }
-                    }
-                };
-                pullInt("max_batch_size");
-                pullInt("max_batch");
-                pullInt("batch_size");
-                for (auto it = node.begin(); it != node.end(); ++it) {
-                    walk(it.value());
-                }
-            } else if (node.is_array()) {
-                for (const auto& x : node) walk(x);
-            }
-        };
-        walk(info);
-        return std::max(1, best);
-    } catch (...) {
-        return 1;
-    }
-}
-
-std::vector<std::vector<Demo3CropContext>> SplitCropChunks(const std::vector<Demo3CropContext>& source, int chunkSize) {
-    std::vector<std::vector<Demo3CropContext>> chunks;
-    if (source.empty()) return chunks;
-    const int n = std::max(1, chunkSize);
-    for (int i = 0; i < static_cast<int>(source.size()); i += n) {
-        const int count = std::min(n, static_cast<int>(source.size()) - i);
-        chunks.emplace_back(source.begin() + i, source.begin() + i + count);
-    }
-    return chunks;
-}
-
-Demo3ChainDebugResult RunDemo3ChainReference(
-    dlcv_infer::Model& model1,
-    dlcv_infer::Model& model2,
-    const cv::Mat& fullImageRgb,
-    bool model2WithMask) {
-
-    Demo3ChainDebugResult out;
-    json params;
-    params["with_mask"] = false;
-    dlcv_infer::Result model1Result = model1.Infer(fullImageRgb, params);
-
-    std::vector<dlcv_infer::ObjectResult> model1Objects;
-    if (!model1Result.sampleResults.empty()) {
-        for (const auto& obj : model1Result.sampleResults.front().results) {
-            dlcv_infer::ObjectResult clamped = obj;
-            if (TryClampObjectToImage(obj, fullImageRgb.cols, fullImageRgb.rows, clamped)) {
-                model1Objects.push_back(clamped);
-            }
-        }
-    }
-    out.model1ObjectCount = static_cast<int>(model1Objects.size());
-    DisposeResultMasks(model1Result);
-
-    std::vector<Demo3CropContext> cropContexts;
-    cropContexts.reserve(model1Objects.size());
-    for (const auto& obj : model1Objects) {
-        Demo3CropContext ctx;
-        if (BuildCenteredCropContext(fullImageRgb, GetObjectCenter(obj), kDemo3CropWidth, kDemo3CropHeight, ctx)) {
-            cropContexts.push_back(std::move(ctx));
-        }
-    }
-    out.cropCount = static_cast<int>(cropContexts.size());
-
-    out.model2BatchLimit = GetModelMaxBatchSize(model2);
-    const auto chunks = SplitCropChunks(cropContexts, out.model2BatchLimit);
-    json params2;
-    params2["with_mask"] = model2WithMask;
-    for (const auto& chunk : chunks) {
-        std::vector<cv::Mat> mats;
-        mats.reserve(chunk.size());
-        for (const auto& one : chunk) mats.push_back(one.cropRgb);
-        dlcv_infer::Result batchResult = model2.InferBatch(mats, params2);
-        for (int i = 0; i < static_cast<int>(chunk.size()); ++i) {
-            if (i >= static_cast<int>(batchResult.sampleResults.size())) continue;
-            for (const auto& localObj : batchResult.sampleResults[static_cast<size_t>(i)].results) {
-                dlcv_infer::ObjectResult mapped = localObj;
-                if (!TryMapObjectByTranslate(localObj, chunk[static_cast<size_t>(i)].translateX, chunk[static_cast<size_t>(i)].translateY, mapped)) {
-                    continue;
-                }
-                dlcv_infer::ObjectResult clamped = mapped;
-                if (TryClampObjectToImage(mapped, fullImageRgb.cols, fullImageRgb.rows, clamped)) {
-                    out.finalObjects.push_back(clamped);
-                }
-            }
-        }
-        DisposeResultMasks(batchResult);
-    }
-
-    out.finalObjectCount = static_cast<int>(out.finalObjects.size());
-    return out;
-}
-
-int RunDemo3Validation(
-    const std::wstring& model1Path,
-    const std::wstring& model2Path,
-    const std::wstring& chainImagePath,
-    const std::wstring& model2SingleImagePath) {
-
-    std::cout << "==== Demo3 串联专项验证 ====\n";
-    std::cout << "model1: " << WideToUtf8(model1Path) << "\n";
-    std::cout << "model2: " << WideToUtf8(model2Path) << "\n";
-    std::cout << "chain_image: " << WideToUtf8(chainImagePath) << "\n";
-    std::cout << "model2_single_image: " << WideToUtf8(model2SingleImagePath) << "\n";
-
-    if (!FileExistsW(model1Path) || !FileExistsW(model2Path) || !FileExistsW(chainImagePath) || !FileExistsW(model2SingleImagePath)) {
-        std::cout << "输入文件不存在，请检查路径。\n";
-        return 2;
-    }
-
-    try {
-        dlcv_infer::Model model1(model1Path, kGpuDeviceId);
-        dlcv_infer::Model model2(model2Path, kGpuDeviceId);
-        std::cout << "model1 provider=" << DogProviderToString(model1.LoadedDogProvider())
-                  << ", dll=" << model1.LoadedNativeDllName() << "\n";
-        std::cout << "model2 provider=" << DogProviderToString(model2.LoadedDogProvider())
-                  << ", dll=" << model2.LoadedNativeDllName() << "\n";
-
-        cv::Mat singleBgr = LoadImageByDecode(model2SingleImagePath);
-        if (singleBgr.empty()) throw std::runtime_error("模型2单图解码失败");
-        cv::Mat singleRgb;
-        cv::cvtColor(singleBgr, singleRgb, cv::COLOR_BGR2RGB);
-
-        json singleParams;
-        singleParams["threshold"] = 0.05;
-        singleParams["with_mask"] = true;
-        singleParams["batch_size"] = 1;
-        dlcv_infer::Result singleResult = model2.InferBatch(std::vector<cv::Mat>{singleRgb}, singleParams);
-        std::vector<dlcv_infer::ObjectResult> singleObjects;
-        if (!singleResult.sampleResults.empty()) {
-            singleObjects = singleResult.sampleResults.front().results;
-        }
-        const auto singleCounts = CountCategories(singleObjects);
-        PrintCategorySummary("模型2单图类别统计", singleCounts);
-        const bool singleHasLed = ContainsCategory(singleCounts, "LED");
-        const bool singleHasPad = ContainsCategory(singleCounts, "焊盘");
-        std::cout << "单图包含 LED: " << (singleHasLed ? "是" : "否")
-                  << "，包含 焊盘: " << (singleHasPad ? "是" : "否") << "\n";
-        DisposeResultMasks(singleResult);
-        bool mismatchDetected = false;
-
-        // RGB 语义回归：同一张 RGB 图，快路径(8U) 与慢路径(16U->8U 归一化)类别统计应一致。
-        json rgbSemanticsParams;
-        rgbSemanticsParams["threshold"] = 0.05;
-        rgbSemanticsParams["with_mask"] = false;
-        rgbSemanticsParams["batch_size"] = 1;
-        dlcv_infer::Result rgbFastResult = model2.InferBatch(std::vector<cv::Mat>{singleRgb}, rgbSemanticsParams);
-        cv::Mat singleRgb16;
-        singleRgb.convertTo(singleRgb16, CV_16UC3, 256.0);
-        dlcv_infer::Result rgbSlowResult = model2.InferBatch(std::vector<cv::Mat>{singleRgb16}, rgbSemanticsParams);
-        std::vector<dlcv_infer::ObjectResult> rgbFastObjects;
-        std::vector<dlcv_infer::ObjectResult> rgbSlowObjects;
-        if (!rgbFastResult.sampleResults.empty()) rgbFastObjects = rgbFastResult.sampleResults.front().results;
-        if (!rgbSlowResult.sampleResults.empty()) rgbSlowObjects = rgbSlowResult.sampleResults.front().results;
-        const auto rgbFastCounts = CountCategories(rgbFastObjects);
-        const auto rgbSlowCounts = CountCategories(rgbSlowObjects);
-        const bool rgbSemanticsConsistent = AreCategoryCountsEqual(rgbFastCounts, rgbSlowCounts);
-        std::cout << "RGB语义一致性(8U快路径 vs 16U慢路径): "
-                  << (rgbSemanticsConsistent ? "通过" : "失败") << "\n";
-        if (!rgbSemanticsConsistent) mismatchDetected = true;
-        DisposeResultMasks(rgbFastResult);
-        DisposeResultMasks(rgbSlowResult);
-
-        cv::Mat chainBgr = LoadImageByDecode(chainImagePath);
-        if (chainBgr.empty()) throw std::runtime_error("串联图像解码失败");
-        cv::Mat chainRgb;
-        cv::cvtColor(chainBgr, chainRgb, cv::COLOR_BGR2RGB);
-
-        Demo3ChainDebugResult chainWithMaskFalse = RunDemo3ChainReference(model1, model2, chainRgb, false);
-        const auto chainFalseCounts = CountCategories(chainWithMaskFalse.finalObjects);
-        std::cout << "\n-- 串联(模型2 with_mask=false) --\n";
-        std::cout << "模型1目标数: " << chainWithMaskFalse.model1ObjectCount
-                  << "，有效裁图数: " << chainWithMaskFalse.cropCount
-                  << "，模型2最大Batch: " << chainWithMaskFalse.model2BatchLimit
-                  << "，最终结果数: " << chainWithMaskFalse.finalObjectCount << "\n";
-        PrintCategorySummary("串联类别统计(with_mask=false)", chainFalseCounts);
-        const bool chainFalseHasLed = ContainsCategory(chainFalseCounts, "LED");
-        const bool chainFalseHasPad = ContainsCategory(chainFalseCounts, "焊盘");
-        const int chainFalseWithMaskCount = CountObjectsWithMask(chainWithMaskFalse.finalObjects);
-        const int chainFalseDuplicateCount = CountExactDuplicateObjects(chainWithMaskFalse.finalObjects);
-        std::cout << "串联(with_mask=false)包含 LED: " << (chainFalseHasLed ? "是" : "否")
-                  << "，包含 焊盘: " << (chainFalseHasPad ? "是" : "否")
-                  << "，with_mask对象数: " << chainFalseWithMaskCount
-                  << "，重复结果数: " << chainFalseDuplicateCount << "\n";
-        if (chainFalseWithMaskCount > 0) mismatchDetected = true;
-        if (chainFalseDuplicateCount > 0) mismatchDetected = true;
-
-        Demo3ChainDebugResult chainWithMaskTrue = RunDemo3ChainReference(model1, model2, chainRgb, true);
-        const auto chainTrueCounts = CountCategories(chainWithMaskTrue.finalObjects);
-        std::cout << "\n-- 串联(模型2 with_mask=true) --\n";
-        std::cout << "模型1目标数: " << chainWithMaskTrue.model1ObjectCount
-                  << "，有效裁图数: " << chainWithMaskTrue.cropCount
-                  << "，模型2最大Batch: " << chainWithMaskTrue.model2BatchLimit
-                  << "，最终结果数: " << chainWithMaskTrue.finalObjectCount << "\n";
-        PrintCategorySummary("串联类别统计(with_mask=true)", chainTrueCounts);
-        const bool chainTrueHasLed = ContainsCategory(chainTrueCounts, "LED");
-        const bool chainTrueHasPad = ContainsCategory(chainTrueCounts, "焊盘");
-        const int chainTrueDuplicateCount = CountExactDuplicateObjects(chainWithMaskTrue.finalObjects);
-        std::cout << "串联(with_mask=true)包含 LED: " << (chainTrueHasLed ? "是" : "否")
-                  << "，包含 焊盘: " << (chainTrueHasPad ? "是" : "否")
-                  << "，重复结果数: " << chainTrueDuplicateCount << "\n";
-        if (chainTrueDuplicateCount > 0) mismatchDetected = true;
-
-        if (singleHasLed && !chainFalseHasLed) mismatchDetected = true;
-        if (singleHasPad && !chainFalseHasPad) mismatchDetected = true;
-
-        std::cout << "\n结论: "
-                  << (mismatchDetected ? "检测到串联链路相对单图基线存在类别丢失。" : "未检测到串联链路类别丢失。")
-                  << "\n";
-        return mismatchDetected ? 1 : 0;
-    } catch (const std::exception& e) {
-        std::cout << "专项验证异常: " << e.what() << "\n";
-        return 1;
-    }
-}
-
-std::string BuildCategoryList(const dlcv_infer::Result& out) {
-    constexpr size_t kMaxShowCount = 20;
-    if (out.sampleResults.empty()) return "";
-    const auto& objs = out.sampleResults.front().results;
-    if (objs.empty()) return "";
-    std::string joined;
-    const size_t showCount = std::min(objs.size(), kMaxShowCount);
-    for (size_t i = 0; i < showCount; ++i) {
-        std::string name = dlcv_infer::convertGbkToUtf8(objs[i].categoryName);
-        if (name.empty()) name = "unknown";
-        joined += name;
-        if (i + 1 < showCount) joined += "，";
-    }
-    if (objs.size() > showCount) {
-        joined += " ...(共";
-        joined += std::to_string(objs.size());
-        joined += "个)";
-    }
-    return joined;
-}
-
 void DisposeResultMasks(dlcv_infer::Result& out) {
     for (auto& sr : out.sampleResults) {
         for (auto& o : sr.results) {
             if (!o.mask.empty()) o.mask.release();
         }
     }
-}
-
-SpeedResult RunSpeed(dlcv_infer::Model& model, const cv::Mat& rgb, int batch, bool allowNa) {
-    try {
-        json p;
-        p["threshold"] = 0.05;
-        p["with_mask"] = true;
-        std::vector<cv::Mat> imgs(batch, rgb);
-        for (int i = 0; i < 2; ++i) {
-            auto warm = model.InferBatch(imgs, p);
-            DisposeResultMasks(warm);
-        }
-        long long count = 0;
-        auto begin = Clock::now();
-        while (std::chrono::duration<double>(Clock::now() - begin).count() < kSpeedWindowSeconds) {
-            auto out = model.InferBatch(imgs, p);
-            DisposeResultMasks(out);
-            count++;
-        }
-        double elapsed = std::chrono::duration<double>(Clock::now() - begin).count();
-        if (count <= 0 || elapsed <= 0.0) return allowNa ? SpeedResult{} : SpeedResult{0.0, true};
-        return SpeedResult{static_cast<double>(count * batch) / elapsed, true};
-    } catch (...) {
-        return allowNa ? SpeedResult{} : SpeedResult{0.0, false};
-    }
-}
-
-double RunLoadFreeLeak(const std::wstring& modelPathW) {
-    const double baseline = CaptureMemory().privateMb;
-    for (int i = 0; i < kLeakLoopCount; ++i) {
-        std::unique_ptr<dlcv_infer::Model> m(new dlcv_infer::Model(modelPathW, kGpuDeviceId));
-        m.reset();
-    }
-    return CaptureMemory().privateMb - baseline;
-}
-
-double RunInferLeak3s(const std::wstring& modelPathW, const std::wstring& imagePath) {
-    const double before = CaptureMemory().privateMb;
-    try {
-        std::unique_ptr<dlcv_infer::Model> model(new dlcv_infer::Model(modelPathW, kGpuDeviceId));
-        cv::Mat bgr = LoadImageByDecode(imagePath);
-        if (bgr.empty()) return 0.0;
-        cv::Mat rgb;
-        cv::cvtColor(bgr, rgb, cv::COLOR_BGR2RGB);
-        json p;
-        p["threshold"] = 0.05;
-        p["with_mask"] = true;
-        std::vector<cv::Mat> imgs(1, rgb);
-        auto begin = Clock::now();
-        while (std::chrono::duration<double>(Clock::now() - begin).count() < kSpeedWindowSeconds) {
-            auto out = model->InferBatch(imgs, p);
-            DisposeResultMasks(out);
-        }
-    } catch (...) {}
-    return CaptureMemory().privateMb - before;
-}
-
-CaseRow RunCase(const std::wstring& modelPath, const std::wstring& imagePath) {
-    CaseRow row;
-    const std::wstring modelNameW = BaseName(modelPath);
-    row.modelName = WideToUtf8(modelNameW);
-    row.loadText = "失败";
-    row.inferText = "失败";
-    row.categories = "-";
-    row.speedText = "-";
-    row.batchText = "-";
-
-    const auto memBefore = CaptureMemory();
-    const auto t0 = Clock::now();
-    std::unique_ptr<dlcv_infer::Model> model;
-    try {
-        model.reset(new dlcv_infer::Model(modelPath, kGpuDeviceId));
-    } catch (const std::exception& e) {
-        row.categories = Safe(e.what());
-        return row;
-    }
-    const auto t1 = Clock::now();
-    const auto memAfter = CaptureMemory();
-    const bool loadOk = model && model->modelIndex != -1;
-    row.loadText = std::string(loadOk ? "成功" : "失败") + "(" +
-                   std::to_string(std::chrono::duration<double, std::milli>(t1 - t0).count()) + "ms,Δ" +
-                   std::to_string(memAfter.privateMb - memBefore.privateMb) + "MB," +
-                   "provider=" + DogProviderToString(model->LoadedDogProvider()) + ",dll=" + model->LoadedNativeDllName() + ")";
-    if (!loadOk) return row;
-
-    cv::Mat bgr = LoadImageByDecode(imagePath);
-    if (bgr.empty()) {
-        row.inferText = "失败";
-        row.categories = "图像解码失败";
-    } else {
-        cv::Mat rgb;
-        cv::cvtColor(bgr, rgb, cv::COLOR_BGR2RGB);
-        try {
-            json p;
-            p["threshold"] = 0.05;
-            p["with_mask"] = true;
-            auto out = model->InferBatch(std::vector<cv::Mat>{rgb}, p);
-            row.inferText = out.sampleResults.empty() ? "失败" : "成功";
-            row.categories = BuildCategoryList(out);
-            if (row.categories.empty()) row.categories = "(空)";
-            DisposeResultMasks(out);
-        } catch (const std::exception& e) {
-            row.inferText = "失败";
-            row.categories = Safe(e.what());
-        }
-        auto s1 = RunSpeed(*model, rgb, 1, false);
-        row.speedText = s1.supported ? ("均速 " + std::to_string(s1.fps) + " 张/秒") : "失败";
-        auto sb = RunSpeed(*model, rgb, kFixedBatchSize, true);
-        row.batchText = sb.supported ? ("均速 " + std::to_string(sb.fps) + " 张/秒") : "N/A";
-    }
-
-    model.reset();
-    return row;
-}
-
-void PrintHeader() {
-    std::cout << "| 模型 | 加载 | 推理 | 类别列表 | 3秒速度 | Batch速度 |\n";
-    std::cout << "|---|---|---|---|---|---|\n";
-}
-
-void PrintRow(const CaseRow& r) {
-    std::cout << "| " << Safe(r.modelName) << " | " << Safe(r.loadText) << " | " << Safe(r.inferText) << " | "
-              << Safe(r.categories) << " | " << Safe(r.speedText) << " | " << Safe(r.batchText) << " |\n";
-}
-
-struct NodeTimingAggregate {
-    int nodeId{-1};
-    std::string nodeType;
-    std::string nodeTitle;
-    int count{0};
-    double totalMs{0.0};
-    double AverageMs() const { return count > 0 ? totalMs / static_cast<double>(count) : 0.0; }
-    void Add(double elapsedMs) {
-        count += 1;
-        totalMs += std::max(0.0, elapsedMs);
-    }
-};
-
-int ParsePositiveIntArg(const char* s, int fallback) {
-    if (s == nullptr) return fallback;
-    try {
-        const int v = std::stoi(std::string(s));
-        return v > 0 ? v : fallback;
-    } catch (...) {
-        return fallback;
-    }
-}
-
-int RunBenchmark(const std::wstring& modelPath, const std::wstring& imagePath, int batch, int runs, int warmup) {
-    std::cout << "==== 基准测试 ====\n";
-#if defined(_DEBUG)
-    const char* buildMode = "Debug";
-#else
-    const char* buildMode = "Release";
-#endif
-    std::cout << "构建模式: " << buildMode << "\n";
-#if defined(_DEBUG)
-    std::cout << "提示: 当前为 Debug 构建，性能会显著偏慢，建议使用 Release|x64 进行压测。\n";
-#endif
-    std::cout << "模型: " << WideToUtf8(modelPath) << "\n";
-    std::cout << "图片: " << WideToUtf8(imagePath) << "\n";
-    std::cout << "batch: " << batch << "\n";
-    std::cout << "runs: " << runs << "\n";
-    std::cout << "warmup: " << warmup << "\n";
-
-    if (!FileExistsW(modelPath)) {
-        std::cout << "模型不存在\n";
-        return 2;
-    }
-    if (!FileExistsW(imagePath)) {
-        std::cout << "图片不存在\n";
-        return 2;
-    }
-
-    try {
-        dlcv_infer::Model model(modelPath, kGpuDeviceId);
-        std::cout << "provider=" << DogProviderToString(model.LoadedDogProvider())
-                  << ", dll=" << model.LoadedNativeDllName() << "\n";
-        cv::Mat bgr = LoadImageByDecode(imagePath);
-        if (bgr.empty()) throw std::runtime_error("图像解码失败");
-        cv::Mat rgb;
-        cv::cvtColor(bgr, rgb, cv::COLOR_BGR2RGB);
-
-        std::vector<cv::Mat> list;
-        list.reserve(static_cast<size_t>(batch));
-        for (int i = 0; i < batch; ++i) list.push_back(rgb);
-
-        json params;
-        params["threshold"] = 0.5;
-        params["with_mask"] = false;
-        params["batch_size"] = batch;
-
-        for (int i = 0; i < warmup; ++i) {
-            auto warm = model.InferBatch(list, params);
-            DisposeResultMasks(warm);
-        }
-
-        const auto benchmarkStart = Clock::now();
-        double sdkSum = 0.0;
-        double flowSum = 0.0;
-        double outerSum = 0.0;
-        std::unordered_map<std::string, NodeTimingAggregate> nodeStats;
-
-        for (int i = 0; i < runs; ++i) {
-            const auto t0 = Clock::now();
-            auto out = model.InferBatch(list, params);
-            const auto t1 = Clock::now();
-
-            double sdkMs = 0.0;
-            double flowMs = 0.0;
-            dlcv_infer::Model::GetLastInferTiming(sdkMs, flowMs);
-            const double outerMs = std::chrono::duration<double, std::milli>(t1 - t0).count();
-            if (sdkMs <= 0.0) sdkMs = outerMs;
-            if (flowMs <= 0.0) flowMs = outerMs;
-            sdkSum += sdkMs;
-            flowSum += flowMs;
-            outerSum += outerMs;
-
-            const auto timings = dlcv_infer::Model::GetLastFlowNodeTimings();
-            for (const auto& timing : timings) {
-                const std::string key = std::to_string(timing.nodeId) + "|" + timing.nodeType + "|" + timing.nodeTitle;
-                auto& agg = nodeStats[key];
-                if (agg.count == 0) {
-                    agg.nodeId = timing.nodeId;
-                    agg.nodeType = timing.nodeType;
-                    agg.nodeTitle = timing.nodeTitle;
-                }
-                agg.Add(timing.elapsedMs);
-            }
-
-            DisposeResultMasks(out);
-        }
-
-        const double avgSdk = sdkSum / std::max(1, runs);
-        const double avgFlow = flowSum / std::max(1, runs);
-        const double avgOuter = outerSum / std::max(1, runs);
-        const auto benchmarkEnd = Clock::now();
-        const double elapsedSec = std::chrono::duration<double>(benchmarkEnd - benchmarkStart).count();
-        const long long completedRequests = static_cast<long long>(runs) * static_cast<long long>(batch);
-        const double realtimeRate = elapsedSec > 0.0 ? static_cast<double>(completedRequests) / elapsedSec : 0.0;
-
-        std::cout << "\n压力测试统计:\n";
-        std::cout << "线程数: 1\n";
-        std::cout << "批量大小: " << batch << "\n";
-        std::cout << "运行时间: " << ToFixed(elapsedSec, 2) << " 秒\n";
-        std::cout << "完成请求: " << completedRequests << "\n";
-        std::cout << "平均延迟: " << ToFixed(avgOuter, 2) << "ms\n";
-        std::cout << "平均延迟(SDK): " << ToFixed(avgSdk, 2) << "ms\n";
-        std::cout << "实时速率: " << ToFixed(realtimeRate, 2) << " 请求/秒\n";
-
-        std::vector<NodeTimingAggregate> rows;
-        rows.reserve(nodeStats.size());
-        for (const auto& kv : nodeStats) rows.push_back(kv.second);
-        std::sort(rows.begin(), rows.end(), [](const NodeTimingAggregate& a, const NodeTimingAggregate& b) {
-            return a.AverageMs() > b.AverageMs();
-        });
-
-        std::cout << "模块平均耗时:\n";
-        if (rows.empty()) {
-            std::cout << "(无流程节点统计)\n";
-        } else {
-            for (const auto& item : rows) {
-                const double share = avgFlow > 0.0 ? item.AverageMs() * 100.0 / avgFlow : 0.0;
-                std::cout << "#" << item.nodeId << " [" << item.nodeType << "] "
-                          << (item.nodeTitle.empty() ? "-" : item.nodeTitle)
-                          << ": " << ToFixed(item.AverageMs(), 2)
-                          << "ms (" << ToFixed(share, 1) << "%)\n";
-            }
-        }
-        return 0;
-    } catch (const std::exception& e) {
-        std::cout << "基准异常: " << e.what() << "\n";
-        return 1;
-    }
-}
-
-int RunSlidingAlignOnce(const std::wstring& modelPath, const std::wstring& imagePath) {
-    std::cout << "图片: " << WideToUtf8(imagePath) << "\n";
-    std::cout << "batch_size: " << kSlidingAlignBatchSize << "\n";
-    std::cout << "threshold: " << ToFixed(kSlidingAlignThreshold, 2) << "\n";
-    if (!FileExistsW(modelPath) || !FileExistsW(imagePath)) {
-        std::cout << "模型或图片不存在，请检查路径。\n";
-        return 2;
-    }
-
-    try {
-        dlcv_infer::Model model(modelPath, kGpuDeviceId);
-        std::cout << "provider=" << DogProviderToString(model.LoadedDogProvider())
-                  << ", dll=" << model.LoadedNativeDllName() << "\n";
-        cv::Mat bgr = LoadImageByDecode(imagePath);
-        if (bgr.empty()) throw std::runtime_error("图像解码失败");
-        cv::Mat rgb;
-        cv::cvtColor(bgr, rgb, cv::COLOR_BGR2RGB);
-
-        json params;
-        params["threshold"] = kSlidingAlignThreshold;
-        params["with_mask"] = true;
-        params["batch_size"] = kSlidingAlignBatchSize;
-
-        const auto t0 = Clock::now();
-        auto out = model.InferBatch(std::vector<cv::Mat>{rgb}, params);
-        const auto t1 = Clock::now();
-
-        const double elapsedMs = std::chrono::duration<double, std::milli>(t1 - t0).count();
-        std::cout << "\n推理时间: " << ToFixed(elapsedMs, 2) << "ms\n\n";
-        std::cout << "输入: RGB\n\n";
-        std::cout << "推理结果:\n";
-        if (out.sampleResults.empty() || out.sampleResults.front().results.empty()) {
-            std::cout << "(空)\n";
-        } else {
-            const auto& objs = out.sampleResults.front().results;
-            for (const auto& obj : objs) {
-                std::cout << dlcv_infer::convertGbkToUtf8(obj.categoryName)
-                          << ", Score: " << ToFixed(static_cast<double>(obj.score) * 100.0, 1)
-                          << ", Area: " << ToFixed(static_cast<double>(obj.area), 1);
-                if (obj.bbox.size() >= 4) {
-                    std::cout << ", Bbox: [" << ToFixed(obj.bbox[0], 1)
-                              << ", " << ToFixed(obj.bbox[1], 1)
-                              << ", " << ToFixed(obj.bbox[2], 1)
-                              << ", " << ToFixed(obj.bbox[3], 1) << "]";
-                }
-                std::cout << ", \n";
-            }
-        }
-        DisposeResultMasks(out);
-        return 0;
-    } catch (const std::exception& e) {
-        std::cout << "推理异常: " << e.what() << "\n";
-        return 1;
-    }
-}
-
-int RunFlowInstanceSegFilterSelfTest() {
-    std::cout << "==== Flow 实例分割筛选自测 ====\n";
-    std::cout << "model: " << WideToUtf8(kFlowInstanceSegFilterModelPath) << "\n";
-    std::cout << "image: " << WideToUtf8(kFlowInstanceSegFilterImagePath) << "\n";
-    if (!FileExistsW(kFlowInstanceSegFilterModelPath) || !FileExistsW(kFlowInstanceSegFilterImagePath)) {
-        std::cout << "模型或图片不存在，请检查路径。\n";
-        return 2;
-    }
-
-    try {
-        dlcv_infer::Model model(kFlowInstanceSegFilterModelPath, kGpuDeviceId);
-        std::cout << "provider=" << DogProviderToString(model.LoadedDogProvider())
-                  << ", dll=" << model.LoadedNativeDllName() << "\n";
-
-        cv::Mat bgr = LoadImageByDecode(kFlowInstanceSegFilterImagePath);
-        if (bgr.empty()) throw std::runtime_error("图像解码失败");
-        cv::Mat rgb;
-        cv::cvtColor(bgr, rgb, cv::COLOR_BGR2RGB);
-
-        json params;
-        params["threshold"] = 0.5;
-        params["with_mask"] = true;
-        params["batch_size"] = 1;
-
-        const json oneOutJson = model.InferOneOutJson(rgb, params);
-        std::cout << "one_out_json_count: " << (oneOutJson.is_array() ? oneOutJson.size() : 0) << "\n";
-
-        dlcv_infer::Result out = model.InferBatch(std::vector<cv::Mat>{ rgb }, params);
-        const size_t sampleCount = out.sampleResults.size();
-        const size_t objectCount = sampleCount > 0 ? out.sampleResults[0].results.size() : 0;
-        std::cout << "sample_count: " << sampleCount << "\n";
-        std::cout << "det_counts: [" << objectCount << "]\n";
-
-        bool ok = true;
-        if (sampleCount != 1) {
-            std::cout << "ERROR: expected 1 sample, got " << sampleCount << "\n";
-            ok = false;
-        }
-        if (objectCount != 2) {
-            std::cout << "ERROR: expected exactly 2 objects, got " << objectCount << "\n";
-            ok = false;
-        }
-
-        const auto checkObj = [&](size_t idx,
-                                  double ex, double ey, double ew, double eh) {
-            if (sampleCount == 0 || idx >= out.sampleResults[0].results.size()) {
-                ok = false;
-                return;
-            }
-            const auto& obj = out.sampleResults[0].results[idx];
-            const std::string name = dlcv_infer::convertGbkToUtf8(obj.categoryName);
-            std::cout << "[" << (idx + 1) << "] " << name
-                      << " score=" << ToFixed(static_cast<double>(obj.score), 2);
-            if (obj.bbox.size() >= 4) {
-                std::cout << " bbox=(" << ToFixed(obj.bbox[0], 1)
-                          << ", " << ToFixed(obj.bbox[1], 1)
-                          << ", " << ToFixed(obj.bbox[2], 1)
-                          << ", " << ToFixed(obj.bbox[3], 1) << ")";
-            }
-            std::cout << " area=" << ToFixed(static_cast<double>(obj.area), 1) << "\n";
-
-            if (name != "杯子") {
-                std::cout << "ERROR: object[" << idx << "] category mismatch: " << name << "\n";
-                ok = false;
-            }
-            if (std::abs(obj.score - 1.0f) > 0.01f) {
-                std::cout << "ERROR: object[" << idx << "] score mismatch: " << obj.score << "\n";
-                ok = false;
-            }
-            if (!obj.withBbox || obj.bbox.size() < 4) {
-                std::cout << "ERROR: object[" << idx << "] bbox missing\n";
-                ok = false;
-                return;
-            }
-            if (std::abs(obj.bbox[0] - ex) > 1.0 ||
-                std::abs(obj.bbox[1] - ey) > 1.0 ||
-                std::abs(obj.bbox[2] - ew) > 1.0 ||
-                std::abs(obj.bbox[3] - eh) > 1.0) {
-                std::cout << "ERROR: object[" << idx << "] bbox mismatch\n";
-                ok = false;
-            }
-        };
-
-        checkObj(0, 211.0, 221.0, 160.0, 186.0);
-        checkObj(1, 849.0, 220.0, 161.0, 185.0);
-
-        DisposeResultMasks(out);
-        if (ok) {
-            std::cout << "Flow 实例分割筛选自测通过\n";
-            return 0;
-        }
-        std::cout << "Flow 实例分割筛选自测失败\n";
-        return 1;
-    } catch (const std::exception& e) {
-        std::cout << "Flow 实例分割筛选自测异常: " << e.what() << "\n";
-        return 1;
-    }
-}
-
-int RunDvstDoubleLoadSelfTest() {
-    std::cout << "==== dvst 双模型加载-释放-再加载自测 (C++) ====\n";
-    std::cout << "modelA: " << WideToUtf8(kDvstDoubleLoadModelAPath) << "\n";
-    std::cout << "modelB: " << WideToUtf8(kDvstDoubleLoadModelBPath) << "\n";
-    std::cout << "image:  " << WideToUtf8(kDvstDoubleLoadImagePath) << "\n";
-
-    if (!FileExistsW(kDvstDoubleLoadModelAPath) || !FileExistsW(kDvstDoubleLoadModelBPath) || !FileExistsW(kDvstDoubleLoadImagePath)) {
-        std::cout << "模型或图片不存在，请检查路径。\n";
-        return 2;
-    }
-
-    cv::Mat bgr = LoadImageByDecode(kDvstDoubleLoadImagePath);
-    if (bgr.empty()) {
-        std::cout << "图像解码失败\n";
-        return 2;
-    }
-    cv::Mat rgb;
-    cv::cvtColor(bgr, rgb, cv::COLOR_BGR2RGB);
-
-    json params;
-    params["threshold"] = 0.5;
-    params["with_mask"] = true;
-    params["with_angle"] = true;
-    params["batch_size"] = 1;
-
-    dlcv_infer::Model* modelA = nullptr;
-    dlcv_infer::Model* modelB = nullptr;
-    int step = 0;
-
-    try {
-        // 1. 加载A
-        step = 1;
-        std::cout << "[" << step << "] 加载模型A...\n";
-        modelA = new dlcv_infer::Model(kDvstDoubleLoadModelAPath, kGpuDeviceId);
-        std::cout << "    A loaded, provider=" << DogProviderToString(modelA->LoadedDogProvider())
-                  << ", dll=" << modelA->LoadedNativeDllName() << "\n";
-
-        // 2. 加载B
-        step = 2;
-        std::cout << "[" << step << "] 加载模型B...\n";
-        modelB = new dlcv_infer::Model(kDvstDoubleLoadModelBPath, kGpuDeviceId);
-        std::cout << "    B loaded, provider=" << DogProviderToString(modelB->LoadedDogProvider())
-                  << ", dll=" << modelB->LoadedNativeDllName() << "\n";
-
-        // 3. A推理
-        step = 3;
-        std::cout << "[" << step << "] 模型A首次推理...\n";
-        {
-            auto out = modelA->InferBatch(std::vector<cv::Mat>{rgb}, params);
-            std::cout << "    A推理完成, sample_count=" << out.sampleResults.size() << "\n";
-            DisposeResultMasks(out);
-        }
-
-        // 4. B推理
-        step = 4;
-        std::cout << "[" << step << "] 模型B首次推理...\n";
-        {
-            auto out = modelB->InferBatch(std::vector<cv::Mat>{rgb}, params);
-            std::cout << "    B推理完成, sample_count=" << out.sampleResults.size() << "\n";
-            DisposeResultMasks(out);
-        }
-
-        // 5. 释放A (FreeModel)
-        step = 5;
-        std::cout << "[" << step << "] 释放模型A (FreeModel)...\n";
-        modelA->FreeModel();
-        std::cout << "    A已释放\n";
-
-        // 6. 再次加载A
-        step = 6;
-        std::cout << "[" << step << "] 再次加载模型A...\n";
-        delete modelA;
-        modelA = new dlcv_infer::Model(kDvstDoubleLoadModelAPath, kGpuDeviceId);
-        std::cout << "    A再次加载完成, provider=" << DogProviderToString(modelA->LoadedDogProvider()) << "\n";
-
-        // 7. 释放B (FreeModel)
-        step = 7;
-        std::cout << "[" << step << "] 释放模型B (FreeModel)...\n";
-        modelB->FreeModel();
-        std::cout << "    B已释放\n";
-
-        // 8. 再次加载B
-        step = 8;
-        std::cout << "[" << step << "] 再次加载模型B...\n";
-        delete modelB;
-        modelB = new dlcv_infer::Model(kDvstDoubleLoadModelBPath, kGpuDeviceId);
-        std::cout << "    B再次加载完成, provider=" << DogProviderToString(modelB->LoadedDogProvider()) << "\n";
-
-        // 9. A再次推理
-        step = 9;
-        std::cout << "[" << step << "] 模型A再次推理...\n";
-        {
-            auto out = modelA->InferBatch(std::vector<cv::Mat>{rgb}, params);
-            std::cout << "    A再次推理完成, sample_count=" << out.sampleResults.size() << "\n";
-            DisposeResultMasks(out);
-        }
-
-        // 10. B再次推理
-        step = 10;
-        std::cout << "[" << step << "] 模型B再次推理...\n";
-        {
-            auto out = modelB->InferBatch(std::vector<cv::Mat>{rgb}, params);
-            std::cout << "    B再次推理完成, sample_count=" << out.sampleResults.size() << "\n";
-            DisposeResultMasks(out);
-        }
-
-        std::cout << "==== dvst 双模型加载-释放-再加载自测 全部通过 ====\n";
-
-        delete modelA;
-        modelA = nullptr;
-        delete modelB;
-        modelB = nullptr;
-        return 0;
-    } catch (const std::exception& e) {
-        std::cout << "[" << step << "] std::exception: " << e.what() << "\n";
-        delete modelA;
-        delete modelB;
-        return 1;
-    } catch (...) {
-        std::cout << "[" << step << "] 未知异常 (非std::exception)\n";
-        delete modelA;
-        delete modelB;
-        return 1;
-    }
-}
-
-int RunDvstSingleLoadSelfTest() {
-    std::cout << "==== dvst 单模型加载-释放-再加载自测 (C++) ====\n";
-    std::cout << "modelA: " << WideToUtf8(kDvstDoubleLoadModelAPath) << "\n";
-    std::cout << "image:  " << WideToUtf8(kDvstDoubleLoadImagePath) << "\n";
-
-    if (!FileExistsW(kDvstDoubleLoadModelAPath) || !FileExistsW(kDvstDoubleLoadImagePath)) {
-        std::cout << "模型或图片不存在，请检查路径。\n";
-        return 2;
-    }
-
-    cv::Mat bgr = LoadImageByDecode(kDvstDoubleLoadImagePath);
-    if (bgr.empty()) {
-        std::cout << "图像解码失败\n";
-        return 2;
-    }
-    cv::Mat rgb;
-    cv::cvtColor(bgr, rgb, cv::COLOR_BGR2RGB);
-
-    json params;
-    params["threshold"] = 0.5;
-    params["with_mask"] = true;
-    params["with_angle"] = true;
-    params["batch_size"] = 1;
-
-    dlcv_infer::Model* modelA = nullptr;
-    int step = 0;
-
-    try {
-        // 1. 加载A
-        step = 1;
-        std::cout << "[" << step << "] 加载模型A...\n";
-        modelA = new dlcv_infer::Model(kDvstDoubleLoadModelAPath, kGpuDeviceId);
-        std::cout << "    A loaded, provider=" << DogProviderToString(modelA->LoadedDogProvider())
-                  << ", dll=" << modelA->LoadedNativeDllName() << "\n";
-
-        // 2. A推理
-        step = 2;
-        std::cout << "[" << step << "] 模型A首次推理...\n";
-        {
-            auto out = modelA->InferBatch(std::vector<cv::Mat>{rgb}, params);
-            std::cout << "    A推理完成, sample_count=" << out.sampleResults.size() << "\n";
-            DisposeResultMasks(out);
-        }
-
-        // 3. 释放A (FreeModel)
-        step = 3;
-        std::cout << "[" << step << "] 释放模型A (FreeModel)...\n";
-        modelA->FreeModel();
-        std::cout << "    A已释放\n";
-
-        // 4. 再次加载A
-        step = 4;
-        std::cout << "[" << step << "] 再次加载模型A...\n";
-        delete modelA;
-        modelA = new dlcv_infer::Model(kDvstDoubleLoadModelAPath, kGpuDeviceId);
-        std::cout << "    A再次加载完成, provider=" << DogProviderToString(modelA->LoadedDogProvider()) << "\n";
-
-        // 5. A再次推理
-        step = 5;
-        std::cout << "[" << step << "] 模型A再次推理...\n";
-        {
-            auto out = modelA->InferBatch(std::vector<cv::Mat>{rgb}, params);
-            std::cout << "    A再次推理完成, sample_count=" << out.sampleResults.size() << "\n";
-            DisposeResultMasks(out);
-        }
-
-        std::cout << "==== dvst 单模型加载-释放-再加载自测 全部通过 ====\n";
-
-        delete modelA;
-        modelA = nullptr;
-        return 0;
-    } catch (const std::exception& e) {
-        std::cout << "[" << step << "] std::exception: " << e.what() << "\n";
-        delete modelA;
-        return 1;
-    } catch (...) {
-        std::cout << "[" << step << "] 未知异常 (非std::exception)\n";
-        delete modelA;
-        return 1;
-    }
-}
-
-int RunDvstModelIndexSelfTest() {
-    std::cout << "==== dvst modelIndex 分区自测 (C++ Model) ====\n";
-    constexpr int kFlowIndexBase = 10000;
-    std::cout << "dvst: " << WideToUtf8(kDvstIndexFlowModelPath) << "\n";
-    std::cout << "dvt1: " << WideToUtf8(kDvstIndexDvtCatDogPath) << "\n";
-    std::cout << "dvt2: " << WideToUtf8(kDvstIndexDvtBalloonPath) << "\n";
-
-    if (!FileExistsW(kDvstIndexFlowModelPath) || !FileExistsW(kDvstIndexDvtCatDogPath) || !FileExistsW(kDvstIndexDvtBalloonPath)) {
-        std::cout << "模型不存在，请检查路径\n";
-        return 2;
-    }
-
-    bool ok = true;
-    try {
-        std::cout << "[1] 加载 dvt1(猫狗分类)...\n";
-        dlcv_infer::Model dvt1Model(kDvstIndexDvtCatDogPath, kGpuDeviceId);
-        const int dvt1Idx = dvt1Model.modelIndex;
-        std::cout << "    dvt1 modelIndex=" << dvt1Idx << "\n";
-
-        std::cout << "[2] 加载 dvt2(气球实例分割)...\n";
-        dlcv_infer::Model dvt2Model(kDvstIndexDvtBalloonPath, kGpuDeviceId);
-        const int dvt2Idx = dvt2Model.modelIndex;
-        std::cout << "    dvt2 modelIndex=" << dvt2Idx << "\n";
-
-        std::cout << "[3] 加载 dvst(AOI 流程模型)...\n";
-        dlcv_infer::Model dvstModel(kDvstIndexFlowModelPath, kGpuDeviceId);
-        const int dvstIdx = dvstModel.modelIndex;
-        std::cout << "    dvst modelIndex=" << dvstIdx << "\n";
-
-        if (dvstIdx < kFlowIndexBase) {
-            std::cout << "FAIL: dvst modelIndex=" << dvstIdx << " 应 >= " << kFlowIndexBase
-                      << "（修复前写死 1，会与 dvt 撞键）\n";
-            ok = false;
-        } else {
-            std::cout << "PASS: dvst modelIndex=" << dvstIdx << " >= " << kFlowIndexBase << "\n";
-        }
-        if (dvt1Idx < 0 || dvt1Idx >= kFlowIndexBase) {
-            std::cout << "FAIL: dvt1 modelIndex=" << dvt1Idx << " 应在 [0," << kFlowIndexBase << ")\n";
-            ok = false;
-        }
-        if (dvt2Idx < 0 || dvt2Idx >= kFlowIndexBase) {
-            std::cout << "FAIL: dvt2 modelIndex=" << dvt2Idx << " 应在 [0," << kFlowIndexBase << ")\n";
-            ok = false;
-        }
-        if (dvstIdx == dvt1Idx || dvstIdx == dvt2Idx || dvt1Idx == dvt2Idx) {
-            std::cout << "FAIL: modelIndex 撞键 dvst=" << dvstIdx
-                      << " dvt1=" << dvt1Idx << " dvt2=" << dvt2Idx << "\n";
-            ok = false;
-        } else {
-            std::cout << "PASS: 三模型 modelIndex 互不相同（dvst=" << dvstIdx
-                      << ", dvt1=" << dvt1Idx << ", dvt2=" << dvt2Idx << "）\n";
-        }
-    } catch (const std::exception& e) {
-        std::cout << "异常: " << e.what() << "\n";
-        return 1;
-    }
-
-    std::cout << (ok ? "==== dvst modelIndex 分区自测 通过 ====\n"
-                     : "==== dvst modelIndex 分区自测 失败 ====\n");
-    return ok ? 0 : 1;
-}
-
-int RunImagePrepCheck() {
-    auto fail = [](const std::string& message) -> int {
-        std::cout << "imageprepcheck 失败: " << message << "\n";
-        return 1;
-    };
-
-    {
-        cv::Mat gray16(1, 3, CV_16UC1);
-        gray16.at<std::uint16_t>(0, 0) = 0;
-        gray16.at<std::uint16_t>(0, 1) = 256;
-        gray16.at<std::uint16_t>(0, 2) = 512;
-        const cv::Mat rgb = dlcv_infer::image_input::NormalizeInferInputImage(gray16, 3);
-        if (rgb.type() != CV_8UC3) {
-            return fail("16 位灰度图转 RGB 后类型不是 CV_8UC3");
-        }
-        const cv::Vec3b p0 = rgb.at<cv::Vec3b>(0, 0);
-        const cv::Vec3b p1 = rgb.at<cv::Vec3b>(0, 1);
-        const cv::Vec3b p2 = rgb.at<cv::Vec3b>(0, 2);
-        if (p0 != cv::Vec3b(0, 0, 0) || p1 != cv::Vec3b(1, 1, 1) || p2 != cv::Vec3b(2, 2, 2)) {
-            return fail("16 位灰度图转 RGB 后像素值不符合预期");
-        }
-    }
-
-    {
-        cv::Mat bgra(1, 1, CV_8UC4);
-        bgra.at<cv::Vec4b>(0, 0) = cv::Vec4b(10, 20, 30, 200);
-        const cv::Mat rgb = dlcv_infer::image_input::NormalizeInferInputImage(bgra, 3);
-        if (rgb.type() != CV_8UC3) {
-            return fail("BGRA 转 RGB 后类型不是 CV_8UC3");
-        }
-        const cv::Vec3b pixel = rgb.at<cv::Vec3b>(0, 0);
-        if (pixel != cv::Vec3b(30, 20, 10)) {
-            return fail("BGRA 转 RGB 后像素顺序不正确");
-        }
-    }
-
-    {
-        cv::Mat rgb(1, 1, CV_8UC3);
-        rgb.at<cv::Vec3b>(0, 0) = cv::Vec3b(30, 20, 10);
-        cv::Mat expectedGray;
-        cv::cvtColor(rgb, expectedGray, cv::COLOR_RGB2GRAY);
-        const cv::Mat gray = dlcv_infer::image_input::NormalizeInferInputImage(rgb, 1);
-        if (gray.type() != CV_8UC1) {
-            return fail("RGB 转灰度后类型不是 CV_8UC1");
-        }
-        if (gray.at<std::uint8_t>(0, 0) != expectedGray.at<std::uint8_t>(0, 0)) {
-            return fail("RGB 转灰度后的像素值不正确");
-        }
-    }
-
-    std::cout << "imageprepcheck 通过\n";
-    return 0;
 }
 
 std::string BuildTempRectCorrectionDir() {
@@ -1458,9 +122,63 @@ cv::Mat LoadSingleFileWithSuffix(const std::string& dir, const std::string& suff
     return matchCount == 1 ? loaded : cv::Mat();
 }
 
+int RunImagePrepCheck() {
+    auto fail = [](const std::string& message) -> int {
+        std::cout << "imageprepcheck failed: " << message << "\n";
+        return 1;
+    };
+
+    {
+        cv::Mat gray16(1, 3, CV_16UC1);
+        gray16.at<std::uint16_t>(0, 0) = 0;
+        gray16.at<std::uint16_t>(0, 1) = 256;
+        gray16.at<std::uint16_t>(0, 2) = 512;
+        const cv::Mat rgb = dlcv_infer::image_input::NormalizeInferInputImage(gray16, 3);
+        if (rgb.type() != CV_8UC3) {
+            return fail("16-bit grayscale to RGB type mismatch");
+        }
+        const cv::Vec3b p0 = rgb.at<cv::Vec3b>(0, 0);
+        const cv::Vec3b p1 = rgb.at<cv::Vec3b>(0, 1);
+        const cv::Vec3b p2 = rgb.at<cv::Vec3b>(0, 2);
+        if (p0 != cv::Vec3b(0, 0, 0) || p1 != cv::Vec3b(1, 1, 1) || p2 != cv::Vec3b(2, 2, 2)) {
+            return fail("16-bit grayscale to RGB pixel value mismatch");
+        }
+    }
+
+    {
+        cv::Mat bgra(1, 1, CV_8UC4);
+        bgra.at<cv::Vec4b>(0, 0) = cv::Vec4b(10, 20, 30, 200);
+        const cv::Mat rgb = dlcv_infer::image_input::NormalizeInferInputImage(bgra, 3);
+        if (rgb.type() != CV_8UC3) {
+            return fail("BGRA to RGB type mismatch");
+        }
+        const cv::Vec3b pixel = rgb.at<cv::Vec3b>(0, 0);
+        if (pixel != cv::Vec3b(30, 20, 10)) {
+            return fail("BGRA to RGB pixel order mismatch");
+        }
+    }
+
+    {
+        cv::Mat rgb(1, 1, CV_8UC3);
+        rgb.at<cv::Vec3b>(0, 0) = cv::Vec3b(30, 20, 10);
+        cv::Mat expectedGray;
+        cv::cvtColor(rgb, expectedGray, cv::COLOR_RGB2GRAY);
+        const cv::Mat gray = dlcv_infer::image_input::NormalizeInferInputImage(rgb, 1);
+        if (gray.type() != CV_8UC1) {
+            return fail("RGB to gray type mismatch");
+        }
+        if (gray.at<std::uint8_t>(0, 0) != expectedGray.at<std::uint8_t>(0, 0)) {
+            return fail("RGB to gray pixel value mismatch");
+        }
+    }
+
+    std::cout << "imageprepcheck passed\n";
+    return 0;
+}
+
 int RunRectImageCorrectionSelfTest() {
     auto fail = [](const std::string& message) -> int {
-        std::cout << "rect_image_correction 自测失败: " << message << "\n";
+        std::cout << "rect_image_correction selftest failed: " << message << "\n";
         return 1;
     };
 
@@ -1509,7 +227,7 @@ int RunRectImageCorrectionSelfTest() {
 
     {
         std::ofstream ofs(flowPath, std::ios::binary);
-        if (!ofs) return fail("无法写入临时流程文件");
+        if (!ofs) return fail("cannot write temp flow file");
         ofs << flow.dump(2);
     }
 
@@ -1522,29 +240,29 @@ int RunRectImageCorrectionSelfTest() {
 
     try {
         dlcv_infer::flow::FlowGraphModel model;
-        const json loadReport = model.Load(flowPath, kGpuDeviceId);
+        const json loadReport = model.Load(flowPath, 0);
         if (!loadReport.is_object() || loadReport.value("code", 1) != 0) {
-            return fail(std::string("流程加载失败: ") + loadReport.dump());
+            return fail(std::string("flow load failed: ") + loadReport.dump());
         }
         const json inferRoot = model.InferInternal(std::vector<cv::Mat>{tall}, json::object());
         if (!inferRoot.is_object() || inferRoot.value("code", 1) != 0) {
-            return fail(std::string("流程执行失败: ") + inferRoot.dump());
+            return fail(std::string("flow infer failed: ") + inferRoot.dump());
         }
     } catch (const std::exception& ex) {
-        return fail(std::string("异常: ") + ex.what());
+        return fail(std::string("exception: ") + ex.what());
     }
 
     const cv::Mat saved = LoadSingleFileWithSuffix(saveDir, suffix + ".png");
     if (saved.empty()) {
-        return fail("未保存矫正后的图像");
+        return fail("corrected image not saved");
     }
     if (saved.cols != 3 || saved.rows != 2) {
-        return fail("竖图未旋转为横图，实际尺寸=" + std::to_string(saved.cols) + "x" + std::to_string(saved.rows));
+        return fail("portrait image not rotated to landscape");
     }
 
     DeleteFilesWithSuffix(saveDir, suffix + ".png");
     DeleteFileA(flowPath.c_str());
-    std::cout << "rect_image_correction 自测通过\n";
+    std::cout << "rect_image_correction selftest passed\n";
     return 0;
 }
 
@@ -1790,7 +508,7 @@ bool RunBBoxIoUDedupFlowCase(bool crossModel, int expectedCount, std::string& er
     {
         std::ofstream ofs(flowPath, std::ios::binary);
         if (!ofs) {
-            error = "无法写入临时流程文件";
+            error = "cannot write temp flow file";
             return false;
         }
         ofs << BuildBBoxDedupFlow(crossModel).dump(2);
@@ -1798,9 +516,9 @@ bool RunBBoxIoUDedupFlowCase(bool crossModel, int expectedCount, std::string& er
 
     try {
         dlcv_infer::flow::FlowGraphModel model;
-        const json loadReport = model.Load(flowPath, kGpuDeviceId);
+        const json loadReport = model.Load(flowPath, 0);
         if (!loadReport.is_object() || loadReport.value("code", 1) != 0) {
-            error = std::string("流程加载失败: ") + loadReport.dump();
+            error = std::string("flow load failed: ") + loadReport.dump();
             DeleteFileA(flowPath.c_str());
             return false;
         }
@@ -1808,7 +526,7 @@ bool RunBBoxIoUDedupFlowCase(bool crossModel, int expectedCount, std::string& er
         cv::Mat image(320, 320, CV_8UC3, cv::Scalar(0, 255, 0));
         const json inferRoot = model.InferInternal(std::vector<cv::Mat>{image}, json::object());
         if (!inferRoot.is_object() || inferRoot.value("code", 1) != 0) {
-            error = std::string("流程执行失败: ") + inferRoot.dump();
+            error = std::string("flow infer failed: ") + inferRoot.dump();
             DeleteFileA(flowPath.c_str());
             return false;
         }
@@ -1816,15 +534,15 @@ bool RunBBoxIoUDedupFlowCase(bool crossModel, int expectedCount, std::string& er
         const json results = inferRoot.contains("result_list") ? inferRoot.at("result_list") : json::array();
         const int kept = CountBBoxDedupDetections(results);
         if (kept != expectedCount) {
-            error = std::string(crossModel ? "默认 cross_model=true" : "cross_model=false") +
-                " 保留数量不符合预期，actual=" + std::to_string(kept) +
+            error = std::string(crossModel ? "default cross_model=true" : "cross_model=false") +
+                " kept count mismatch, actual=" + std::to_string(kept) +
                 ", expected=" + std::to_string(expectedCount) +
                 ", root=" + inferRoot.dump();
             DeleteFileA(flowPath.c_str());
             return false;
         }
     } catch (const std::exception& ex) {
-        error = std::string("异常: ") + ex.what();
+        error = std::string("exception: ") + ex.what();
         DeleteFileA(flowPath.c_str());
         return false;
     }
@@ -1839,7 +557,7 @@ bool RunBBoxIoUDedupNoneVsIdentityCase(std::string& error) {
     {
         std::ofstream ofs(flowPath, std::ios::binary);
         if (!ofs) {
-            error = "无法写入临时流程文件";
+            error = "cannot write temp flow file";
             return false;
         }
         ofs << BuildBBoxDedupNoneVsIdentityFlow().dump(2);
@@ -1847,9 +565,9 @@ bool RunBBoxIoUDedupNoneVsIdentityCase(std::string& error) {
 
     try {
         dlcv_infer::flow::FlowGraphModel model;
-        const json loadReport = model.Load(flowPath, kGpuDeviceId);
+        const json loadReport = model.Load(flowPath, 0);
         if (!loadReport.is_object() || loadReport.value("code", 1) != 0) {
-            error = std::string("流程加载失败: ") + loadReport.dump();
+            error = std::string("flow load failed: ") + loadReport.dump();
             DeleteFileA(flowPath.c_str());
             return false;
         }
@@ -1857,7 +575,7 @@ bool RunBBoxIoUDedupNoneVsIdentityCase(std::string& error) {
         cv::Mat image(320, 320, CV_8UC3, cv::Scalar(0, 255, 0));
         const json inferRoot = model.InferInternal(std::vector<cv::Mat>{image}, json::object());
         if (!inferRoot.is_object() || inferRoot.value("code", 1) != 0) {
-            error = std::string("流程执行失败: ") + inferRoot.dump();
+            error = std::string("flow infer failed: ") + inferRoot.dump();
             DeleteFileA(flowPath.c_str());
             return false;
         }
@@ -1865,13 +583,13 @@ bool RunBBoxIoUDedupNoneVsIdentityCase(std::string& error) {
         const json results = inferRoot.contains("result_list") ? inferRoot.at("result_list") : json::array();
         const int kept = CountBBoxDedupDetections(results);
         if (kept != 1) {
-            error = "transform=null 与恒等 transform 未归到同组，actual=" + std::to_string(kept) +
+            error = "null/identity transform not grouped, actual=" + std::to_string(kept) +
                 ", expected=1, root=" + inferRoot.dump();
             DeleteFileA(flowPath.c_str());
             return false;
         }
     } catch (const std::exception& ex) {
-        error = std::string("异常: ") + ex.what();
+        error = std::string("exception: ") + ex.what();
         DeleteFileA(flowPath.c_str());
         return false;
     }
@@ -1880,55 +598,19 @@ bool RunBBoxIoUDedupNoneVsIdentityCase(std::string& error) {
     return true;
 }
 
-void PrintBBoxCropFixObjects(const dlcv_infer::Result& out) {
-    if (out.sampleResults.empty() || out.sampleResults.front().results.empty()) return;
-    const auto& objs = out.sampleResults.front().results;
-    for (size_t i = 0; i < objs.size(); ++i) {
-        const auto& obj = objs[i];
-        std::cout << "[" << (i + 1) << "] " << dlcv_infer::convertGbkToUtf8(obj.categoryName)
-                  << " score=" << ToFixed(static_cast<double>(obj.score), 2);
-        if (obj.bbox.size() >= 4) {
-            std::cout << " bbox=(" << ToFixed(obj.bbox[0], 1)
-                      << ", " << ToFixed(obj.bbox[1], 1)
-                      << ", " << ToFixed(obj.bbox[2], 1)
-                      << ", " << ToFixed(obj.bbox[3], 1) << ")";
-        }
-        std::cout << " area=" << ToFixed(static_cast<double>(obj.area), 1) << "\n";
-    }
-}
+int RunBBoxIoUDedupSelfTest() {
+    auto fail = [](const std::string& message) -> int {
+        std::cout << "bbox_iou_dedup selftest failed: " << message << "\n";
+        return 1;
+    };
 
-bool RunBBoxCropFixOneModel(const std::string& name,
-                            const std::wstring& modelPath,
-                            const cv::Mat& rgb,
-                            size_t expectedCount) {
-    std::cout << "[" << name << "] 加载模型: " << WideToUtf8(modelPath) << "\n";
-    dlcv_infer::Model model(modelPath, kGpuDeviceId);
+    std::string error;
+    if (!RunBBoxIoUDedupFlowCase(true, 1, error)) return fail(error);
+    if (!RunBBoxIoUDedupFlowCase(false, 2, error)) return fail(error);
+    if (!RunBBoxIoUDedupNoneVsIdentityCase(error)) return fail(error);
 
-    json params;
-    params["threshold"] = 0.5;
-    params["with_mask"] = true;
-    params["batch_size"] = 1;
-
-    const auto t0 = Clock::now();
-    dlcv_infer::Result out = model.InferBatch(std::vector<cv::Mat>{rgb}, params);
-    const auto t1 = Clock::now();
-
-    const size_t sampleCount = out.sampleResults.size();
-    const size_t objectCount = sampleCount > 0 ? out.sampleResults.front().results.size() : 0;
-    const double elapsedMs = std::chrono::duration<double, std::milli>(t1 - t0).count();
-    std::cout << "[" << name << "] sample_count: " << sampleCount << "\n";
-    std::cout << "[" << name << "] 推理结果: " << objectCount
-              << "个, elapsed=" << ToFixed(elapsedMs, 2) << "ms\n";
-    PrintBBoxCropFixObjects(out);
-
-    const bool ok = (sampleCount == 1 && objectCount == expectedCount);
-    if (!ok) {
-        std::cout << "[" << name << "] 验证失败：期望 1 个 sample 且 "
-                  << expectedCount << " 个目标，实际 sample=" << sampleCount
-                  << ", target=" << objectCount << "\n";
-    }
-    DisposeResultMasks(out);
-    return ok;
+    std::cout << "bbox_iou_dedup selftest passed\n";
+    return 0;
 }
 
 json BuildImageGenerationExpandFlow(const std::string& saveDir,
@@ -2005,7 +687,7 @@ bool AssertImageGenerationCrop(const std::string& caseName,
     {
         std::ofstream ofs(flowPath, std::ios::binary);
         if (!ofs) {
-            error = caseName + " 无法写入临时流程文件";
+            error = caseName + " cannot write temp flow file";
             return false;
         }
         ofs << BuildImageGenerationExpandFlow(tempDir, suffix, cropProperties, resultProperties).dump(2);
@@ -2013,9 +695,9 @@ bool AssertImageGenerationCrop(const std::string& caseName,
 
     try {
         dlcv_infer::flow::FlowGraphModel model;
-        const json loadReport = model.Load(flowPath, kGpuDeviceId);
+        const json loadReport = model.Load(flowPath, 0);
         if (!loadReport.is_object() || loadReport.value("code", 1) != 0) {
-            error = caseName + " 流程加载失败: " + loadReport.dump();
+            error = caseName + " flow load failed: " + loadReport.dump();
             DeleteFileA(flowPath.c_str());
             return false;
         }
@@ -2023,12 +705,12 @@ bool AssertImageGenerationCrop(const std::string& caseName,
         cv::Mat image(imageHeight, imageWidth, CV_8UC3, cv::Scalar(0, 0, 0));
         const json inferRoot = model.InferInternal(std::vector<cv::Mat>{image}, json::object());
         if (!inferRoot.is_object() || inferRoot.value("code", 1) != 0) {
-            error = caseName + " 流程执行失败: " + inferRoot.dump();
+            error = caseName + " flow infer failed: " + inferRoot.dump();
             DeleteFileA(flowPath.c_str());
             return false;
         }
     } catch (const std::exception& ex) {
-        error = caseName + " 异常: " + ex.what();
+        error = caseName + " exception: " + ex.what();
         DeleteFileA(flowPath.c_str());
         return false;
     }
@@ -2037,12 +719,12 @@ bool AssertImageGenerationCrop(const std::string& caseName,
     DeleteFilesWithSuffix(tempDir, suffix + ".png");
     DeleteFileA(flowPath.c_str());
     if (saved.empty()) {
-        error = caseName + " 未保存裁图";
+        error = caseName + " cropped image not saved";
         return false;
     }
 
     if (saved.cols != expectedWidth || saved.rows != expectedHeight) {
-        error = caseName + " 裁图尺寸错误，actual=" + std::to_string(saved.cols) + "x" +
+        error = caseName + " crop size mismatch, actual=" + std::to_string(saved.cols) + "x" +
                 std::to_string(saved.rows) + ", expected=" + std::to_string(expectedWidth) +
                 "x" + std::to_string(expectedHeight);
         return false;
@@ -2064,7 +746,7 @@ bool RunImageGenerationExpandRegression(std::string& error) {
     });
 
     if (!AssertImageGenerationCrop(
-            "像素外扩",
+            "pixel_expand",
             tempDir,
             json::object({{"crop_expand", 5}, {"crop_shape", json::array()}, {"min_size", 1}}),
             axisResultProps,
@@ -2075,7 +757,7 @@ bool RunImageGenerationExpandRegression(std::string& error) {
     }
 
     if (!AssertImageGenerationCrop(
-            "百分比外扩普通框",
+            "percent_expand_axis",
             tempDir,
             json::object({{"crop_expand", 0}, {"crop_expand_mode", "percent"}, {"crop_expand_percent", 10}, {"crop_shape", json::array()}, {"min_size", 1}}),
             axisResultProps,
@@ -2086,7 +768,7 @@ bool RunImageGenerationExpandRegression(std::string& error) {
     }
 
     if (!AssertImageGenerationCrop(
-            "百分比值不截断为32",
+            "percent_no_round_to_32",
             tempDir,
             json::object({{"crop_expand", 0}, {"crop_expand_mode", "percent"}, {"crop_expand_percent", 50}, {"crop_shape", json::array()}, {"min_size", 1}}),
             axisResultProps,
@@ -2106,7 +788,7 @@ bool RunImageGenerationExpandRegression(std::string& error) {
         {"bbox_h", 200.0}
     });
     if (!AssertImageGenerationCrop(
-            "百分比默认像素上限",
+            "percent_default_pixel_limit",
             tempDir,
             json::object({{"crop_expand", 0}, {"crop_expand_mode", "percent"}, {"crop_expand_percent", 20}, {"crop_shape", json::array()}, {"min_size", 1}}),
             largeAxisResultProps,
@@ -2119,7 +801,7 @@ bool RunImageGenerationExpandRegression(std::string& error) {
     }
 
     if (!AssertImageGenerationCrop(
-            "百分比自定义像素上限",
+            "percent_custom_pixel_limit",
             tempDir,
             json::object({{"crop_expand", 0}, {"crop_expand_mode", "percent"}, {"crop_expand_percent", 20}, {"crop_expand_percent_limit", 10}, {"crop_shape", json::array()}, {"min_size", 1}}),
             largeAxisResultProps,
@@ -2132,7 +814,7 @@ bool RunImageGenerationExpandRegression(std::string& error) {
     }
 
     if (!AssertImageGenerationCrop(
-            "固定尺寸优先",
+            "fixed_size_priority",
             tempDir,
             json::object({{"crop_expand", 5}, {"crop_expand_mode", "percent"}, {"crop_expand_percent", 10}, {"crop_shape", json::array({30, 25})}, {"min_size", 1}}),
             axisResultProps,
@@ -2154,7 +836,7 @@ bool RunImageGenerationExpandRegression(std::string& error) {
         {"angle", 0.0}
     });
     if (!AssertImageGenerationCrop(
-            "百分比外扩旋转框",
+            "percent_expand_rotated",
             tempDir,
             json::object({{"crop_expand", 0}, {"crop_expand_mode", "percent"}, {"crop_expand_percent", 10}, {"crop_shape", json::array()}, {"min_size", 1}}),
             rotatedResultProps,
@@ -2176,7 +858,7 @@ bool RunImageGenerationExpandRegression(std::string& error) {
         {"angle", 0.0}
     });
     if (!AssertImageGenerationCrop(
-            "旋转框百分比默认像素上限",
+            "rotated_percent_default_pixel_limit",
             tempDir,
             json::object({{"crop_expand", 0}, {"crop_expand_mode", "percent"}, {"crop_expand_percent", 20}, {"crop_shape", json::array()}, {"min_size", 1}}),
             largeRotatedResultProps,
@@ -2192,14 +874,14 @@ bool RunImageGenerationExpandRegression(std::string& error) {
 }
 
 int RunImageGenerationExpandSelfTest() {
-    std::cout << "==== AI 裁图外扩参数自测 ====\n";
+    std::cout << "==== image_generation expand selftest ====\n";
     std::string error;
     if (!RunImageGenerationExpandRegression(error)) {
-        std::cout << "AI 裁图外扩参数自测失败: " << error << "\n";
+        std::cout << "image_generation expand selftest failed: " << error << "\n";
         return 1;
     }
 
-    std::cout << "AI 裁图外扩参数自测通过\n";
+    std::cout << "image_generation expand selftest passed\n";
     return 0;
 }
 
@@ -2309,7 +991,7 @@ bool RunCrossModelLabelMergeCase(std::string& error) {
     {
         std::ofstream ofs(flowPath, std::ios::binary);
         if (!ofs) {
-            error = "无法写入临时流程文件";
+            error = "cannot write temp flow file";
             return false;
         }
         ofs << BuildCrossModelLabelMergeFlow().dump(2);
@@ -2317,9 +999,9 @@ bool RunCrossModelLabelMergeCase(std::string& error) {
 
     try {
         dlcv_infer::flow::FlowGraphModel model;
-        const json loadReport = model.Load(flowPath, kGpuDeviceId);
+        const json loadReport = model.Load(flowPath, 0);
         if (!loadReport.is_object() || loadReport.value("code", 1) != 0) {
-            error = std::string("流程加载失败: ") + loadReport.dump();
+            error = std::string("flow load failed: ") + loadReport.dump();
             DeleteFileA(flowPath.c_str());
             return false;
         }
@@ -2327,33 +1009,33 @@ bool RunCrossModelLabelMergeCase(std::string& error) {
         cv::Mat image(200, 200, CV_8UC3, cv::Scalar(0, 0, 0));
         const json inferRoot = model.InferInternal(std::vector<cv::Mat>{image}, json::object());
         if (!inferRoot.is_object() || inferRoot.value("code", 1) != 0) {
-            error = std::string("流程执行失败: ") + inferRoot.dump();
+            error = std::string("flow infer failed: ") + inferRoot.dump();
             DeleteFileA(flowPath.c_str());
             return false;
         }
 
         const json results = inferRoot.contains("result_list") ? inferRoot.at("result_list") : json::array();
         if (!results.is_array() || results.size() != 1) {
-            error = "结果数量错误，actual=" + std::to_string(results.size()) + ", expected=1, root=" + inferRoot.dump();
+            error = "result count mismatch, actual=" + std::to_string(results.size()) + ", expected=1, root=" + inferRoot.dump();
             DeleteFileA(flowPath.c_str());
             return false;
         }
 
         const json& det = results.at(0);
         if (!det.is_object() || !det.contains("category_name") || !det.at("category_name").is_string()) {
-            error = "检测结果缺少 category_name, det=" + det.dump() + ", root=" + inferRoot.dump();
+            error = "detection result missing category_name, det=" + det.dump() + ", root=" + inferRoot.dump();
             DeleteFileA(flowPath.c_str());
             return false;
         }
 
         const std::string cat = det.at("category_name").get<std::string>();
         if (cat != "base-suffix") {
-            error = "合并标签错误，actual=" + cat + ", expected=base-suffix";
+            error = "merged label mismatch, actual=" + cat + ", expected=base-suffix";
             DeleteFileA(flowPath.c_str());
             return false;
         }
     } catch (const std::exception& ex) {
-        error = std::string("异常: ") + ex.what();
+        error = std::string("exception: ") + ex.what();
         DeleteFileA(flowPath.c_str());
         return false;
     }
@@ -2365,78 +1047,10 @@ bool RunCrossModelLabelMergeCase(std::string& error) {
 int RunCrossModelLabelMergeSelfTest() {
     std::string error;
     if (!RunCrossModelLabelMergeCase(error)) {
-        std::cout << "cross_model_label_merge 自测失败: " << error << "\n";
+        std::cout << "cross_model_label_merge selftest failed: " << error << "\n";
         return 1;
     }
-    std::cout << "cross_model_label_merge 自测通过\n";
-    return 0;
-}
-
-int RunBBoxCropFixSelfTest() {
-    std::cout << "==== BBOX 去重与裁图修复自测 ====\n";
-
-    std::string error;
-    if (!RunImageGenerationExpandRegression(error)) {
-        std::cout << "AI 裁图外扩参数逻辑回归失败: " << error << "\n";
-        return 1;
-    }
-    std::cout << "AI 裁图外扩参数逻辑回归通过\n";
-
-    if (!RunBBoxIoUDedupFlowCase(true, 1, error)) {
-        std::cout << "bbox_iou_dedup 默认跨模型自测失败: " << error << "\n";
-        return 1;
-    }
-    if (!RunBBoxIoUDedupNoneVsIdentityCase(error)) {
-        std::cout << "bbox_iou_dedup null/identity 自测失败: " << error << "\n";
-        return 1;
-    }
-
-    std::cout << "==== 苏州三谛 BBOX 裁图实际模型自测 ====\n";
-    if (!FileExistsW(kBBoxCropFixModelAPath)) {
-        std::cout << "模型A不存在: " << WideToUtf8(kBBoxCropFixModelAPath) << "\n";
-        return 2;
-    }
-    if (!FileExistsW(kBBoxCropFixModelBPath)) {
-        std::cout << "模型B不存在: " << WideToUtf8(kBBoxCropFixModelBPath) << "\n";
-        return 2;
-    }
-    if (!FileExistsW(kBBoxCropFixImagePath)) {
-        std::cout << "图像不存在: " << WideToUtf8(kBBoxCropFixImagePath) << "\n";
-        return 2;
-    }
-
-    try {
-        cv::Mat bgr = LoadImageByDecode(kBBoxCropFixImagePath);
-        if (bgr.empty()) throw std::runtime_error("图像解码失败");
-        cv::Mat rgb;
-        cv::cvtColor(bgr, rgb, cv::COLOR_BGR2RGB);
-
-        bool ok = true;
-        ok = RunBBoxCropFixOneModel("A", kBBoxCropFixModelAPath, rgb, 4) && ok;
-        ok = RunBBoxCropFixOneModel("B", kBBoxCropFixModelBPath, rgb, 4) && ok;
-        try { dlcv_infer::Utils::FreeAllModels(); } catch (...) {}
-        if (!ok) return 1;
-    } catch (const std::exception& ex) {
-        std::cout << "苏州三谛实际模型自测异常: " << ex.what() << "\n";
-        return 1;
-    }
-
-    std::cout << "BBOX 去重与裁图修复自测通过\n";
-    return 0;
-}
-
-int RunBBoxIoUDedupSelfTest() {
-    auto fail = [](const std::string& message) -> int {
-        std::cout << "bbox_iou_dedup 自测失败: " << message << "\n";
-        return 1;
-    };
-
-    std::string error;
-    if (!RunBBoxIoUDedupFlowCase(true, 1, error)) return fail(error);
-    if (!RunBBoxIoUDedupFlowCase(false, 2, error)) return fail(error);
-    if (!RunBBoxIoUDedupNoneVsIdentityCase(error)) return fail(error);
-
-    std::cout << "bbox_iou_dedup 自测通过\n";
+    std::cout << "cross_model_label_merge selftest passed\n";
     return 0;
 }
 }  // namespace
@@ -2444,37 +1058,6 @@ int RunBBoxIoUDedupSelfTest() {
 int main(int argc, char* argv[]) {
     SetConsoleOutputCP(CP_UTF8);
     SetConsoleCP(CP_UTF8);
-
-    if (argc <= 1) {
-        return RunBenchmark(
-            kDefaultPressureModelPath,
-            kDefaultPressureImagePath,
-            kDefaultPressureBatchSize,
-            kDefaultPressureRuns,
-            kDefaultPressureWarmup);
-    }
-
-    if (argc >= 2 && std::string(argv[1]) == "demo3check") {
-        const std::wstring model1Path = (argc >= 3) ? Utf8ToWide(argv[2]) : kDemo3Model1Path;
-        const std::wstring model2Path = (argc >= 4) ? Utf8ToWide(argv[3]) : kDemo3Model2Path;
-        const std::wstring chainImagePath = (argc >= 5) ? Utf8ToWide(argv[4]) : kDemo3ChainImagePath;
-        const std::wstring model2SingleImagePath =
-            (argc >= 6) ? Utf8ToWide(argv[5]) : kDemo3Model2SingleImagePath;
-        return RunDemo3Validation(model1Path, model2Path, chainImagePath, model2SingleImagePath);
-    }
-
-    if (argc >= 2 && std::string(argv[1]) == "bench") {
-        if (argc < 4) {
-            std::cout << "用法: dlcv_infer_cpp_test bench <modelPath> <imagePath> [batch] [runs] [warmup]\n";
-            return 2;
-        }
-        const std::wstring modelPath = Utf8ToWide(argv[2]);
-        const std::wstring imagePath = Utf8ToWide(argv[3]);
-        const int batch = (argc >= 5) ? ParsePositiveIntArg(argv[4], kDefaultPressureBatchSize) : kDefaultPressureBatchSize;
-        const int runs = (argc >= 6) ? ParsePositiveIntArg(argv[5], kDefaultPressureRuns) : kDefaultPressureRuns;
-        const int warmup = (argc >= 7) ? ParsePositiveIntArg(argv[6], kDefaultPressureWarmup) : kDefaultPressureWarmup;
-        return RunBenchmark(modelPath, imagePath, batch, runs, warmup);
-    }
 
     if (argc >= 2 && std::string(argv[1]) == "imageprepcheck") {
         return RunImagePrepCheck();
@@ -2488,10 +1071,6 @@ int main(int argc, char* argv[]) {
         return RunBBoxIoUDedupSelfTest();
     }
 
-    if (argc >= 2 && std::string(argv[1]) == "bbox-crop-fix-selftest") {
-        return RunBBoxCropFixSelfTest();
-    }
-
     if (argc >= 2 && std::string(argv[1]) == "image-generation-expand-selftest") {
         return RunImageGenerationExpandSelfTest();
     }
@@ -2500,107 +1079,12 @@ int main(int argc, char* argv[]) {
         return RunCrossModelLabelMergeSelfTest();
     }
 
-    if (argc >= 2 && std::string(argv[1]) == "flow-instance-seg-filter-selftest") {
-        return RunFlowInstanceSegFilterSelfTest();
-    }
-
-    if (argc >= 2 && std::string(argv[1]) == "dvst-double-load-selftest") {
-        return RunDvstDoubleLoadSelfTest();
-    }
-
-    if (argc >= 2 && std::string(argv[1]) == "dvst-single-load-selftest") {
-        return RunDvstSingleLoadSelfTest();
-    }
-
-    if (argc >= 2 && std::string(argv[1]) == "dvst-modelindex-selftest") {
-        return RunDvstModelIndexSelfTest();
-    }
-
-    std::cout << "==== C++ 测试程序 ====\n";
-    std::cout << "模型目录: " << WideToUtf8(kModelRoot) << "\n";
-    std::cout << "固定设备: GPU(" << kGpuDeviceId << ")\n";
-    std::cout << "固定Batch: " << kFixedBatchSize << "\n\n";
-
-    const bool modelRootOk = DirExistsW(kModelRoot);
-    if (!modelRootOk) {
-        std::cout << "模型目录不存在: " << WideToUtf8(kModelRoot) << "\n";
-    }
-
-    // 内存泄露专项：只跑一个实例分割模型
-    std::wstring leakModelPath;
-    std::wstring leakImagePath;
-    std::wstring leakModelFile;
-    if (modelRootOk) {
-        for (const auto& c : kCases) {
-            if (c.modelFile.find(L"实例分割") == std::wstring::npos) continue;
-            const std::wstring mp = JoinPath(kModelRoot, c.modelFile);
-            const std::wstring ip = JoinPath(kModelRoot, c.imageFile);
-            if (!FileExistsW(mp) || !FileExistsW(ip)) continue;
-            leakModelPath = mp;
-            leakImagePath = ip;
-            leakModelFile = c.modelFile;
-            break;
-        }
-    }
-
-    int total = 0;
-    int pass = 0;
-    int skipped = 0;
-    std::vector<CaseRow> rows;
-    rows.reserve(kCases.size());
-    for (const auto& c : kCases) {
-        const std::wstring modelPath = JoinPath(kModelRoot, c.modelFile);
-        const std::wstring imagePath = JoinPath(kModelRoot, c.imageFile);
-        if (!modelRootOk) {
-            rows.push_back(CaseRow{WideToUtf8(c.modelFile), "跳过", "-", "模型目录不存在", "-", "-"});
-            skipped++;
-            continue;
-        }
-        if (!FileExistsW(modelPath) || !FileExistsW(imagePath)) {
-            rows.push_back(CaseRow{WideToUtf8(c.modelFile), "跳过", "-", "模型或图片不存在", "-", "-"});
-            skipped++;
-            continue;
-        }
-        total++;
-        auto row = RunCase(modelPath, imagePath);
-        rows.push_back(row);
-        if (row.loadText.find("成功") == 0 && row.inferText == "成功") pass++;
-    }
-
-    try { dlcv_infer::Utils::FreeAllModels(); } catch (...) {}
-
-    rows.push_back(CaseRow{"汇总",
-                           "总数=" + std::to_string(total),
-                           "成功=" + std::to_string(pass),
-                           "失败=" + std::to_string(total - pass),
-                           "-",
-                           "-"});
-
-    PrintHeader();
-    for (const auto& r : rows) PrintRow(r);
-
-    std::cout << "\n==== 内存泄露专项(仅测1个实例分割模型) ====\n";
-    if (!modelRootOk) {
-        std::cout << "跳过：模型目录不存在\n";
-    } else if (leakModelPath.empty() || leakImagePath.empty()) {
-        std::cout << "跳过：未找到可用实例分割模型\n";
-    } else {
-        std::cout << "模型: " << WideToUtf8(BaseName(leakModelPath)) << "\n";
-        try {
-            const double inc = RunLoadFreeLeak(leakModelPath);
-            std::cout << "加载/释放循环" << kLeakLoopCount << "次内存增量: " << ToFixed(inc, 2) << "MB\n";
-        } catch (...) {
-            std::cout << "加载/释放循环" << kLeakLoopCount << "次内存增量: 错误\n";
-        }
-        try {
-            const double inc = RunInferLeak3s(leakModelPath, leakImagePath);
-            std::cout << "推理" << kSpeedWindowSeconds << "秒内存增量: " << ToFixed(inc, 2) << "MB\n";
-        } catch (...) {
-            std::cout << "推理" << kSpeedWindowSeconds << "秒内存增量: 错误\n";
-        }
-    }
-
-    if (!modelRootOk) return 2;
-    if (total == 0 && skipped > 0) return 2;
-    return total == pass ? 0 : 1;
+    std::cout << "Usage: " << (argc >= 1 ? argv[0] : "dlcv_infer_cpp_test") << " <subcommand>\n";
+    std::cout << "Available subcommands:\n";
+    std::cout << "  imageprepcheck\n";
+    std::cout << "  rect-image-correction-selftest\n";
+    std::cout << "  bbox-iou-dedup-selftest\n";
+    std::cout << "  image-generation-expand-selftest\n";
+    std::cout << "  cross-model-label-merge-selftest\n";
+    return 2;
 }

--- a/Test/dlcv_infer_cpp_test/main.cpp
+++ b/Test/dlcv_infer_cpp_test/main.cpp
@@ -1302,20 +1302,20 @@ int RunDvstModelIndexSelfTest() {
 
     bool ok = true;
     try {
-        std::cout << "[1] 加载 dvst(AOI 流程模型)...\n";
-        dlcv_infer::Model dvstModel(kDvstIndexFlowModelPath, kGpuDeviceId);
-        const int dvstIdx = dvstModel.modelIndex;
-        std::cout << "    dvst modelIndex=" << dvstIdx << "\n";
-
-        std::cout << "[2] 加载 dvt1(猫狗分类)...\n";
+        std::cout << "[1] 加载 dvt1(猫狗分类)...\n";
         dlcv_infer::Model dvt1Model(kDvstIndexDvtCatDogPath, kGpuDeviceId);
         const int dvt1Idx = dvt1Model.modelIndex;
         std::cout << "    dvt1 modelIndex=" << dvt1Idx << "\n";
 
-        std::cout << "[3] 加载 dvt2(气球实例分割)...\n";
+        std::cout << "[2] 加载 dvt2(气球实例分割)...\n";
         dlcv_infer::Model dvt2Model(kDvstIndexDvtBalloonPath, kGpuDeviceId);
         const int dvt2Idx = dvt2Model.modelIndex;
         std::cout << "    dvt2 modelIndex=" << dvt2Idx << "\n";
+
+        std::cout << "[3] 加载 dvst(AOI 流程模型)...\n";
+        dlcv_infer::Model dvstModel(kDvstIndexFlowModelPath, kGpuDeviceId);
+        const int dvstIdx = dvstModel.modelIndex;
+        std::cout << "    dvst modelIndex=" << dvstIdx << "\n";
 
         if (dvstIdx < kFlowIndexBase) {
             std::cout << "FAIL: dvst modelIndex=" << dvstIdx << " 应 >= " << kFlowIndexBase

--- a/dlcv_infer_cpp_dll/dlcv_infer.cpp
+++ b/dlcv_infer_cpp_dll/dlcv_infer.cpp
@@ -1077,6 +1077,16 @@ namespace dlcv_infer {
     static std::mutex g_modelIndexRefMu;
     static std::unordered_map<int, int> g_modelIndexRefCount;
 
+    // dvst（流程模型）的 modelIndex 由本层自管理，从 10000 起递增，
+    // 与底层 dvt 返回的 model_index（0 起递增）分区，避免上层按 modelIndex 索引时 dvst 与 dvt 撞键。
+    static std::mutex g_flowModelIndexMu;
+    static int g_nextFlowModelIndex = 10000;
+
+    static int AllocateFlowModelIndex() {
+        std::lock_guard<std::mutex> lk(g_flowModelIndexMu);
+        return g_nextFlowModelIndex++;
+    }
+
 #ifdef _WIN32
     std::wstring Win32MultiByteToWide(const std::string& input, uint32_t codePage) {
         int len = MultiByteToWideChar(codePage, 0, input.c_str(), -1, nullptr, 0);
@@ -1438,7 +1448,7 @@ namespace dlcv_infer {
                 if (code != 0) {
                     throw std::runtime_error(report.dump());
                 }
-                modelIndex = 1; // dvst 模式下仅作为“已加载”标记
+                modelIndex = AllocateFlowModelIndex();
                 return;
             } catch (const std::exception& ex) {
                 delete _flowModel;
@@ -1502,7 +1512,7 @@ namespace dlcv_infer {
                 if (code != 0) {
                     throw std::runtime_error(report.dump());
                 }
-                modelIndex = 1;
+                modelIndex = AllocateFlowModelIndex();
                 return;
             } catch (const std::exception& ex) {
                 delete _flowModel;

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import shutil
 
 from setuptools import setup
 
-version = '2026.6.23.0a0'
+version = '2026.7.7.0a0'
 
 package_name = "dlcvpro_infer_csharp"  # 包名
 packages: list = [package_name]  # 需要打包的包


### PR DESCRIPTION
## 背景

dvst（流程模型，`.dvst/.dvso/.dvsp`）的 `modelIndex` 原写死为 `1`，仅作"已加载"标记；dvt（普通模型）的 `modelIndex` 由底层 `dlcv_infer` 返回（0,1,2…递增）。

C API 封装层 `dlcv_infer_c_dll` 用 `modelIndex` 作为全局表 `g_models` 的键索引模型。dvst 永远 `1` → 与任何拿到 `model_index=1` 的 dvt 撞键，后加载者覆盖先加载者（`shared_ptr` 计数清零析构），推理传 `index=1` 路由到错误模型；两个 dvst 也互相覆盖，全局表实际只允许一个 dvst。

## 改动（相对 master）

### C++ `dlcv_infer_cpp_dll`
- 新增 dvst modelIndex 自管理分配器：`g_flowModelIndexMu` / `g_nextFlowModelIndex = 10000` / `AllocateFlowModelIndex()`（`dlcv_infer.cpp`）。
- dvst 两处构造（string / wstring）的 `modelIndex = 1` 改为 `AllocateFlowModelIndex()`。
- dvt 维持从底层返回；dvst 不进入 `g_modelIndexRefCount`，`FreeModel` 的 `_isFlowGraphMode` 分支不调底层 unload，与 dvt 生命周期天然隔离。

### C# `DlcvCsharpApi`
- 新增静态分配器 `s_nextFlowModelIndex = 10000` / `AllocateFlowModelIndex()`（`Model.cs`）。
- `InitializeDvsMode`（DVS 流程模型）的 `modelIndex = 1` 改为 `AllocateFlowModelIndex()`。

### 不改：DVP / RPC 模式
- `Model` 构造模式判定顺序：`.dvp`→DVP；`.dvst/.dvso/.dvsp`→DVS（在 RPC 之前截走）；其余 + `rpc_mode=true`→RPC。
- RPC 仅支持 `.dvt` 普通模型，DVP 仅 `.dvp`；C# 推理按实例模式标志分发、不按 `modelIndex` 索引，二者非 dvst/dvt 冲突源。

### 文档
- `AGENTS.md`：新增 model_index 分配约定（普通模型 0 起 / 流程模型 10000 起）。
- `C++ API文档.md`（4.6）、`C# API文档.md`（3.2）：补充 modelIndex 来源说明。

### 测试版本号
- 更新至 `2026.7.7.0a0`（`setup.py` + DlcvDemo/DlcvCsharpApi 的 AssemblyInfo，经 `sync_assembly_version.py` 同步）。

## 验证
- 代码改动 grep 核验：`modelIndex = 1` 仅剩 DVP（`Model.cs`）/RPC。
- 递增器核验：C++ `AllocateFlowModelIndex` 定义 + 2 调用；C# 定义 + 1 调用。
- C# 测试程序已编译打包安装：whl `dlcvpro_infer_csharp-2026.7.7.0a0-cp311-none-win_amd64.whl`，pip 装入 `C:\dlcv`，`DlcvCsharpApi.dll` FileVersion `2026.7.7.0`。

## 测试覆盖范围说明
C# 测试程序（DlcvDemo）直接调用底层 `dlcv_infer.dll`、**不走 `dlcv_infer_cpp_dll`**：本次 C# `Model.cs`（DVS 模式 modelIndex）修复已编入 whl；C++ `dlcv_infer.cpp` / `dlcv_infer_c_dll`（`g_models` 撞键根源）修复**不在 C# whl 内**，需另行编译 C++ dll + C++ 测试程序（如 `dlcv_infer_c_test`）验证。
