### PR TITLE
fix: 深盾开发商过滤与无加密狗时不加载推理 DLL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,8 +151,9 @@ C API 封装层（`dlcv_infer_c_dll`）以 `model_index` 作为全局表键索�
 |-----------|---------|---------|
 | Sentinel | `dlcv_infer.dll` | `C:\dlcv\Lib\site-packages\dlcvpro_infer\dlcv_infer.dll` |
 | Virbox | `dlcv_infer_v.dll` | `C:\dlcv\Lib\site-packages\dlcvpro_infer\dlcv_infer_v.dll` |
+| None / Unknown | 不加载 | — |
 
-自动检测优先级：先检测 Sentinel，再检测 Virbox；均未检测到则回退到 Sentinel。每个 `Model` 实例在加载时绑定自己的 `_dllLoader`，后续所有操作都走该 loader。
+自动检测优先级：先检测 Sentinel，再检测 Virbox；均未检测到则返回 `None`/`Unknown`，不加载任何推理 DLL。每个 `Model` 实例在加载时绑定自己的 `_dllLoader`，后续所有操作都走该 loader。
 
 ## 输入图像处理约定
 

--- a/C# API文档.md
+++ b/C# API文档.md
@@ -288,8 +288,9 @@ public class DllLoader
 |-----------|---------|------|
 | Sentinel | `dlcv_infer.dll` | `C:\dlcv\Lib\site-packages\dlcvpro_infer\dlcv_infer.dll` |
 | Virbox | `dlcv_infer_v.dll` | `C:\dlcv\Lib\site-packages\dlcvpro_infer\dlcv_infer_v.dll` |
+| None（无狗） | 不加载 | — |
 
-**自动检测优先级**：`Instance` 初始化时先检测 Sentinel，再检测 Virbox；均未检测到则回退到 Sentinel。
+**自动检测优先级**：`Instance` 初始化时调用一次 `DogUtils.GetAvailableProviders()`，按 **Sentinel 优先、Virbox 第二** 选择 Provider；均未检测到时返回 `DogProvider.None`，**不加载**任何推理 DLL，也不抛异常。真正加载模型时若仍无授权，再抛出 `未检测到授权`。
 
 **Provider 一致性校验**：`EnsureForModel` 在加载模型前，先读取模型头 `dog_provider` 得到所需 provider，再调用 `DogUtils.GetAvailableProviders()` 获取当前可用授权列表。若所需 provider 不在可用列表中，抛出异常：
 - 可用列表为空时提示 `未检测到授权`。
@@ -598,9 +599,9 @@ C# 侧额外处理 `DV\n` 文件头校验、归档解包、`pipeline.json` 中 `
 `ForModel(string)` 的加载策略：
 - 先通过 `ModelHeaderProviderResolver.TryResolveExplicitProvider` 判断模型头是否**明确指定**了 `dog_provider`。
 - 若**明确指定**（`sentinel` 或 `virbox`），则校验对应加密狗是否存在；不存在时抛出异常，不静默 fallback。
-- 若**未指定**（旧模型或省略该字段），则调用 `AutoDetectProvider()` 自动检测当前插入的加密狗，按 **Sentinel 优先、Virbox 第二** 的顺序选择 Provider；检测不到任何狗时，默认使用 Sentinel。
+- 若**未指定**（旧模型或省略该字段），则调用 `AutoDetectProvider()` 自动检测当前插入的加密狗，按 **Sentinel 优先、Virbox 第二** 的顺序选择 Provider；检测不到任何狗时返回 `DogProvider.None`，不加载推理 DLL。
 
-`Instance`（兼容旧代码的单例）在首次创建时同样调用 `AutoDetectProvider()`，而非硬编码 Sentinel。
+`Instance`（兼容旧代码的单例）在首次创建时同样调用 `AutoDetectProvider()`；无狗时创建空 loader（函数指针均为 null），不加载 `dlcv_infer.dll` / `dlcv_infer_v.dll`。
 
 每个 `Model` 实例在加载时绑定自己的 `_dllLoader`，后续 `GetModelInfoDvt`、`InferInternalDvt`、`FreeModel` 都走该 loader。`Utils` 的 `FreeAllModels`、`GetDeviceInfo`、`KeepMaxClock` 遍历所有已创建 loader 执行。
 

--- a/C#测试程序开发文档.md
+++ b/C#测试程序开发文档.md
@@ -396,11 +396,13 @@
 - 调用 `Utils.FreeAllModels()`
 - `richTextBox1.Text="所有模型已释放"`
 
-#### 7.12 检查加密狗（按钮：`检查加密狗`）
+#### 7.12 检查加密狗（按钮：`检查加密狗`；启动时自动执行一次）
 
-- 调用：`DogUtils.GetAllDogInfo()`
+- 调用：`DogUtils.GetAllDogInfo()`（`ShowDogInfo()`）
 - 输出到 `richTextBox1`（格式必须一致）：
   - `Sentinel加密狗ID：\n{sentinelDeviceList}\n\nSentinel加密狗特性：\n{sentinelFeatureList}\n\nVirbox加密狗ID：\n{virboxDeviceList}\n\nVirbox加密狗特性：\n{virboxFeatureList}`
+- 若 Sentinel/Virbox 的 devices 与 features 均为空：在上述内容前追加一行 `未检测到加密狗\n\n`
+- 启动时在设备列表初始化完成后自动调用一次 `ShowDogInfo()`；无加密狗时不加载推理 DLL
 
 #### 7.13 文档（按钮：`文档`）
 

--- a/C#测试程序开发文档.md
+++ b/C#测试程序开发文档.md
@@ -396,13 +396,13 @@
 - 调用 `Utils.FreeAllModels()`
 - `richTextBox1.Text="所有模型已释放"`
 
-#### 7.12 检查加密狗（按钮：`检查加密狗`；启动时自动执行一次）
+#### 7.12 检查加密狗（按钮：`检查加密狗`）
 
 - 调用：`DogUtils.GetAllDogInfo()`（`ShowDogInfo()`）
 - 输出到 `richTextBox1`（格式必须一致）：
   - `Sentinel加密狗ID：\n{sentinelDeviceList}\n\nSentinel加密狗特性：\n{sentinelFeatureList}\n\nVirbox加密狗ID：\n{virboxDeviceList}\n\nVirbox加密狗特性：\n{virboxFeatureList}`
 - 若 Sentinel/Virbox 的 devices 与 features 均为空：在上述内容前追加一行 `未检测到加密狗\n\n`
-- 启动时在设备列表初始化完成后自动调用一次 `ShowDogInfo()`；无加密狗时不加载推理 DLL
+- 启动流程：先做一次 `GetAllDogInfo()`；**仅当都未检测到时**把结果写到界面并停止（不加载推理 DLL）；检测到加密狗时不自动写界面，继续原逻辑加载推理 DLL
 
 #### 7.13 文档（按钮：`文档`）
 

--- a/C#测试程序开发文档.md
+++ b/C#测试程序开发文档.md
@@ -37,15 +37,17 @@
 
 > 这些依赖用于保证“加载模型/推理/设备枚举/加密狗检查”行为可用。若缺失，会导致对应功能失败或降级（必须与本文档描述一致）。
 
-- **DLCV 推理 DLL（必须）**
-  - `dlcv_infer.dll`（Sentinel）或 `dlcv_infer_v.dll`（Virbox）：必须可被进程加载（通常位于输出目录或系统 PATH，或 SDK 固定路径）
+- **DLCV 推理 DLL（按加密狗加载）**
+  - `dlcv_infer.dll`（Sentinel）或 `dlcv_infer_v.dll`（Virbox）：仅在检测到对应加密狗后由 `DllLoader` 加载
+  - 都未检测到加密狗时：不加载上述 DLL；启动界面提示「未检测到加密狗」
 - **OpenCvSharp 运行时（必须）**
   - `OpenCvSharpExtern.dll` + OpenCV 相关运行时 DLL（由 `OpenCvSharp4.runtime.win` 提供）
 - **GPU 枚举（可选）**
   - `nvml.dll`（NVIDIA 驱动自带）：用于枚举 GPU 名称；失败/缺失时的 UI 表现见 **6.2**
 - **加密狗检查（可选）**
-  - `sntl_adminapi_windows_x64.dll`：用于读取加密狗信息
+  - `sntl_adminapi_windows_x64.dll` / `slm_control.dll`：用于读取加密狗信息
   - 缺失时：`检查加密狗` 输出为空数组（`[]`），不应崩溃
+  - 启动时先调用一次 `GetAllDogInfo()`；仅当都未检测到时写界面并停止加载推理 DLL
 - **RPC 模式（按需）**
   - `AIModelRPC.exe`：优先从 `DlcvDemo` 输出目录启动；若不存在，可使用 SDK 固定路径（如 `C:\dlcv\Lib\site-packages\dlcvpro_infer_csharp\AIModelRPC.exe`）
 - **DVP 模式（按需，加载 `.dvp` 时启用）**

--- a/C++ API文档.md
+++ b/C++ API文档.md
@@ -102,7 +102,7 @@ struct FlowBatchResult {
 ```cpp
 class DllLoader {
 public:
-    // 获取全局单例；首次调用自动检测加密狗类型并加载对应 DLL
+    // 获取全局单例；首次调用自动检测加密狗类型，有狗时加载对应 DLL，无狗时不加载
     static DllLoader& Instance();
 
     // 根据模型头中的 dog_provider 字段，确保加载正确的 DLL
@@ -142,8 +142,9 @@ private:
 |-----------|---------|------|
 | Sentinel | `dlcv_infer.dll` | `C:\dlcv\Lib\site-packages\dlcvpro_infer\dlcv_infer.dll` |
 | Virbox | `dlcv_infer_v.dll` | `C:\dlcv\Lib\site-packages\dlcvpro_infer\dlcv_infer_v.dll` |
+| Unknown（无狗） | 不加载 | — |
 
-**自动检测优先级**：先检测 Sentinel，再检测 Virbox；均未检测到则回退到 Sentinel。
+**自动检测优先级**：先检测 Sentinel，再检测 Virbox；均未检测到则返回 `DogProvider::Unknown`，**不加载**任何推理 DLL，也不抛异常。真正加载模型时若仍无授权，再抛出 `未检测到授权`。
 
 ---
 
@@ -548,8 +549,9 @@ auto nodes = dlcv_infer::Model::GetLastFlowNodeTimings();
 
 | 组件 | 当前加载方式 | 缺失时行为 |
 | --- | --- | --- |
-| `dlcv_infer.dll` | Sentinel 版本；`DllLoader::ForProvider(DogProvider::Sentinel)` 加载；`Instance()` 与 `ForModel` 在未明确指定 provider 时，通过 `AutoDetectProvider()` 自动检测当前加密狗并按 Sentinel 优先、Virbox 第二选择；先按系统搜索路径查找，再回退到 `C:\dlcv\Lib\site-packages\dlcvpro_infer\dlcv_infer.dll` | 弹框 `需要先安装 dlcv_infer`，并抛出 `need install dlcv_infer first` |
-| `dlcv_infer_v.dll` | Virbox 版本；`DllLoader::ForProvider(DogProvider::Virbox)` 加载；仅在模型头明确指定 `dog_provider=virbox` 或 `AutoDetectProvider()` 检测到 Virbox 且未检测到 Sentinel 时启用；查找顺序为系统搜索路径，再到 `C:\dlcv\Lib\site-packages\dlcvpro_infer\dlcv_infer_v.dll` | 弹框 `需要先安装 dlcv_infer`，并抛出 `need install dlcv_infer first` |
+| `dlcv_infer.dll` | Sentinel 版本；`AutoDetectProvider()` 检测到 Sentinel 时加载；先按系统搜索路径查找，再回退到 `C:\dlcv\Lib\site-packages\dlcvpro_infer\dlcv_infer.dll` | 弹框 `需要先安装 dlcv_infer`，并抛出 `need install dlcv_infer first` |
+| `dlcv_infer_v.dll` | Virbox 版本；仅在模型头明确指定 `dog_provider=virbox`，或 `AutoDetectProvider()` 检测到 Virbox 且未检测到 Sentinel 时启用；查找顺序为系统搜索路径，再到 `C:\dlcv\Lib\site-packages\dlcvpro_infer\dlcv_infer_v.dll` | 弹框 `需要先安装 dlcv_infer`，并抛出 `need install dlcv_infer first` |
+| 无加密狗 | `AutoDetectProvider()` 返回 `DogProvider::Unknown`；创建空 `DllLoader`，不 `LoadLibrary` 任何推理 DLL | 不弹框、不抛异常；加载模型时再报「未检测到授权」 |
 | `sntl_adminapi_windows_x64.dll` | `SNTLDllLoader` 先按系统搜索路径查找，再回退到 `C:\dlcv\bin\sntl_adminapi_windows_x64.dll` | 切换为空代理：`context_new/get` 返回 `SNTL_ADMIN_LM_NOT_FOUND`，`context_delete` 返回成功，`free` 为空函数 |
 | `nvml.dll` | `Utils::GetGpuInfo()` 与 NVML 包装函数运行时 `LoadLibraryA("nvml.dll")` | `GetGpuInfo()` 返回错误 JSON；初始化失败时 `code=1`，取设备数失败时 `code=2` |
 

--- a/C++测试程序开发文档.md
+++ b/C++测试程序开发文档.md
@@ -182,9 +182,11 @@ int main(int argc, char* argv[]) {
 
 1. 点击 **检查加密狗**。
 2. 文本区显示 Sentinel 和 Virbox 的设备和特性列表。
+3. 若两者均为空，表示未检测到加密狗；此时 `DllLoader` 不加载推理 DLL。
 
 **代码路径**：`MainWindow::onCheckDog()`
 - 调用 `dlcv_infer::GetAllDogInfo()`。
+- 底层 `AutoDetectProvider()`：Sentinel 优先、Virbox 第二；都没有返回 `Unknown`，不加载 `dlcv_infer.dll` / `dlcv_infer_v.dll`。
 
 ---
 

--- a/DlcvCsharpApi/DllLoader.cs
+++ b/DlcvCsharpApi/DllLoader.cs
@@ -154,21 +154,13 @@ namespace dlcv_infer_csharp
 
         private static DogProvider AutoDetectProvider()
         {
-            try
-            {
-                var sentinel = DogUtils.GetSentinelInfo();
-                if (sentinel != null && ((sentinel.Devices != null && sentinel.Devices.Count > 0) || (sentinel.Features != null && sentinel.Features.Count > 0)))
-                    return DogProvider.Sentinel;
-            }
-            catch { }
-            try
-            {
-                var virbox = DogUtils.GetVirboxInfo();
-                if (virbox != null && ((virbox.Devices != null && virbox.Devices.Count > 0) || (virbox.Features != null && virbox.Features.Count > 0)))
-                    return DogProvider.Virbox;
-            }
-            catch { }
-            return DogProvider.Sentinel;
+            // 只做一次加密狗检测：先 Sentinel 再 Virbox；都没有则不加载任何推理 DLL
+            List<DogProvider> available = DogUtils.GetAvailableProviders();
+            if (available.Contains(DogProvider.Sentinel))
+                return DogProvider.Sentinel;
+            if (available.Contains(DogProvider.Virbox))
+                return DogProvider.Virbox;
+            throw new Exception("未检测到授权");
         }
 
         private static DogProvider? ResolveProviderFromHeader(string modelPath)

--- a/DlcvCsharpApi/DllLoader.cs
+++ b/DlcvCsharpApi/DllLoader.cs
@@ -105,6 +105,8 @@ namespace dlcv_infer_csharp
         {
             switch (provider)
             {
+                case DogProvider.None:
+                    return "无";
                 case DogProvider.Sentinel:
                     return "Sentinel";
                 case DogProvider.Virbox:
@@ -136,6 +138,12 @@ namespace dlcv_infer_csharp
             loader.LoadedDogProvider = provider;
             switch (provider)
             {
+                case DogProvider.None:
+                    // 只执行加密狗检测，不加载推理 DLL
+                    loader.DllName = null;
+                    loader.DllPath = null;
+                    loader.LoadedNativeDllName = null;
+                    return loader;
                 case DogProvider.Sentinel:
                     loader.DllName = "dlcv_infer.dll";
                     loader.DllPath = @"C:\dlcv\Lib\site-packages\dlcvpro_infer\dlcv_infer.dll";
@@ -154,13 +162,13 @@ namespace dlcv_infer_csharp
 
         private static DogProvider AutoDetectProvider()
         {
-            // 只做一次加密狗检测：先 Sentinel 再 Virbox；都没有则不加载任何推理 DLL
+            // 只做一次加密狗检测：先 Sentinel 再 Virbox；都没有则不加载任何推理 DLL，也不抛异常
             List<DogProvider> available = DogUtils.GetAvailableProviders();
             if (available.Contains(DogProvider.Sentinel))
                 return DogProvider.Sentinel;
             if (available.Contains(DogProvider.Virbox))
                 return DogProvider.Virbox;
-            throw new Exception("未检测到授权");
+            return DogProvider.None;
         }
 
         private static DogProvider? ResolveProviderFromHeader(string modelPath)

--- a/DlcvCsharpApi/Model.cs
+++ b/DlcvCsharpApi/Model.cs
@@ -83,8 +83,8 @@ namespace dlcv_infer_csharp
 
         }
 
-        public DogProvider LoadedDogProvider => _dllLoader?.LoadedDogProvider ?? DogProvider.Sentinel;
-        public string LoadedNativeDllName => _dllLoader?.LoadedNativeDllName ?? "dlcv_infer.dll";
+        public DogProvider LoadedDogProvider => _dllLoader?.LoadedDogProvider ?? DogProvider.None;
+        public string LoadedNativeDllName => _dllLoader?.LoadedNativeDllName;
 
         public Model(string modelPath, int device_id, bool rpc_mode = false, bool enableCache = false)
         {
@@ -303,6 +303,10 @@ namespace dlcv_infer_csharp
         {
             DllLoader.EnsureForModel(modelPath);
             _dllLoader = DllLoader.Instance;
+            if (_dllLoader == null || _dllLoader.dlcv_load_model == null)
+            {
+                throw new Exception("未检测到授权");
+            }
 
             var setting = new JsonSerializerSettings() { StringEscapeHandling = StringEscapeHandling.EscapeNonAscii };
 

--- a/DlcvCsharpApi/Properties/AssemblyInfo.cs
+++ b/DlcvCsharpApi/Properties/AssemblyInfo.cs
@@ -29,6 +29,6 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.7.7.0")]
-[assembly: AssemblyFileVersion("2026.7.7.0")]
-[assembly: AssemblyInformationalVersion("2026.7.7.0a0")]
+[assembly: AssemblyVersion("2026.7.13.0")]
+[assembly: AssemblyFileVersion("2026.7.13.0")]
+[assembly: AssemblyInformationalVersion("2026.7.13.0")]

--- a/DlcvCsharpApi/sntl_admin_csharp.cs
+++ b/DlcvCsharpApi/sntl_admin_csharp.cs
@@ -690,6 +690,7 @@ namespace sntl_admin_csharp
 
     public enum DogProvider
     {
+        None,
         Sentinel,
         Virbox
     }

--- a/DlcvCsharpApi/sntl_admin_csharp.cs
+++ b/DlcvCsharpApi/sntl_admin_csharp.cs
@@ -380,6 +380,8 @@ namespace sntl_admin_csharp
         private const string DllPath = @"C:\dlcv\bin\slm_control.dll";
         private const uint SS_OK = 0;
         private const uint INFO_FORMAT_JSON = 2;
+        // 深度视觉开发商 ID
+        private const string DlcvDeveloperId = "0800000000002866";
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         private delegate uint ClientOpenDelegate(ref IntPtr ipc);
@@ -525,21 +527,31 @@ namespace sntl_admin_csharp
             }
 
             JToken root = ParseJson(ReadAndFree(descPtr));
+            // 仅保留深度视觉开发商的锁
             if (root is JObject obj)
             {
-                result.Add(obj);
+                if (IsDlcvDeveloper(obj))
+                {
+                    result.Add(obj);
+                }
             }
             else if (root is JArray array)
             {
                 foreach (JToken item in array)
                 {
-                    if (item is JObject itemObj)
+                    if (item is JObject itemObj && IsDlcvDeveloper(itemObj))
                     {
                         result.Add(itemObj);
                     }
                 }
             }
             return result;
+        }
+
+        private static bool IsDlcvDeveloper(JObject desc)
+        {
+            string developerId = FirstStringByKeys(desc, new[] { "developer_id", "owner_developer_id" });
+            return developerId == DlcvDeveloperId;
         }
 
         private string ReadAndFree(IntPtr ptr)

--- a/DlcvDemo/Form1.cs
+++ b/DlcvDemo/Form1.cs
@@ -102,7 +102,7 @@ namespace DlcvDemo
             var info = Utils.GetDeviceInfo();
             Console.WriteLine(info.ToString());
 
-            DllLoader.Instance.dlcv_keep_max_clock();
+            DllLoader.Instance.dlcv_keep_max_clock?.Invoke();
         }
 
         private dynamic model;

--- a/DlcvDemo/Form1.cs
+++ b/DlcvDemo/Form1.cs
@@ -97,12 +97,70 @@ namespace DlcvDemo
                 {
                     comboBox1.SelectedIndex = 0; // 选择CPU
                 }
+
+                // 启动时只做加密狗检测并显示结果，不强制加载推理 DLL
+                ShowDogInfo();
             });
 
-            var info = Utils.GetDeviceInfo();
-            Console.WriteLine(info.ToString());
+            // 有加密狗时再加载对应推理 DLL 并保持最高时钟；无狗则跳过，避免卡死/闪退
+            if (DllLoader.Instance.LoadedDogProvider != sntl_admin_csharp.DogProvider.None)
+            {
+                try
+                {
+                    var info = Utils.GetDeviceInfo();
+                    Console.WriteLine(info.ToString());
+                    DllLoader.Instance.dlcv_keep_max_clock?.Invoke();
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine("GetDeviceInfo/keep_max_clock failed: " + ex.Message);
+                }
+            }
+        }
 
-            DllLoader.Instance.dlcv_keep_max_clock?.Invoke();
+        /// <summary>
+        /// 查询 Sentinel/Virbox 加密狗信息并显示到 richTextBox1。
+        /// 都未检测到时明确提示「未检测到加密狗」。
+        /// </summary>
+        private void ShowDogInfo()
+        {
+            JObject allInfo;
+            try
+            {
+                allInfo = sntl_admin_csharp.DogUtils.GetAllDogInfo();
+            }
+            catch
+            {
+                allInfo = new JObject
+                {
+                    ["sentinel"] = new JObject { ["devices"] = new JArray(), ["features"] = new JArray() },
+                    ["virbox"] = new JObject { ["devices"] = new JArray(), ["features"] = new JArray() }
+                };
+            }
+
+            JObject sentinel = allInfo["sentinel"] as JObject ?? new JObject { ["devices"] = new JArray(), ["features"] = new JArray() };
+            JObject virbox = allInfo["virbox"] as JObject ?? new JObject { ["devices"] = new JArray(), ["features"] = new JArray() };
+
+            JArray sentinelDevices = sentinel["devices"] as JArray ?? new JArray();
+            JArray sentinelFeatures = sentinel["features"] as JArray ?? new JArray();
+            JArray virboxDevices = virbox["devices"] as JArray ?? new JArray();
+            JArray virboxFeatures = virbox["features"] as JArray ?? new JArray();
+
+            string text =
+                "Sentinel加密狗ID：\n" + sentinelDevices.ToString() + "\n\n" +
+                "Sentinel加密狗特性：\n" + sentinelFeatures.ToString() + "\n\n" +
+                "Virbox加密狗ID：\n" + virboxDevices.ToString() + "\n\n" +
+                "Virbox加密狗特性：\n" + virboxFeatures.ToString();
+
+            bool noDog =
+                sentinelDevices.Count == 0 && sentinelFeatures.Count == 0 &&
+                virboxDevices.Count == 0 && virboxFeatures.Count == 0;
+            if (noDog)
+            {
+                text = "未检测到加密狗\n\n" + text;
+            }
+
+            richTextBox1.Text = text;
         }
 
         private dynamic model;
@@ -821,28 +879,7 @@ namespace DlcvDemo
 
         private void button1_Click(object sender, EventArgs e)
         {
-            JObject allInfo;
-            try
-            {
-                allInfo = sntl_admin_csharp.DogUtils.GetAllDogInfo();
-            }
-            catch
-            {
-                allInfo = new JObject
-                {
-                    ["sentinel"] = new JObject { ["devices"] = new JArray(), ["features"] = new JArray() },
-                    ["virbox"] = new JObject { ["devices"] = new JArray(), ["features"] = new JArray() }
-                };
-            }
-
-            JObject sentinel = allInfo["sentinel"] as JObject ?? new JObject { ["devices"] = new JArray(), ["features"] = new JArray() };
-            JObject virbox = allInfo["virbox"] as JObject ?? new JObject { ["devices"] = new JArray(), ["features"] = new JArray() };
-
-            richTextBox1.Text =
-                "Sentinel加密狗ID：\n" + (sentinel["devices"] ?? new JArray()).ToString() + "\n\n" +
-                "Sentinel加密狗特性：\n" + (sentinel["features"] ?? new JArray()).ToString() + "\n\n" +
-                "Virbox加密狗ID：\n" + (virbox["devices"] ?? new JArray()).ToString() + "\n\n" +
-                "Virbox加密狗特性：\n" + (virbox["features"] ?? new JArray()).ToString();
+            ShowDogInfo();
         }
 
         private void button_free_all_model_Click(object sender, EventArgs e)

--- a/DlcvDemo/Form1.cs
+++ b/DlcvDemo/Form1.cs
@@ -58,6 +58,10 @@ namespace DlcvDemo
             Thread.Sleep(1);
             JObject device_info = Utils.GetGpuInfo();
 
+            // 启动时先做一次加密狗检测：都没有则只展示结果、不加载推理 DLL
+            JObject allDogInfo = QueryAllDogInfo();
+            bool hasDog = HasAnyDog(allDogInfo);
+
             Invoke((MethodInvoker)delegate
             {
                 // 清空现有项目和映射表
@@ -98,49 +102,63 @@ namespace DlcvDemo
                     comboBox1.SelectedIndex = 0; // 选择CPU
                 }
 
-                // 启动时只做加密狗检测并显示结果，不强制加载推理 DLL
-                ShowDogInfo();
+                // 仅在检测不到加密狗时，把检测结果显示到界面提醒用户
+                if (!hasDog)
+                {
+                    richTextBox1.Text = FormatDogInfoText(allDogInfo, prependNoDogHint: true);
+                }
             });
 
-            // 有加密狗时再加载对应推理 DLL 并保持最高时钟；无狗则跳过，避免卡死/闪退
-            if (DllLoader.Instance.LoadedDogProvider != sntl_admin_csharp.DogProvider.None)
+            if (!hasDog)
             {
-                try
-                {
-                    var info = Utils.GetDeviceInfo();
-                    Console.WriteLine(info.ToString());
-                    DllLoader.Instance.dlcv_keep_max_clock?.Invoke();
-                }
-                catch (Exception ex)
-                {
-                    Console.WriteLine("GetDeviceInfo/keep_max_clock failed: " + ex.Message);
-                }
+                return;
+            }
+
+            // 检测到加密狗后再加载对应推理 DLL，并保持最高时钟
+            try
+            {
+                var info = Utils.GetDeviceInfo();
+                Console.WriteLine(info.ToString());
+                DllLoader.Instance.dlcv_keep_max_clock?.Invoke();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("GetDeviceInfo/keep_max_clock failed: " + ex.Message);
             }
         }
 
-        /// <summary>
-        /// 查询 Sentinel/Virbox 加密狗信息并显示到 richTextBox1。
-        /// 都未检测到时明确提示「未检测到加密狗」。
-        /// </summary>
-        private void ShowDogInfo()
+        private static JObject QueryAllDogInfo()
         {
-            JObject allInfo;
             try
             {
-                allInfo = sntl_admin_csharp.DogUtils.GetAllDogInfo();
+                return sntl_admin_csharp.DogUtils.GetAllDogInfo();
             }
             catch
             {
-                allInfo = new JObject
+                return new JObject
                 {
                     ["sentinel"] = new JObject { ["devices"] = new JArray(), ["features"] = new JArray() },
                     ["virbox"] = new JObject { ["devices"] = new JArray(), ["features"] = new JArray() }
                 };
             }
+        }
 
+        private static bool HasAnyDog(JObject allInfo)
+        {
+            JObject sentinel = allInfo["sentinel"] as JObject ?? new JObject();
+            JObject virbox = allInfo["virbox"] as JObject ?? new JObject();
+            JArray sentinelDevices = sentinel["devices"] as JArray ?? new JArray();
+            JArray sentinelFeatures = sentinel["features"] as JArray ?? new JArray();
+            JArray virboxDevices = virbox["devices"] as JArray ?? new JArray();
+            JArray virboxFeatures = virbox["features"] as JArray ?? new JArray();
+            return sentinelDevices.Count > 0 || sentinelFeatures.Count > 0
+                || virboxDevices.Count > 0 || virboxFeatures.Count > 0;
+        }
+
+        private static string FormatDogInfoText(JObject allInfo, bool prependNoDogHint)
+        {
             JObject sentinel = allInfo["sentinel"] as JObject ?? new JObject { ["devices"] = new JArray(), ["features"] = new JArray() };
             JObject virbox = allInfo["virbox"] as JObject ?? new JObject { ["devices"] = new JArray(), ["features"] = new JArray() };
-
             JArray sentinelDevices = sentinel["devices"] as JArray ?? new JArray();
             JArray sentinelFeatures = sentinel["features"] as JArray ?? new JArray();
             JArray virboxDevices = virbox["devices"] as JArray ?? new JArray();
@@ -152,15 +170,21 @@ namespace DlcvDemo
                 "Virbox加密狗ID：\n" + virboxDevices.ToString() + "\n\n" +
                 "Virbox加密狗特性：\n" + virboxFeatures.ToString();
 
-            bool noDog =
-                sentinelDevices.Count == 0 && sentinelFeatures.Count == 0 &&
-                virboxDevices.Count == 0 && virboxFeatures.Count == 0;
-            if (noDog)
+            if (prependNoDogHint)
             {
                 text = "未检测到加密狗\n\n" + text;
             }
+            return text;
+        }
 
-            richTextBox1.Text = text;
+        /// <summary>
+        /// 「检查加密狗」按钮：查询并显示 Sentinel/Virbox 信息。
+        /// </summary>
+        private void ShowDogInfo()
+        {
+            JObject allInfo = QueryAllDogInfo();
+            bool noDog = !HasAnyDog(allInfo);
+            richTextBox1.Text = FormatDogInfoText(allInfo, prependNoDogHint: noDog);
         }
 
         private dynamic model;

--- a/DlcvDemo/Properties/AssemblyInfo.cs
+++ b/DlcvDemo/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.7.7.0")]
-[assembly: AssemblyFileVersion("2026.7.7.0")]
-[assembly: AssemblyInformationalVersion("2026.7.7.0a0")]
+[assembly: AssemblyVersion("2026.7.13.0")]
+[assembly: AssemblyFileVersion("2026.7.13.0")]
+[assembly: AssemblyInformationalVersion("2026.7.13.0")]
 [assembly: NeutralResourcesLanguage("zh-CN")]

--- a/dlcv_infer_cpp_dll/dlcv_infer.cpp
+++ b/dlcv_infer_cpp_dll/dlcv_infer.cpp
@@ -1172,6 +1172,12 @@ namespace dlcv_infer {
 
     DllLoader::DllLoader(sntl_admin::DogProvider provider) : dogProvider(provider) {
         switch (provider) {
+        case sntl_admin::DogProvider::Unknown:
+            // 只执行加密狗检测，不加载推理 DLL
+            dllName.clear();
+            dllPath.clear();
+            dllDevPath.clear();
+            return;
         case sntl_admin::DogProvider::Sentinel:
 #ifdef _WIN32
             dllName = "dlcv_infer.dll";
@@ -1305,7 +1311,7 @@ namespace dlcv_infer {
     }
 
     sntl_admin::DogProvider DllLoader::AutoDetectProvider() {
-        // 只做一次加密狗检测：先 Sentinel 再 Virbox；都没有则不加载任何推理 DLL
+        // 只做一次加密狗检测：先 Sentinel 再 Virbox；都没有则不加载任何推理 DLL，也不抛异常
         auto available = sntl_admin::DogUtils::GetAvailableProviders();
         for (const auto& p : available) {
             if (p == sntl_admin::DogProvider::Sentinel) {
@@ -1317,7 +1323,7 @@ namespace dlcv_infer {
                 return sntl_admin::DogProvider::Virbox;
             }
         }
-        throw std::runtime_error("未检测到授权");
+        return sntl_admin::DogProvider::Unknown;
     }
 
     DllLoader& DllLoader::Instance() {
@@ -1463,6 +1469,9 @@ namespace dlcv_infer {
         _dllLoader = &DllLoader::Instance();
         _loadedDogProvider = _dllLoader->GetDogProvider();
         _loadedNativeDllName = _dllLoader->GetLoadedNativeDllName();
+        if (!_dllLoader->GetLoadModelFunc()) {
+            throw std::runtime_error("未检测到授权");
+        }
 
         json config;
         config["model_path"] = modelPathUtf8;
@@ -1527,6 +1536,9 @@ namespace dlcv_infer {
         _dllLoader = &DllLoader::Instance();
         _loadedDogProvider = _dllLoader->GetDogProvider();
         _loadedNativeDllName = _dllLoader->GetLoadedNativeDllName();
+        if (!_dllLoader->GetLoadModelFunc()) {
+            throw std::runtime_error("未检测到授权");
+        }
 
         json config;
         config["model_path"] = modelPathUtf8;
@@ -2189,6 +2201,9 @@ namespace dlcv_infer {
         _dllLoader = &DllLoader::Instance();
         _loadedDogProvider = _dllLoader->GetDogProvider();
         _loadedNativeDllName = _dllLoader->GetLoadedNativeDllName();
+        if (!_dllLoader->GetLoadModelFunc()) {
+            throw std::runtime_error("未检测到授权");
+        }
 
         json config;
         config["type"] = "sliding_window_pipeline";

--- a/dlcv_infer_cpp_dll/dlcv_infer.cpp
+++ b/dlcv_infer_cpp_dll/dlcv_infer.cpp
@@ -1305,21 +1305,19 @@ namespace dlcv_infer {
     }
 
     sntl_admin::DogProvider DllLoader::AutoDetectProvider() {
-        try {
-            auto sentinel = sntl_admin::DogUtils::GetSentinelInfo();
-            if (sentinel.provider != sntl_admin::DogProvider::Unknown) {
+        // 只做一次加密狗检测：先 Sentinel 再 Virbox；都没有则不加载任何推理 DLL
+        auto available = sntl_admin::DogUtils::GetAvailableProviders();
+        for (const auto& p : available) {
+            if (p == sntl_admin::DogProvider::Sentinel) {
                 return sntl_admin::DogProvider::Sentinel;
             }
-        } catch (...) {}
-
-        try {
-            auto virbox = sntl_admin::DogUtils::GetVirboxInfo();
-            if (virbox.provider != sntl_admin::DogProvider::Unknown) {
+        }
+        for (const auto& p : available) {
+            if (p == sntl_admin::DogProvider::Virbox) {
                 return sntl_admin::DogProvider::Virbox;
             }
-        } catch (...) {}
-
-        return sntl_admin::DogProvider::Sentinel;
+        }
+        throw std::runtime_error("未检测到授权");
     }
 
     DllLoader& DllLoader::Instance() {

--- a/dlcv_infer_cpp_dll/dlcv_infer.h
+++ b/dlcv_infer_cpp_dll/dlcv_infer.h
@@ -116,7 +116,7 @@ namespace dlcv_infer {
 
         /// <summary>
         /// 自动检测当前插入的加密狗，按 Sentinel 优先、Virbox 第二返回 Provider。
-        /// 若均未检测到，默认返回 Sentinel。
+        /// 若均未检测到，抛出异常，不加载任何推理 DLL。
         /// </summary>
         static sntl_admin::DogProvider AutoDetectProvider();
 

--- a/dlcv_infer_cpp_dll/dlcv_infer.h
+++ b/dlcv_infer_cpp_dll/dlcv_infer.h
@@ -116,7 +116,7 @@ namespace dlcv_infer {
 
         /// <summary>
         /// 自动检测当前插入的加密狗，按 Sentinel 优先、Virbox 第二返回 Provider。
-        /// 若均未检测到，抛出异常，不加载任何推理 DLL。
+        /// 若均未检测到，返回 Unknown，不加载任何推理 DLL。
         /// </summary>
         static sntl_admin::DogProvider AutoDetectProvider();
 

--- a/dlcv_infer_cpp_dll/dlcv_sntl_admin.cpp
+++ b/dlcv_infer_cpp_dll/dlcv_sntl_admin.cpp
@@ -149,6 +149,16 @@ namespace {
         return text;
     }
 
+    // 深度视觉开发商 ID
+    const char* kDlcvVirboxDeveloperId = "0800000000002866";
+
+    std::string FirstStringByKeys(const nlohmann::json& value, const std::vector<std::string>& keys);
+
+    bool IsDlcvDeveloper(const nlohmann::json& desc) {
+        std::string developer_id = FirstStringByKeys(desc, { "developer_id", "owner_developer_id" });
+        return developer_id == kDlcvVirboxDeveloperId;
+    }
+
     std::vector<nlohmann::json> GetVirboxDescriptions(void* ipc, VirboxControlApi& api) {
         char* desc = nullptr;
         int status = api.get_all_description(ipc, VIRBOX_JSON, &desc);
@@ -158,9 +168,14 @@ namespace {
         }
 
         nlohmann::json root = ParseJsonSafe(ReadAndFree(api, desc));
+        // 仅保留深度视觉开发商的锁
         if (root.is_object())
         {
-            return { root };
+            if (IsDlcvDeveloper(root))
+            {
+                return { root };
+            }
+            return {};
         }
         if (!root.is_array())
         {
@@ -170,7 +185,7 @@ namespace {
         std::vector<nlohmann::json> result;
         for (const auto& item : root)
         {
-            if (item.is_object())
+            if (item.is_object() && IsDlcvDeveloper(item))
             {
                 result.push_back(item);
             }

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import shutil
 
 from setuptools import setup
 
-version = '2026.7.7.0a0'
+version = '2026.7.13.0'
 
 package_name = "dlcvpro_infer_csharp"  # 包名
 packages: list = [package_name]  # 需要打包的包


### PR DESCRIPTION
## 变更

1. **Virbox 开发商过滤**  
   枚举时仅保留 `developer_id == 0800000000002866` 的深盾狗，避免别家狗误判为可用并加载 `dlcv_infer_v.dll`。

2. **无加密狗时不加载推理 DLL**  
   `AutoDetectProvider`（C# / C++）只调用一次 `GetAvailableProviders()`：
   - 有 Sentinel → 加载 `dlcv_infer.dll`
   - 无 Sentinel 有 Virbox → 加载 `dlcv_infer_v.dll`
   - 都没有 → 返回 `None`/`Unknown`，创建空 loader，**不 `LoadLibrary`**，不抛异常

3. **C# 测试程序启动**  
   - 启动只做一次 `GetAllDogInfo()`
   - **仅当都未检测到** → 界面显示「未检测到加密狗」+ 空列表，并停止后续 DLL 加载
   - **有狗** → 不自动写界面，继续原逻辑加载对应推理 DLL
   - 「检查加密狗」按钮仍可手动查询并显示

4. **文档同步**  
   已更新 `C# API文档.md`、`C++ API文档.md`、`C#测试程序开发文档.md`、`C++测试程序开发文档.md`、`AGENTS.md`。

## 涉及文件

- `DlcvCsharpApi/sntl_admin_csharp.cs`（`DogProvider.None` + 开发商过滤）
- `DlcvCsharpApi/DllLoader.cs` / `Model.cs`
- `DlcvDemo/Form1.cs`
- `dlcv_infer_cpp_dll/dlcv_sntl_admin.cpp` / `dlcv_infer.cpp` / `dlcv_infer.h`
- 上述文档

## 验证

| 场景 | 结果 |
|---|---|
| 官方 `1_编译打包.bat` + `2_安装新版.bat` | 已执行，版本 `2026.7.13.0` |
| 无狗启动 | 不闪退、不加载 `dlcv_infer.dll`；界面提示「未检测到加密狗」 |
| 有狗启动 | 正常加载对应推理 DLL；不自动覆盖界面 |
| 开发商过滤（双狗） | 仅保留自家狗 `A67700000058` |

## 请验收

运行：
```text
C:\dlcv\Lib\site-packages\dlcvpro_infer_csharp\C# 测试程序.exe
```
