### PR TITLE
fix: 修正流程模型阈值职责并补齐命令行验证

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,17 +23,17 @@ OpenIVS 是一个 .NET WPF 工业视觉框架。**本 AGENTS.md 聚焦 API 层�
 - **禁止直接调用** `msbuild`、`dotnet`、`devenv` 或其他本地 shell 编译命令
 - **默认构建参数**：`Debug`、`x64`、`Build`、`minimal`
 - 用户明确指定 `Release`、`Rebuild`、`Clean` 等参数时，按指定值执行
-- .NET 项目通过 Visual Studio 或 `dotnet build` 编译
-- C++ 项目通过 Visual Studio 编译（x64 Release）
+- .NET 与 C++ 项目均通过 `.cursor/skills/vs-build/scripts/build.py` 调用 Visual Studio 工具链编译
 - Qt 项目需配置 Qt 路径和 OpenCV 路径
 - 构建前需确保深度视觉 SDK 已正确安装（`dlcv_infer.dll` 可用）
 - WPF 框架额外需要海康 MVS 安装
 
 ## 统一运行与验证输入规则
 
-- 本仓库所有程序、测试程序、自测入口、验证入口和临时排查入口均**禁止使用命令行传参**覆盖模型路径、图片路径、batch、阈值、运行次数、线程数或其他业务输入。
-- 需要切换验证输入时，只修改源码中的固定变量、常量字符串或配置对象字段。
-- 控制台测试程序也遵守该规则；验证时不通过 shell 命令行追加参数。
+- `DlcvDemo` 与 `dlcv_infer_cpp_qt_demo` 支持文档中定义的 `infer` 命令行模式，用于传入模型、图片、阈值、设备和 mask 开关并执行无界面自动验证。
+- 两个实际测试程序无命令行参数时仍启动原 GUI，不改变桌面交互行为。
+- 其他程序、自测入口和临时排查入口仅使用各自文档中已经定义的参数；未记录的业务输入通过源码固定变量或配置对象字段设置。
+- 命令行推理模式输出结构化与 JSON 两条 API 路径的结果摘要，并以退出码区分成功、运行错误、参数错误和验证失败。
 
 ## 核心模块与入口
 
@@ -340,6 +340,7 @@ C API 封装层（`dlcv_infer_c_dll`）以 `model_index` 作为全局表键索�
 - **参数控件**：选择显卡（下拉）、batch_size（1~1024，默认1）、threshold（0.0~1.0，默认0.5）、线程数（1~32，默认1）
 - **图像预处理**：`prepareImageForInference` 将 BGR/BGRA 转为 RGB
 - **压力测试**：每 500ms 更新统计，包含运行时间、完成请求数、平均延迟、实时速率、各节点平均耗时
+- **命令行模式**：`infer --model ... --image ... --threshold ...`，无界面执行结构化与 JSON 双路径验证
 
 ### C++ Qt Demo3（`dlcv_infer_cpp_qt_demo3`）
 
@@ -364,6 +365,7 @@ C API 封装层（`dlcv_infer_c_dll`）以 `model_index` 作为全局表键索�
   - 多线程测试按钮为**开关**（运行中显示"停止"）
   - 一致性测试：首次推理保存基准，后续不一致时立即停止并弹 Warning
 - **关闭窗口**：停止测试 → Dispose 模型 → `Utils.FreeAllModels()`
+- **命令行模式**：`infer --model ... --image ... --threshold ...`，支持可选设备、mask 和 JSON 输出文件
 
 ### C# WinForms Demo2（`DlcvDemo2`）
 
@@ -412,9 +414,9 @@ C API 封装层（`dlcv_infer_c_dll`）以 `model_index` 作为全局表键索�
 
 ## 运行验证方式
 
-- 构建完成后运行 `DlcvDemo` 或 `dlcv_infer_cpp_qt_demo` 加载模型并执行单次推理验证。
+- 构建完成后可运行 `DlcvDemo` 或 `dlcv_infer_cpp_qt_demo` GUI 加载模型并执行单次推理验证。
+- 自动验证使用两个实际测试程序的 `infer` 命令行模式；模型、图片与阈值通过已定义参数传入。
 - 使用 `Test/DlcvCSharpTest` 或 `Test/dlcv_infer_cpp_test` 执行自动化控制台测试（模型加载、推理、速度、内存）。
 - C# 测试支持 `demo2-rgb-selftest` 验证 Demo2 入口 RGB 数据流一致性。
-- 验证时禁止通过命令行传参覆盖模型路径或图片路径；需修改源码中的固定变量或配置对象字段。
 
 

--- a/C# API文档.md
+++ b/C# API文档.md
@@ -206,7 +206,7 @@ public Tuple<JObject, IntPtr> InferInternal(List<Mat> images, JObject paramsJson
 private Tuple<JObject, IntPtr> InferInternalCore(List<Mat> images, JObject paramsJson, bool emitPoly);
 ```
 - `InferInternalCore` 是核心实现：
-  1. 将输入图像放入 `ExecutionContext`（键：`frontend_image_mat`、`frontend_image_mats`、`frontend_image_mat_list`、`frontend_image_path`、`device_id`、`return_json_emit_poly`）。
+  1. 将输入图像和入口参数放入 `ExecutionContext`（键：`frontend_image_mat`、`frontend_image_mats`、`frontend_image_mat_list`、`frontend_image_path`、`device_id`、`return_json_emit_poly`、`infer_params`）。
   2. 执行 `GraphExecutor::Run()`。
   3. 从 `frontend_json` / `frontend_json_by_node` 收集各节点输出。
   4. 按 `origin_index` 或位置索引映射回原始图像结果。
@@ -615,7 +615,7 @@ C# 侧额外处理 `DV\n` 文件头校验、归档解包、`pipeline.json` 中 `
 
 ### 15.1 执行框架
 
-`ExecutionContext`、`ModuleRegistry`、`GlobalDebug`、`InferTiming`、`TransformationState`、`ModuleImage`、`ModuleIO`、`ModuleChannel` 位于 `DlcvCsharpApi\flow\runtime\ExecutionRuntime.cs` 与 `DlcvCsharpApi\flow\runtime\ModuleRuntime.cs`。`BaseModule` / `BaseInputModule` 提供模块基类。`GraphExecutor` 位于 `DlcvCsharpApi\flow\GraphExecutor.cs`，负责节点排序、链路路由、标量注入、`NormalizeBboxProperties()` 和模型节点预加载；`LoadModels()` 仅对 `BaseModelModule` 调用 `LoadModel()`，并把加载元信息写入 `ExecutionContext.loaded_model_meta`。
+`ExecutionContext`、`ModuleRegistry`、`GlobalDebug`、`InferTiming`、`TransformationState`、`ModuleImage`、`ModuleIO`、`ModuleChannel` 位于 `DlcvCsharpApi\flow\runtime\ExecutionRuntime.cs` 与 `DlcvCsharpApi\flow\runtime\ModuleRuntime.cs`。`BaseModule` / `BaseInputModule` 提供模块基类。`GraphExecutor` 位于 `DlcvCsharpApi\flow\GraphExecutor.cs`，负责节点排序、链路路由、标量注入、入口推理参数覆盖、`NormalizeBboxProperties()` 和模型节点预加载；参数覆盖语义见 `模块、流程与模型推理标准文档.md`。`LoadModels()` 仅对 `BaseModelModule` 调用 `LoadModel()`，并把加载元信息写入 `ExecutionContext.loaded_model_meta`。
 
 ### 15.2 模块实现文件
 

--- a/C# API文档.md
+++ b/C# API文档.md
@@ -195,9 +195,11 @@ public Utils.CSharpResult Infer(Mat image, JObject paramsJson = null);
 public Utils.CSharpResult InferBatch(List<Mat> imageList, JObject paramsJson = null);
 public dynamic InferOneOutJson(Mat image, JObject paramsJson = null);
 ```
-- 接口与 `Model` 完全一致。
+- 调用形式与 `Model` 一致，流程模型的阈值职责边界如下。
 - `Infer` 内部调用 `InferBatch(new List<Mat> { image })`。
 - `InferOneOutJson` 内部调用 `InferInternalCore(..., emitPoly: true)` 以保留 `poly` 字段。
+- 流程中的 `model/*` 节点始终使用流程文件自身的 `properties.threshold`；入口 `paramsJson.threshold` 不会改写节点属性。
+- 入口 `threshold` 仅在流程执行完成后过滤最终对外结果，保留 `score >= threshold` 的对象；未传入有限数值时不做额外过滤，无有限数值 `score` 的非标准条目保留。
 
 ### 4.3 内部推理方法
 
@@ -210,7 +212,8 @@ private Tuple<JObject, IntPtr> InferInternalCore(List<Mat> images, JObject param
   2. 执行 `GraphExecutor::Run()`。
   3. 从 `frontend_json` / `frontend_json_by_node` 收集各节点输出。
   4. 按 `origin_index` 或位置索引映射回原始图像结果。
-  5. 返回 `{"result_list": [...]}` 格式 JSON。
+  5. 若入口含有限数值 `threshold`，按该值过滤每张图的最终结果。
+  6. 返回 `{"result_list": [...]}` 格式 JSON。
 
 ### 4.4 模型信息
 
@@ -246,6 +249,8 @@ public class DvsModel : FlowGraphModel
 4. 修改 `pipeline.json` 中各节点的 `model_path` 为临时目录中的实际路径，保留原始路径到 `model_path_original` 和 `model_name`。
 5. 调用 `LoadFromRoot(pipelineJson, deviceId)` 完成加载。
 6. `finally` 中清理临时目录。
+
+`DvsModel` 继承 `FlowGraphModel` 的推理语义：归档中模型节点使用 `pipeline.json` 保存的阈值，调用 `.dvst`/`.dvso`/`.dvsp` 时传入的 `threshold` 只过滤最终对外结果。
 
 **异常**：
 - 文件格式错误：`InvalidDataException`（"文件格式错误：缺少 DV 头部"）
@@ -423,7 +428,7 @@ Console.WriteLine(info.ToString());
 
 | 字段名 | 类型 | 默认值 | 说明 |
 |--------|------|--------|------|
-| `threshold` | float | 0.5 | 置信度阈值 |
+| `threshold` | float | 普通模型为 0.5；流程未传时不追加过滤 | 普通模型的推理阈值；流程模型的最终对外结果阈值 |
 | `with_mask` | bool | true | 是否输出 mask |
 | `batch_size` | int | 1 | 批量大小 |
 | `device_id` | int | 构造时传入 | GPU 设备 ID（-1 表示 CPU） |
@@ -615,7 +620,7 @@ C# 侧额外处理 `DV\n` 文件头校验、归档解包、`pipeline.json` 中 `
 
 ### 15.1 执行框架
 
-`ExecutionContext`、`ModuleRegistry`、`GlobalDebug`、`InferTiming`、`TransformationState`、`ModuleImage`、`ModuleIO`、`ModuleChannel` 位于 `DlcvCsharpApi\flow\runtime\ExecutionRuntime.cs` 与 `DlcvCsharpApi\flow\runtime\ModuleRuntime.cs`。`BaseModule` / `BaseInputModule` 提供模块基类。`GraphExecutor` 位于 `DlcvCsharpApi\flow\GraphExecutor.cs`，负责节点排序、链路路由、标量注入、入口推理参数覆盖、`NormalizeBboxProperties()` 和模型节点预加载；参数覆盖语义见 `模块、流程与模型推理标准文档.md`。`LoadModels()` 仅对 `BaseModelModule` 调用 `LoadModel()`，并把加载元信息写入 `ExecutionContext.loaded_model_meta`。
+`ExecutionContext`、`ModuleRegistry`、`GlobalDebug`、`InferTiming`、`TransformationState`、`ModuleImage`、`ModuleIO`、`ModuleChannel` 位于 `DlcvCsharpApi\flow\runtime\ExecutionRuntime.cs` 与 `DlcvCsharpApi\flow\runtime\ModuleRuntime.cs`。`BaseModule` / `BaseInputModule` 提供模块基类。`GraphExecutor` 位于 `DlcvCsharpApi\flow\GraphExecutor.cs`，负责节点排序、链路路由、标量注入、`NormalizeBboxProperties()` 和模型节点预加载；执行时保留流程文件中的节点属性。`LoadModels()` 仅对 `BaseModelModule` 调用 `LoadModel()`，并把加载元信息写入 `ExecutionContext.loaded_model_meta`。
 
 ### 15.2 模块实现文件
 

--- a/C#测试程序开发文档.md
+++ b/C#测试程序开发文档.md
@@ -28,7 +28,7 @@
 - **平台**：只提供 `x64`（Debug/Release），必须以 **x64** 方式编译与运行
 - **启动项目**：`DlcvDemo`
 - **输出**：
-  - `DlcvDemo`：WinExe（无控制台窗口）
+  - `DlcvDemo`：WinExe；无参数启动不显示控制台，命令行模式连接父控制台并输出 UTF-8 文本
   - 说明：当前源码中 **没有**为 `DlcvDemo` 配置“自动复制 `AIModelRPC.exe`”的构建步骤；若要启用 RPC 模式，请确保 `AIModelRPC.exe` 位于以下任一路径（见 `DlcvCsharpApi/Model.cs` 的查找顺序）：
     - `DlcvDemo` 的输出目录（与主 EXE 同目录）
     - SDK 固定路径：`C:\dlcv\Lib\site-packages\dlcvpro_infer_csharp\AIModelRPC.exe`
@@ -79,6 +79,26 @@
   - **位深**：非 `CV_8U` 时转为 8 位（`ConvertMatDepthTo8U`：16U 按 `1/256`，浮点按值域映射等）。
   - **通道**：`ParseInputChFromModelInfo` 可从 `model_info.input_shapes.*.max_shape` 推断 1 或 3，并缓存到 `_expectedChCache`；调用方负责把三/四通道颜色图整理为 `RGB`，接口再按模型输入自动做最小必要的通道规整，例如把灰度图补成 `RGB`，或把三/四通道图压成灰度。
 
+#### 2.5 命令行推理模式
+
+无参数启动时进入 WinForms GUI。存在命令行参数时由 `CliRunner` 执行无界面模式。
+
+```text
+"C# 测试程序.exe" infer --model <path> --image <path> --threshold <0..1> [--device <int>] [--with-mask <true|false>] [--output <jsonPath>]
+"C# 测试程序.exe" --help
+"C# 测试程序.exe" --version
+```
+
+- `--model`、`--image`、`--threshold` 为必填参数；`--device` 默认 `0`，`--with-mask` 默认 `true`。
+- `--device=-1` 表示 CPU，非负整数表示 GPU 编号。
+- 中文图片路径通过 `File.ReadAllBytes` 与 `Cv2.ImDecode` 解码；三通道和四通道图像分别转换为 RGB。
+- 同一次命令分别调用 `Infer` 与 `InferOneOutJson`，摘要包含 `structured`、`json`、`consistent` 和 `threshold_check_passed`。
+- `structured` 与 `json` 均包含 `count`、`scores`、`categories` 和 `below_threshold`。
+- `--output` 写入无 BOM 的 UTF-8 JSON；该路径不得覆盖模型或图片，父目录必须存在。
+- 原生推理运行库仍可能向标准输出写入本地编码日志；机器解析使用 `--output` 文件，不把 stdout 当作单一 JSON 文档。
+- WinExe 从交互式 `cmd` 启动时由调用方使用等待方式运行；PowerShell 自动化使用 `Start-Process -Wait -PassThru` 读取退出码。
+- 退出码：`0` 为验证通过，`1` 为运行异常，`2` 为参数错误，`3` 为双路径不一致或存在低于阈值的结果。
+
 ### 3. 功能边界（必须严格一致）
 
 - **必须具备的功能**：
@@ -98,7 +118,7 @@
 - **明确不做的功能**（避免不同人实现“加功能”导致不一致）：
   - 不提供相机/视频流推理
   - 不提供批量文件夹推理（除内部压力测试使用 batch_size 重复同一张图）
-  - 不提供结果导出/保存到文件
+  - GUI 不提供结果导出/保存到文件；命令行模式只保存推理验证摘要
   - 不提供可配置的推理参数面板（除阈值、batch_size、线程数）
   - 不提供 GPU 列表“刷新”按钮
   - 不提供流程编辑器/可视化编辑

--- a/C#测试程序开发文档.md
+++ b/C#测试程序开发文档.md
@@ -91,6 +91,7 @@
 
 - `--model`、`--image`、`--threshold` 为必填参数；`--device` 默认 `0`，`--with-mask` 默认 `true`。
 - `--device=-1` 表示 CPU，非负整数表示 GPU 编号。
+- 普通模型使用 `--threshold` 作为底层推理阈值；`.dvst`/`.dvso`/`.dvsp` 流程模型只用它过滤最终对外结果，流程内各 `model/*` 节点继续使用流程文件保存的 `threshold`。
 - 中文图片路径通过 `File.ReadAllBytes` 与 `Cv2.ImDecode` 解码；三通道和四通道图像分别转换为 RGB。
 - 同一次命令分别调用 `Infer` 与 `InferOneOutJson`，摘要包含 `structured`、`json`、`consistent` 和 `threshold_check_passed`。
 - `structured` 与 `json` 均包含 `count`、`scores`、`categories` 和 `below_threshold`。

--- a/C++ API文档.md
+++ b/C++ API文档.md
@@ -451,13 +451,15 @@ dlcv_infer::Model::GetLastInferTiming(sdkMs, totalMs);
 auto nodes = dlcv_infer::Model::GetLastFlowNodeTimings();
 ```
 
+流程模型的 `threshold` 有明确的两层语义：流程内每个 `model/*` 节点始终使用流程文件中自身的 `threshold`；调用 `Infer` / `InferBatch` / `InferOneOutJson` 时传入的 `params["threshold"]` 只在流程执行和结果聚合完成后，对最终对外结果按 `score >= threshold` 进行筛选。该入口参数不会改写任何流程节点属性。
+
 ---
 
 ## 12. 推理参数 JSON 字段
 
 | 字段名 | 类型 | 默认值 | 说明 |
 |--------|------|--------|------|
-| `threshold` | float | 0.5 | 置信度阈值 |
+| `threshold` | float | 普通模型为 0.5；流程未传时不追加过滤 | 普通模型的推理阈值；流程模型中仅筛选最终对外结果，不覆盖节点自身阈值 |
 | `with_mask` | bool | true | 是否输出 mask |
 | `batch_size` | int | 1 | 批量大小 |
 | `device_id` | int | 构造时传入 | GPU 设备 ID（-1 表示 CPU） |

--- a/C++测试程序开发文档.md
+++ b/C++测试程序开发文档.md
@@ -65,6 +65,7 @@ dlcv_infer_cpp_qt_demo.exe --help
 
 - `--model`、`--image`、`--threshold` 为必填参数；`--device` 默认 `0`，`--with-mask` 默认 `true`。
 - `--device=-1` 表示 CPU，非负整数表示 GPU 编号。
+- 普通模型使用 `--threshold` 作为推理阈值；流程模型保留各模型节点自身的阈值，`--threshold` 只对最终对外结果进行筛选。
 - 图片由 `QFile` 读取字节并通过 `cv::imdecode` 解码；BGR/BGRA 转为 RGB。
 - 同一次命令分别调用 `Infer` 与 `InferOneOutJson`，输出字段与 C# 测试程序一致。
 - C++ 结构化结果的本地 GBK 类别名在 CLI 边界转换为 UTF-8，再写入 JSON。

--- a/C++测试程序开发文档.md
+++ b/C++测试程序开发文档.md
@@ -28,33 +28,23 @@
 |------|------|
 | Qt 5/6 | UI 框架（QApplication、QMainWindow、QTimer 等） |
 | OpenCV 4.x | 图像读取、通道转换、Mat 操作 |
-| `dlcv_infer.h` + `dlcv_infer.lib` | C++ API 头文件与导入库 |
-| `dlcv_infer.dll`（运行时） | 底层推理 DLL |
+| `dlcv_infer.h` + `dlcv_infer_cpp_dll.lib` | C++ API 头文件与导入库 |
+| `dlcv_infer_cpp_dll.dll`（运行时） | OpenIVS C++ API DLL |
 
 ### 2.2 Visual Studio 编译
 
-**前提条件**：
-1. 安装 Qt 并配置 VS Qt Tools（或手动配置 `QTDIR` 环境变量）。
-2. 确保 OpenCV 路径已添加到项目属性（包含目录 + 库目录 + 链接器输入）。
-3. 确保 `dlcv_infer_cpp_dll` 已编译，输出 `dlcv_infer.lib` 和 `dlcv_infer.h` 可用。
-
-**编译流程**：
-1. 打开 `OpenIVS.sln`，选择 `dlcv_infer_cpp_qt_demo` 项目。
-2. 平台配置：**x64 Release**（Qt 和 OpenCV 均需匹配 x64）。
-3. 链接器输入确认包含：
-   - `dlcv_infer.lib`
-   - OpenCV 核心库（`opencv_core`、`opencv_imgproc`、`opencv_imgcodecs` 等）
-   - Qt 核心库（`Qt5Core.lib`、`Qt5Gui.lib`、`Qt5Widgets.lib`）
-4. 生成解决方案（Ctrl+Shift+B）。
+- 构建统一通过 `.cursor/skills/vs-build/scripts/build.py` 执行，目标为 `dlcv_infer_cpp_qt_demo/dlcv_infer_cpp_qt_demo.vcxproj`。
+- 默认配置为 `Debug`、`x64`、`Build`、`minimal`；发布构建使用 `Release`、`x64`、`Build`、`minimal`。
+- 项目通过 `ProjectReference` 构建 `dlcv_infer_cpp_dll`；直接构建项目时从 `$(ProjectDir)..\dlcv_infer_cpp_dll\$(Configuration)\` 解析导入库，解决方案构建时从 `$(SolutionDir)$(Configuration)\` 解析。
+- Qt、OpenCV 与 DLCV SDK 依赖路径由工程属性解析；缺失时构建失败。
 
 ### 2.3 输出与部署
 
-- 编译输出：`x64\Release\dlcv_infer_cpp_qt_demo.exe`
-- 运行时需要将以下文件放在 exe 同级目录或系统 PATH 中：
-  - `dlcv_infer.dll`（或 `dlcv_infer_v.dll`，取决于加密狗类型）
-  - Qt 运行时 DLL（`Qt5Core.dll`、`Qt5Gui.dll`、`Qt5Widgets.dll` 等）
-  - OpenCV 运行时 DLL（`opencv_core4x.dll`、`opencv_imgproc4x.dll`、`opencv_imgcodecs4x.dll`）
-  - `nvml.dll`（可选，GPU 信息获取需要）
+- 直接构建项目时，Debug 输出为 `dlcv_infer_cpp_qt_demo/Debug/dlcv_infer_cpp_qt_demo/dlcv_infer_cpp_qt_demo.exe`。
+- 直接构建项目时，Release 输出为 `dlcv_infer_cpp_qt_demo/Release/dlcv_infer_cpp_qt_demo/dlcv_infer_cpp_qt_demo.exe`。
+- 通过 `OpenIVS.sln` 构建时，EXE 输出位于解决方案根目录的 `Debug/dlcv_infer_cpp_qt_demo/` 或 `Release/dlcv_infer_cpp_qt_demo/`。
+- 构建后事件把 `dlcv_infer_cpp_dll.dll`、Qt Core/Gui/Widgets、平台插件和样式插件复制到 EXE 输出目录。
+- 底层 `dlcv_infer.dll` 或 `dlcv_infer_v.dll` 仍按模型授权类型由 C++ API 从 SDK 路径加载。
 
 ---
 
@@ -62,25 +52,26 @@
 
 ### 3.1 程序入口（main.cpp）
 
-```cpp
-int main(int argc, char* argv[]) {
-    QApplication app(argc, argv);
-    app.setApplicationName("C++测试程序");
-    app.setOrganizationName("dlcv");
-    app.setFont(QFont("Microsoft YaHei", 9));
-    
-    // 退出时释放所有模型
-    QObject::connect(&app, &QCoreApplication::aboutToQuit, []() {
-        dlcv_infer::Utils::FreeAllModels();
-    });
+- 无参数时初始化 `QApplication`、显示 `MainWindow`，退出前调用 `FreeAllModels()`。
+- 有参数时解析 `infer` 或 `--help`；`infer` 模式不显示窗口，完成验证后直接返回退出码。
+- Windows 控制台输入输出使用 UTF-8；模型路径通过 `std::wstring` 传给 C++ API。
 
-    MainWindow w;
-    w.show();
-    return app.exec();
-}
+### 3.2 命令行推理模式
+
+```text
+dlcv_infer_cpp_qt_demo.exe infer --model <path> --image <path> --threshold <0..1> [--device <int>] [--with-mask <true|false>] [--output <jsonPath>]
+dlcv_infer_cpp_qt_demo.exe --help
 ```
 
-### 3.2 UI 布局
+- `--model`、`--image`、`--threshold` 为必填参数；`--device` 默认 `0`，`--with-mask` 默认 `true`。
+- `--device=-1` 表示 CPU，非负整数表示 GPU 编号。
+- 图片由 `QFile` 读取字节并通过 `cv::imdecode` 解码；BGR/BGRA 转为 RGB。
+- 同一次命令分别调用 `Infer` 与 `InferOneOutJson`，输出字段与 C# 测试程序一致。
+- C++ 结构化结果的本地 GBK 类别名在 CLI 边界转换为 UTF-8，再写入 JSON。
+- `--output` 使用 `QSaveFile` 原子写入 UTF-8 JSON；该路径不得覆盖模型或图片，父目录必须存在。
+- 退出码：`0` 为验证通过，`1` 为运行异常，`2` 为参数错误，`3` 为双路径不一致或存在低于阈值的结果。
+
+### 3.3 UI 布局
 
 主窗口分为上下两部分：
 - **上方控制栏**：按钮 + 参数调节控件

--- a/DlcvCsharpApi/Properties/AssemblyInfo.cs
+++ b/DlcvCsharpApi/Properties/AssemblyInfo.cs
@@ -29,6 +29,6 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.7.19.0")]
-[assembly: AssemblyFileVersion("2026.7.19.0")]
-[assembly: AssemblyInformationalVersion("2026.7.19.0a0")]
+[assembly: AssemblyVersion("2026.7.19.1")]
+[assembly: AssemblyFileVersion("2026.7.19.1")]
+[assembly: AssemblyInformationalVersion("2026.7.19.1a0")]

--- a/DlcvCsharpApi/Properties/AssemblyInfo.cs
+++ b/DlcvCsharpApi/Properties/AssemblyInfo.cs
@@ -29,6 +29,6 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.7.13.0")]
-[assembly: AssemblyFileVersion("2026.7.13.0")]
-[assembly: AssemblyInformationalVersion("2026.7.13.0")]
+[assembly: AssemblyVersion("2026.7.19.0")]
+[assembly: AssemblyFileVersion("2026.7.19.0")]
+[assembly: AssemblyInformationalVersion("2026.7.19.0a0")]

--- a/DlcvCsharpApi/flow/FlowGraphModel.cs
+++ b/DlcvCsharpApi/flow/FlowGraphModel.cs
@@ -258,6 +258,8 @@ namespace DlcvModules
                 }
 
                 AggregateFrontendResults(ctx, perImageResults);
+                // 入口阈值只作用于 return_json 汇总后的最终对外结果。
+                ApplyFinalThresholdFilter(perImageResults, paramsJson);
 
                 var root = new JObject();
                 if (images.Count == 1)
@@ -662,6 +664,86 @@ namespace DlcvModules
                 target.Add(token.DeepClone());
                 if (sig != null) seen.Add(sig);
             }
+        }
+
+        private static void ApplyFinalThresholdFilter(List<JArray> perImageResults, JObject paramsJson)
+        {
+            if (perImageResults == null || !TryReadFinalThreshold(paramsJson, out double threshold))
+            {
+                return;
+            }
+
+            for (int i = 0; i < perImageResults.Count; i++)
+            {
+                FilterFinalResultArray(perImageResults[i], threshold);
+            }
+        }
+
+        private static void FilterFinalResultArray(JArray results, double threshold)
+        {
+            if (results == null) return;
+
+            for (int i = results.Count - 1; i >= 0; i--)
+            {
+                var result = results[i] as JObject;
+                if (result == null) continue;
+
+                // 兼容旧格式容器：容器本身保留，只过滤其最终结果对象。
+                var nestedResults = result["sample_results"] as JArray;
+                if (nestedResults != null)
+                {
+                    FilterFinalResultArray(nestedResults, threshold);
+                    continue;
+                }
+
+                if (TryReadFiniteScore(result["score"], out double score) && score < threshold)
+                {
+                    results.RemoveAt(i);
+                }
+            }
+        }
+
+        private static bool TryReadFinalThreshold(JObject paramsJson, out double threshold)
+        {
+            threshold = 0.0;
+            if (paramsJson == null) return false;
+
+            JToken token = paramsJson["threshold"];
+            if (token == null || (token.Type != JTokenType.Integer && token.Type != JTokenType.Float))
+            {
+                return false;
+            }
+
+            try
+            {
+                threshold = token.Value<double>();
+            }
+            catch
+            {
+                return false;
+            }
+
+            return !double.IsNaN(threshold) && !double.IsInfinity(threshold);
+        }
+
+        private static bool TryReadFiniteScore(JToken token, out double score)
+        {
+            score = 0.0;
+            if (token == null || (token.Type != JTokenType.Integer && token.Type != JTokenType.Float))
+            {
+                return false;
+            }
+
+            try
+            {
+                score = token.Value<double>();
+            }
+            catch
+            {
+                return false;
+            }
+
+            return !double.IsNaN(score) && !double.IsInfinity(score);
         }
 
         private Utils.CSharpResult ConvertFlowResultsToCSharp(JArray resultList, bool includeMask = true)

--- a/DlcvCsharpApi/flow/GraphExecutor.cs
+++ b/DlcvCsharpApi/flow/GraphExecutor.cs
@@ -80,6 +80,13 @@ namespace DlcvModules
 					}
 				}
 				if (props == null) props = new Dictionary<string, object>();
+
+				try
+				{
+					var inferParams = _context.Get<JObject>("infer_params", null);
+					ApplyInferParamOverrides(props, inferParams);
+				}
+				catch { }
 				
 				// 统一 bbox 属性：允许前端/旧配置用 XYXY 输入，C# 侧统一补齐为 XYWH（不删除原字段）
 				try { NormalizeBboxProperties(props); } catch { }
@@ -456,6 +463,34 @@ namespace DlcvModules
 				return "scalar";
 			// 其余类型均视作非标量通道
 			return "channel";
+		}
+
+		private static void ApplyInferParamOverrides(Dictionary<string, object> props, JObject inferParams)
+		{
+			if (props == null || inferParams == null) return;
+
+			foreach (var property in inferParams.Properties())
+			{
+				if (string.Equals(property.Name, "with_mask", StringComparison.OrdinalIgnoreCase))
+				{
+					continue;
+				}
+
+				JToken value = property.Value;
+				if (value == null || value.Type == JTokenType.Null)
+				{
+					props[property.Name] = null;
+					continue;
+				}
+
+				if (value.Type == JTokenType.Boolean ||
+					value.Type == JTokenType.Integer ||
+					value.Type == JTokenType.Float ||
+					value.Type == JTokenType.String)
+				{
+					props[property.Name] = ((JValue)value).Value;
+				}
+			}
 		}
 
 		/// <summary>

--- a/DlcvCsharpApi/flow/GraphExecutor.cs
+++ b/DlcvCsharpApi/flow/GraphExecutor.cs
@@ -80,13 +80,6 @@ namespace DlcvModules
 					}
 				}
 				if (props == null) props = new Dictionary<string, object>();
-
-				try
-				{
-					var inferParams = _context.Get<JObject>("infer_params", null);
-					ApplyInferParamOverrides(props, inferParams);
-				}
-				catch { }
 				
 				// 统一 bbox 属性：允许前端/旧配置用 XYXY 输入，C# 侧统一补齐为 XYWH（不删除原字段）
 				try { NormalizeBboxProperties(props); } catch { }
@@ -463,34 +456,6 @@ namespace DlcvModules
 				return "scalar";
 			// 其余类型均视作非标量通道
 			return "channel";
-		}
-
-		private static void ApplyInferParamOverrides(Dictionary<string, object> props, JObject inferParams)
-		{
-			if (props == null || inferParams == null) return;
-
-			foreach (var property in inferParams.Properties())
-			{
-				if (string.Equals(property.Name, "with_mask", StringComparison.OrdinalIgnoreCase))
-				{
-					continue;
-				}
-
-				JToken value = property.Value;
-				if (value == null || value.Type == JTokenType.Null)
-				{
-					props[property.Name] = null;
-					continue;
-				}
-
-				if (value.Type == JTokenType.Boolean ||
-					value.Type == JTokenType.Integer ||
-					value.Type == JTokenType.Float ||
-					value.Type == JTokenType.String)
-				{
-					props[property.Name] = ((JValue)value).Value;
-				}
-			}
 		}
 
 		/// <summary>

--- a/DlcvCsharpApi/flow/modules/Models.cs
+++ b/DlcvCsharpApi/flow/modules/Models.cs
@@ -175,7 +175,7 @@ namespace DlcvModules
 			var outResults = new JArray();
 			LoadModel();
 
-			// 透传推理参数
+			// 只透传流程节点自身的推理参数；入口阈值在最终结果层处理。
 			var p = new JObject();
 			TryAddParam(p, "threshold");
 			TryAddParam(p, "iou_threshold");

--- a/DlcvDemo/CliRunner.cs
+++ b/DlcvDemo/CliRunner.cs
@@ -1,0 +1,564 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using OpenCvSharp;
+using dlcv_infer_csharp;
+using DlcvModules;
+
+namespace DlcvDemo
+{
+    internal static class CliRunner
+    {
+        private const uint AttachParentProcess = 0xFFFFFFFF;
+        private const int ErrorAccessDenied = 5;
+        private const double ScoreConsistencyTolerance = 1e-6;
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool AttachConsole(uint processId);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool AllocConsole();
+
+        internal static void InitializeConsole()
+        {
+            try
+            {
+                if (!AttachConsole(AttachParentProcess))
+                {
+                    int error = Marshal.GetLastWin32Error();
+                    if (error != ErrorAccessDenied)
+                    {
+                        AllocConsole();
+                    }
+                }
+
+                var utf8 = new UTF8Encoding(false);
+                var stdout = Console.OpenStandardOutput();
+                if (stdout != null && stdout.CanWrite)
+                {
+                    var writer = new StreamWriter(stdout, utf8) { AutoFlush = true };
+                    Console.SetOut(writer);
+                }
+
+                var stderr = Console.OpenStandardError();
+                if (stderr != null && stderr.CanWrite)
+                {
+                    var writer = new StreamWriter(stderr, utf8) { AutoFlush = true };
+                    Console.SetError(writer);
+                }
+            }
+            catch
+            {
+                // 无控制台时仍允许 --output 写入验证结果。
+            }
+        }
+
+        internal static int Run(string[] args)
+        {
+            if (args == null || args.Length == 0)
+            {
+                WriteParameterError("缺少 CLI 命令。");
+                return 2;
+            }
+
+            if (args.Length == 1 && IsHelpToken(args[0]))
+            {
+                PrintHelp();
+                return 0;
+            }
+
+            if (args.Length == 1 && IsVersionToken(args[0]))
+            {
+                Console.Out.WriteLine(GetVersion());
+                return 0;
+            }
+
+            if (!string.Equals(args[0], "infer", StringComparison.OrdinalIgnoreCase))
+            {
+                WriteParameterError("未知命令: " + args[0]);
+                return 2;
+            }
+
+            if (args.Length == 2 && IsHelpToken(args[1]))
+            {
+                PrintHelp();
+                return 0;
+            }
+
+            if (!TryParseInferOptions(args, out CliOptions options, out string error))
+            {
+                WriteParameterError(error);
+                return 2;
+            }
+
+            try
+            {
+                JObject summary = ExecuteInference(options);
+                string json = summary.ToString(Formatting.Indented);
+
+                // 先写 stdout，即使后续输出文件失败也能看到本次验证摘要。
+                Console.Out.WriteLine(json);
+
+                if (!string.IsNullOrWhiteSpace(options.OutputPath))
+                {
+                    File.WriteAllText(options.OutputPath, json + Environment.NewLine, new UTF8Encoding(false));
+                }
+
+                bool consistent = summary.Value<bool>("consistent");
+                bool thresholdCheckPassed = summary.Value<bool>("threshold_check_passed");
+                return consistent && thresholdCheckPassed ? 0 : 3;
+            }
+            catch (Exception ex)
+            {
+                WriteException(ex);
+                return 1;
+            }
+        }
+
+        private static JObject ExecuteInference(CliOptions options)
+        {
+            Model model = null;
+            Mat decodedImage = null;
+            Mat inferImage = null;
+            try
+            {
+                Model.EnableConsoleLog = false;
+                GlobalDebug.PrintDebug = false;
+                model = new Model(options.ModelPath, options.DeviceId, false, false);
+
+                byte[] imageBytes = File.ReadAllBytes(options.ImagePath);
+                decodedImage = Cv2.ImDecode(imageBytes, ImreadModes.Unchanged);
+                if (decodedImage == null || decodedImage.Empty())
+                {
+                    throw new InvalidOperationException("图像解码失败。");
+                }
+
+                inferImage = PrepareImageForInference(decodedImage);
+                if (inferImage == null || inferImage.Empty())
+                {
+                    throw new InvalidOperationException("图像预处理失败。");
+                }
+
+                JObject inferParams = new JObject
+                {
+                    ["threshold"] = (float)options.Threshold,
+                    ["with_mask"] = options.WithMask
+                };
+
+                PathSummary structuredSummary;
+                Utils.CSharpResult structuredResult = default(Utils.CSharpResult);
+                bool structuredResultCreated = false;
+                try
+                {
+                    structuredResult = model.Infer(inferImage, (JObject)inferParams.DeepClone());
+                    structuredResultCreated = true;
+                    structuredSummary = BuildStructuredSummary(structuredResult, options.Threshold);
+                }
+                finally
+                {
+                    if (structuredResultCreated)
+                    {
+                        DisposeResultMasks(structuredResult);
+                    }
+                }
+
+                object rawJsonResult = model.InferOneOutJson(inferImage, (JObject)inferParams.DeepClone());
+                var jsonResults = rawJsonResult as JArray;
+                if (jsonResults == null)
+                {
+                    throw new InvalidOperationException("InferOneOutJson 未返回 JSON 数组。");
+                }
+
+                PathSummary jsonSummary = BuildJsonSummary(jsonResults, options.Threshold);
+                bool consistent = AreConsistent(structuredSummary, jsonSummary);
+                bool thresholdCheckPassed = structuredSummary.BelowThresholdCount == 0
+                    && jsonSummary.BelowThresholdCount == 0;
+
+                return new JObject
+                {
+                    ["language"] = "csharp",
+                    ["model"] = options.ModelPath,
+                    ["image"] = options.ImagePath,
+                    ["device"] = options.DeviceId,
+                    ["threshold"] = options.Threshold,
+                    ["with_mask"] = options.WithMask,
+                    ["structured"] = structuredSummary.ToJson(),
+                    ["json"] = jsonSummary.ToJson(),
+                    ["consistent"] = consistent,
+                    ["threshold_check_passed"] = thresholdCheckPassed
+                };
+            }
+            finally
+            {
+                if (inferImage != null && !ReferenceEquals(inferImage, decodedImage))
+                {
+                    try { inferImage.Dispose(); } catch { }
+                }
+                if (decodedImage != null)
+                {
+                    try { decodedImage.Dispose(); } catch { }
+                }
+                if (model != null)
+                {
+                    try { model.Dispose(); } catch { }
+                }
+                try { Utils.FreeAllModels(); } catch { }
+            }
+        }
+
+        private static Mat PrepareImageForInference(Mat image)
+        {
+            int channels = image.Channels();
+            if (channels == 3)
+            {
+                var rgb = new Mat();
+                Cv2.CvtColor(image, rgb, ColorConversionCodes.BGR2RGB);
+                return rgb;
+            }
+            if (channels == 4)
+            {
+                var rgb = new Mat();
+                Cv2.CvtColor(image, rgb, ColorConversionCodes.BGRA2RGB);
+                return rgb;
+            }
+            return image;
+        }
+
+        private static PathSummary BuildStructuredSummary(Utils.CSharpResult result, double threshold)
+        {
+            var summary = new PathSummary();
+            if (result.SampleResults == null)
+            {
+                return summary;
+            }
+
+            foreach (var sample in result.SampleResults)
+            {
+                if (sample.Results == null) continue;
+                foreach (var item in sample.Results)
+                {
+                    summary.Add(item.Score, item.CategoryName, threshold);
+                }
+            }
+            return summary;
+        }
+
+        private static PathSummary BuildJsonSummary(JArray resultArray, double threshold)
+        {
+            var summary = new PathSummary();
+            for (int i = 0; i < resultArray.Count; i++)
+            {
+                var item = resultArray[i] as JObject;
+                double score = double.NaN;
+                string category = string.Empty;
+                if (item != null)
+                {
+                    TryReadScore(item["score"], out score);
+                    category = item["category_name"] != null ? item["category_name"].ToString() : string.Empty;
+                }
+                summary.Add(score, category, threshold);
+            }
+            return summary;
+        }
+
+        private static bool TryReadScore(JToken token, out double score)
+        {
+            score = double.NaN;
+            if (token == null) return false;
+            if (token.Type == JTokenType.Float || token.Type == JTokenType.Integer)
+            {
+                score = token.Value<double>();
+                return true;
+            }
+            return double.TryParse(token.ToString(), NumberStyles.Float, CultureInfo.InvariantCulture, out score);
+        }
+
+        private static bool AreConsistent(PathSummary left, PathSummary right)
+        {
+            if (left.Count != right.Count) return false;
+            for (int i = 0; i < left.Count; i++)
+            {
+                double leftScore = left.Scores[i];
+                double rightScore = right.Scores[i];
+                if (!IsFinite(leftScore) || !IsFinite(rightScore)) return false;
+                if (Math.Abs(leftScore - rightScore) > ScoreConsistencyTolerance) return false;
+                if (!string.Equals(left.Categories[i], right.Categories[i], StringComparison.Ordinal)) return false;
+            }
+            return true;
+        }
+
+        private static void DisposeResultMasks(Utils.CSharpResult result)
+        {
+            if (result.SampleResults == null) return;
+            foreach (var sample in result.SampleResults)
+            {
+                if (sample.Results == null) continue;
+                foreach (var item in sample.Results)
+                {
+                    if (item.Mask != null)
+                    {
+                        try { item.Mask.Dispose(); } catch { }
+                    }
+                }
+            }
+        }
+
+        private static bool TryParseInferOptions(string[] args, out CliOptions options, out string error)
+        {
+            options = new CliOptions
+            {
+                DeviceId = 0,
+                WithMask = true
+            };
+            error = null;
+
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            for (int i = 1; i < args.Length; i += 2)
+            {
+                string key = args[i];
+                if (string.IsNullOrWhiteSpace(key) || !key.StartsWith("--", StringComparison.Ordinal))
+                {
+                    error = "无效参数名: " + (key ?? string.Empty);
+                    return false;
+                }
+                if (i + 1 >= args.Length)
+                {
+                    error = "参数缺少值: " + key;
+                    return false;
+                }
+                if (!seen.Add(key))
+                {
+                    error = "参数重复: " + key;
+                    return false;
+                }
+
+                string value = args[i + 1];
+                switch (key.ToLowerInvariant())
+                {
+                    case "--model":
+                        options.ModelPath = value;
+                        break;
+                    case "--image":
+                        options.ImagePath = value;
+                        break;
+                    case "--threshold":
+                        if (!double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out double threshold)
+                            || !IsFinite(threshold)
+                            || threshold < 0.0
+                            || threshold > 1.0)
+                        {
+                            error = "--threshold 必须是 0 到 1 之间的数字。";
+                            return false;
+                        }
+                        options.Threshold = threshold;
+                        options.HasThreshold = true;
+                        break;
+                    case "--device":
+                        if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int deviceId)
+                            || deviceId < -1)
+                        {
+                            error = "--device 必须是 -1 或非负整数。";
+                            return false;
+                        }
+                        options.DeviceId = deviceId;
+                        break;
+                    case "--with-mask":
+                        if (!bool.TryParse(value, out bool withMask))
+                        {
+                            error = "--with-mask 必须是 true 或 false。";
+                            return false;
+                        }
+                        options.WithMask = withMask;
+                        break;
+                    case "--output":
+                        options.OutputPath = value;
+                        break;
+                    default:
+                        error = "未知参数: " + key;
+                        return false;
+                }
+            }
+
+            if (string.IsNullOrWhiteSpace(options.ModelPath))
+            {
+                error = "缺少必填参数 --model。";
+                return false;
+            }
+            if (string.IsNullOrWhiteSpace(options.ImagePath))
+            {
+                error = "缺少必填参数 --image。";
+                return false;
+            }
+            if (!options.HasThreshold)
+            {
+                error = "缺少必填参数 --threshold。";
+                return false;
+            }
+            if (!File.Exists(options.ModelPath))
+            {
+                error = "模型文件不存在。";
+                return false;
+            }
+            if (!File.Exists(options.ImagePath))
+            {
+                error = "图片文件不存在。";
+                return false;
+            }
+
+            if (!string.IsNullOrWhiteSpace(options.OutputPath))
+            {
+                try
+                {
+                    string outputFullPath = Path.GetFullPath(options.OutputPath);
+                    string modelFullPath = Path.GetFullPath(options.ModelPath);
+                    string imageFullPath = Path.GetFullPath(options.ImagePath);
+                    if (string.Equals(outputFullPath, modelFullPath, StringComparison.OrdinalIgnoreCase)
+                        || string.Equals(outputFullPath, imageFullPath, StringComparison.OrdinalIgnoreCase))
+                    {
+                        error = "--output 不能覆盖模型或图片文件。";
+                        return false;
+                    }
+
+                    string outputDirectory = Path.GetDirectoryName(outputFullPath);
+                    if (string.IsNullOrWhiteSpace(outputDirectory) || !Directory.Exists(outputDirectory))
+                    {
+                        error = "--output 的父目录不存在。";
+                        return false;
+                    }
+                    options.OutputPath = outputFullPath;
+                }
+                catch (Exception ex)
+                {
+                    error = "--output 路径无效: " + ex.Message;
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool IsHelpToken(string value)
+        {
+            return string.Equals(value, "--help", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(value, "-h", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(value, "help", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(value, "/?", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsVersionToken(string value)
+        {
+            return string.Equals(value, "--version", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(value, "version", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string GetVersion()
+        {
+            Assembly assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
+            object[] attributes = assembly.GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute), false);
+            if (attributes.Length > 0)
+            {
+                var info = attributes[0] as AssemblyInformationalVersionAttribute;
+                if (info != null && !string.IsNullOrWhiteSpace(info.InformationalVersion))
+                {
+                    return info.InformationalVersion;
+                }
+            }
+            Version version = assembly.GetName().Version;
+            return version != null ? version.ToString() : "unknown";
+        }
+
+        private static void PrintHelp()
+        {
+            Console.Out.WriteLine("Usage:");
+            Console.Out.WriteLine("  \"C# 测试程序.exe\" infer --model <path> --image <path> --threshold <0..1> [--device <int>] [--with-mask <true|false>] [--output <jsonPath>]");
+            Console.Out.WriteLine("  \"C# 测试程序.exe\" --help");
+            Console.Out.WriteLine("  \"C# 测试程序.exe\" --version");
+            Console.Out.WriteLine();
+            Console.Out.WriteLine("Exit codes: 0=passed, 1=runtime error, 2=invalid arguments, 3=validation failed");
+        }
+
+        private static void WriteParameterError(string message)
+        {
+            Console.Error.WriteLine("参数错误: " + message);
+            PrintHelp();
+        }
+
+        private static void WriteException(Exception ex)
+        {
+            var error = new JObject
+            {
+                ["language"] = "csharp",
+                ["error"] = ex.Message,
+                ["exception_type"] = ex.GetType().FullName
+            };
+            Console.Error.WriteLine(error.ToString(Formatting.Indented));
+        }
+
+        private static bool IsFinite(double value)
+        {
+            return !double.IsNaN(value) && !double.IsInfinity(value);
+        }
+
+        private sealed class CliOptions
+        {
+            public string ModelPath { get; set; }
+            public string ImagePath { get; set; }
+            public double Threshold { get; set; }
+            public bool HasThreshold { get; set; }
+            public int DeviceId { get; set; }
+            public bool WithMask { get; set; }
+            public string OutputPath { get; set; }
+        }
+
+        private sealed class PathSummary
+        {
+            private readonly JArray _belowThreshold = new JArray();
+
+            public List<double> Scores { get; } = new List<double>();
+            public List<string> Categories { get; } = new List<string>();
+            public int Count { get { return Scores.Count; } }
+            public int BelowThresholdCount { get { return _belowThreshold.Count; } }
+
+            public void Add(double score, string category, double threshold)
+            {
+                int index = Scores.Count;
+                string normalizedCategory = category ?? string.Empty;
+                Scores.Add(score);
+                Categories.Add(normalizedCategory);
+
+                if (!IsFinite(score) || score < threshold)
+                {
+                    _belowThreshold.Add(new JObject
+                    {
+                        ["index"] = index,
+                        ["score"] = IsFinite(score) ? new JValue(score) : JValue.CreateNull(),
+                        ["category"] = normalizedCategory
+                    });
+                }
+            }
+
+            public JObject ToJson()
+            {
+                var scores = new JArray();
+                foreach (double score in Scores)
+                {
+                    scores.Add(IsFinite(score) ? new JValue(score) : JValue.CreateNull());
+                }
+
+                return new JObject
+                {
+                    ["count"] = Count,
+                    ["scores"] = scores,
+                    ["categories"] = new JArray(Categories),
+                    ["below_threshold"] = _belowThreshold.DeepClone()
+                };
+            }
+        }
+    }
+}

--- a/DlcvDemo/CliRunner.cs
+++ b/DlcvDemo/CliRunner.cs
@@ -480,6 +480,7 @@ namespace DlcvDemo
             Console.Out.WriteLine("  \"C# 测试程序.exe\" --help");
             Console.Out.WriteLine("  \"C# 测试程序.exe\" --version");
             Console.Out.WriteLine();
+            Console.Out.WriteLine("Flow archives: --threshold filters final output only; model-node thresholds come from the flow.");
             Console.Out.WriteLine("Exit codes: 0=passed, 1=runtime error, 2=invalid arguments, 3=validation failed");
         }
 

--- a/DlcvDemo/DlcvDemo.csproj
+++ b/DlcvDemo/DlcvDemo.csproj
@@ -135,6 +135,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CliRunner.cs" />
     <Compile Include="Form1.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/DlcvDemo/Program.cs
+++ b/DlcvDemo/Program.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace DlcvDemo
@@ -12,11 +9,18 @@ namespace DlcvDemo
         /// 应用程序的主入口点。
         /// </summary>
         [STAThread]
-        static void Main()
+        static int Main(string[] args)
         {
+            if (args != null && args.Length > 0)
+            {
+                CliRunner.InitializeConsole();
+                return CliRunner.Run(args);
+            }
+
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
             Application.Run(new Form1());
+            return 0;
         }
     }
 }

--- a/DlcvDemo/Properties/AssemblyInfo.cs
+++ b/DlcvDemo/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.7.13.0")]
-[assembly: AssemblyFileVersion("2026.7.13.0")]
-[assembly: AssemblyInformationalVersion("2026.7.13.0")]
+[assembly: AssemblyVersion("2026.7.19.0")]
+[assembly: AssemblyFileVersion("2026.7.19.0")]
+[assembly: AssemblyInformationalVersion("2026.7.19.0a0")]
 [assembly: NeutralResourcesLanguage("zh-CN")]

--- a/DlcvDemo/Properties/AssemblyInfo.cs
+++ b/DlcvDemo/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.7.19.0")]
-[assembly: AssemblyFileVersion("2026.7.19.0")]
-[assembly: AssemblyInformationalVersion("2026.7.19.0a0")]
+[assembly: AssemblyVersion("2026.7.19.1")]
+[assembly: AssemblyFileVersion("2026.7.19.1")]
+[assembly: AssemblyInformationalVersion("2026.7.19.1a0")]
 [assembly: NeutralResourcesLanguage("zh-CN")]

--- a/build_package.py
+++ b/build_package.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent
+PACKAGE_NAME = "dlcvpro_infer_csharp"
+STAGING_DIR = REPO_ROOT / PACKAGE_NAME
+DEMO_OUTPUT_DIR = REPO_ROOT / "DlcvDemo" / "bin"
+DEMO_EXE_NAME = "C# 测试程序.exe"
+SIGNTOOL_PATH = Path(r"C:\sign-tool\signtool.exe")
+SIGN_CERT_SUBJECT = "深度视觉（广东）人工智能研究有限公司"
+TIMESTAMP_URL = "http://time.certum.pl"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="构建、签名并打包 C# 测试程序")
+    parser.add_argument(
+        "--install",
+        action="store_true",
+        help="打包成功后使用当前 Python 环境安装本次生成的 wheel",
+    )
+    return parser.parse_args()
+
+
+def require_file(path: Path) -> None:
+    if not path.is_file():
+        raise FileNotFoundError(f"未找到必需文件: {path}")
+
+
+def run_step(name: str, command: list[str]) -> None:
+    print(f"[build_package] {name}")
+    print(f"[build_package] command: {subprocess.list2cmdline(command)}")
+    subprocess.run(command, cwd=REPO_ROOT, check=True)
+
+
+def rebuild_staging_directory() -> None:
+    repo_root = REPO_ROOT.resolve()
+    lexical_path = STAGING_DIR.absolute()
+    resolved_path = STAGING_DIR.resolve(strict=False)
+
+    if lexical_path.parent != repo_root or lexical_path.name != PACKAGE_NAME:
+        raise RuntimeError(f"拒绝清理仓库外目录: {lexical_path}")
+    if resolved_path != lexical_path:
+        raise RuntimeError(f"拒绝清理链接或重解析目录: {lexical_path} -> {resolved_path}")
+
+    if STAGING_DIR.exists():
+        if not STAGING_DIR.is_dir():
+            raise RuntimeError(f"暂存路径不是目录: {STAGING_DIR}")
+        shutil.rmtree(STAGING_DIR)
+    STAGING_DIR.mkdir()
+
+
+def copy_package_files() -> Path:
+    if not DEMO_OUTPUT_DIR.is_dir():
+        raise FileNotFoundError(f"未找到 C# 构建输出目录: {DEMO_OUTPUT_DIR}")
+
+    rebuild_staging_directory()
+
+    for pattern in ("*.exe", "*.config", "*.dll"):
+        sources = sorted(path for path in DEMO_OUTPUT_DIR.glob(pattern) if path.is_file())
+        if not sources:
+            raise FileNotFoundError(f"构建输出中没有匹配文件: {DEMO_OUTPUT_DIR / pattern}")
+        for source in sources:
+            shutil.copy2(source, STAGING_DIR / source.name)
+
+    hasp_ini = REPO_ROOT / "hasp_26146.ini"
+    require_file(hasp_ini)
+    shutil.copy2(hasp_ini, STAGING_DIR / hasp_ini.name)
+
+    demo_exe = STAGING_DIR / DEMO_EXE_NAME
+    require_file(demo_exe)
+    return demo_exe
+
+
+def snapshot_wheels() -> dict[Path, tuple[int, int, int]]:
+    dist_dir = REPO_ROOT / "dist"
+    return {
+        path.resolve(): (path.stat().st_mtime_ns, path.stat().st_ctime_ns, path.stat().st_size)
+        for path in dist_dir.glob("*.whl")
+    }
+
+
+def find_generated_wheel(before: dict[Path, tuple[int, int, int]]) -> Path:
+    dist_dir = REPO_ROOT / "dist"
+    generated: list[Path] = []
+    for path in dist_dir.glob("*.whl"):
+        resolved = path.resolve()
+        stat = path.stat()
+        current = (stat.st_mtime_ns, stat.st_ctime_ns, stat.st_size)
+        if before.get(resolved) != current:
+            generated.append(resolved)
+
+    if len(generated) != 1:
+        names = ", ".join(str(path) for path in sorted(generated)) or "无"
+        raise RuntimeError(f"无法唯一确认本次生成的 wheel: {names}")
+    return generated[0]
+
+
+def main() -> int:
+    args = parse_args()
+    os.chdir(REPO_ROOT)
+
+    sync_script = REPO_ROOT / "sync_assembly_version.py"
+    build_script = REPO_ROOT / ".cursor" / "skills" / "vs-build" / "scripts" / "build.py"
+    demo_project = REPO_ROOT / "DlcvDemo" / "DlcvDemo.csproj"
+
+    try:
+        require_file(sync_script)
+        require_file(build_script)
+        require_file(demo_project)
+        require_file(SIGNTOOL_PATH)
+
+        run_step("同步程序集版本", [sys.executable, str(sync_script)])
+        run_step(
+            "构建 C# 测试程序",
+            [
+                sys.executable,
+                str(build_script),
+                str(demo_project),
+                "--configuration",
+                "Release",
+                "--platform",
+                "x64",
+                "--target",
+                "Build",
+                "--verbosity",
+                "minimal",
+            ],
+        )
+
+        demo_exe = copy_package_files()
+        run_step(
+            "签名 C# 测试程序",
+            [
+                str(SIGNTOOL_PATH),
+                "sign",
+                "/n",
+                SIGN_CERT_SUBJECT,
+                "/t",
+                TIMESTAMP_URL,
+                "/fd",
+                "sha256",
+                "/v",
+                str(demo_exe),
+            ],
+        )
+        wheels_before_build = snapshot_wheels()
+        run_step(
+            "构建 wheel",
+            [sys.executable, "-m", "build", "--wheel", "--outdir", str(REPO_ROOT / "dist")],
+        )
+
+        wheel_path = find_generated_wheel(wheels_before_build)
+        install_status = "未安装（未指定 --install）"
+        if args.install:
+            run_step(
+                "安装本次生成的 wheel",
+                [sys.executable, "-m", "pip", "install", "--force-reinstall", str(wheel_path)],
+            )
+            install_status = "已安装"
+
+        print(f"[build_package] wheel: {wheel_path}")
+        print(f"[build_package] install: {install_status}")
+        return 0
+    except subprocess.CalledProcessError as exc:
+        exit_code = exc.returncode if exc.returncode != 0 else 1
+        print(f"[build_package] 步骤失败，退出码: {exit_code}", file=sys.stderr)
+        return exit_code
+    except Exception as exc:
+        print(f"[build_package] 失败: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dlcv_infer_cpp_dll/flow/FlowGraphModel.cpp
+++ b/dlcv_infer_cpp_dll/flow/FlowGraphModel.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <fstream>
 #include <stdexcept>
 #include <unordered_set>
@@ -196,6 +197,69 @@ static FlowBatchResult AggregateFrontendResults(ExecutionContext& ctx, int image
     }
 
     return batch;
+}
+
+static bool TryResolveFinalThreshold(const Json& paramsJson, double& threshold) {
+    if (!paramsJson.is_object() || !paramsJson.contains("threshold")) return false;
+    try {
+        const Json& value = paramsJson.at("threshold");
+        if (!value.is_number()) return false;
+        threshold = value.get<double>();
+        return std::isfinite(threshold);
+    } catch (...) {
+        return false;
+    }
+}
+
+static bool ShouldKeepFinalResult(const Json& result, double threshold) {
+    if (!result.is_object() || !result.contains("score")) return true;
+    try {
+        const Json& scoreValue = result.at("score");
+        if (!scoreValue.is_number()) return true;
+        const double score = scoreValue.get<double>();
+        return !std::isfinite(score) || score >= threshold;
+    } catch (...) {
+        return true;
+    }
+}
+
+static void FilterFinalResultArray(Json& results, double threshold) {
+    if (!results.is_array()) return;
+    for (auto it = results.begin(); it != results.end();) {
+        if (ShouldKeepFinalResult(*it, threshold)) {
+            ++it;
+        } else {
+            it = results.erase(it);
+        }
+    }
+}
+
+static void ApplyFinalThresholdFilter(Json& flowRoot, const Json& paramsJson) {
+    double threshold = 0.0;
+    if (!TryResolveFinalThreshold(paramsJson, threshold)) return;
+    if (!flowRoot.is_object() || !flowRoot.contains("result_list")) return;
+
+    Json& resultList = flowRoot["result_list"];
+    if (!resultList.is_array()) return;
+
+    bool isBatchContainer = false;
+    if (!resultList.empty()) {
+        const Json& first = resultList.front();
+        isBatchContainer = first.is_object() &&
+            first.contains("result_list") &&
+            first.at("result_list").is_array();
+    }
+
+    if (!isBatchContainer) {
+        FilterFinalResultArray(resultList, threshold);
+        return;
+    }
+
+    for (auto& entry : resultList) {
+        if (entry.is_object() && entry.contains("result_list") && entry["result_list"].is_array()) {
+            FilterFinalResultArray(entry["result_list"], threshold);
+        }
+    }
 }
 
 void FlowGraphModel::ReleaseOwnedModelsNoexcept() {
@@ -420,6 +484,7 @@ Json FlowGraphModel::InferInternal(const std::vector<cv::Mat>& images, const Jso
 
     const FlowBatchResult batch = AggregateFrontendResults(ctx, static_cast<int>(images.size()));
     Json root = batch.ToFlowRootJson();
+    ApplyFinalThresholdFilter(root, paramsJson);
 
     const std::vector<GraphExecutor::UnregisteredNodeInfo> unregistered = exec.GetLastUnregisteredNodes();
     if (!unregistered.empty()) {

--- a/dlcv_infer_cpp_dll/flow/GraphExecutor.cpp
+++ b/dlcv_infer_cpp_dll/flow/GraphExecutor.cpp
@@ -138,13 +138,13 @@ bool GraphExecutor::IsScalarPortType(const std::string& tLower) {
 static void ApplyInferParamOverrides(Json& props, const Json& inferParams) {
     if (!props.is_object() || !inferParams.is_object()) return;
     for (auto it = inferParams.begin(); it != inferParams.end(); ++it) {
-        // with_mask 仅用于控制最终返回格式，不应该全局覆盖流程节点属性。
-        // 否则会导致依赖 mask_rle 的后处理节点（如 mask_to_rbox）在流程内部被意外打断。
+        // with_mask 只控制最终返回格式；threshold 只筛选流程最终对外结果。
+        // threshold 不能覆盖节点属性，模型节点必须使用流程文件中自身的阈值。
         std::string keyLower = it.key();
         std::transform(keyLower.begin(), keyLower.end(), keyLower.begin(), [](unsigned char ch) {
             return static_cast<char>(std::tolower(ch));
         });
-        if (keyLower == "with_mask") {
+        if (keyLower == "with_mask" || keyLower == "threshold") {
             continue;
         }
 

--- a/dlcv_infer_cpp_qt_demo/dlcv_infer_cpp_qt_demo.vcxproj
+++ b/dlcv_infer_cpp_qt_demo/dlcv_infer_cpp_qt_demo.vcxproj
@@ -84,7 +84,8 @@
     <QtIncludeDir Condition="'$(QtIncludeDir)'==''">$(QtInstallDir)\include</QtIncludeDir>
     <QtLibDir Condition="'$(QtLibDir)'==''">$(QtInstallDir)\lib</QtLibDir>
     <QtPluginsDir Condition="'$(QtPluginsDir)'==''">$(QtInstallDir)\plugins</QtPluginsDir>
-    <DlcvInferCppDllOutDir>$(SolutionDir)$(Configuration)\</DlcvInferCppDllOutDir>
+    <DlcvInferCppDllOutDir Condition="'$(BuildingSolutionFile)'=='true'">$(SolutionDir)$(Configuration)\</DlcvInferCppDllOutDir>
+    <DlcvInferCppDllOutDir Condition="'$(BuildingSolutionFile)'!='true'">$(ProjectDir)..\dlcv_infer_cpp_dll\$(Configuration)\</DlcvInferCppDllOutDir>
     <DlcvInferCppDllPath>$(DlcvInferCppDllOutDir)dlcv_infer_cpp_dll.dll</DlcvInferCppDllPath>
   </PropertyGroup>
 

--- a/dlcv_infer_cpp_qt_demo/main.cpp
+++ b/dlcv_infer_cpp_qt_demo/main.cpp
@@ -1,7 +1,19 @@
 ﻿#include <QApplication>
+#include <QByteArray>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
 #include <QFont>
+#include <QSaveFile>
+#include <QStringList>
 
+#include <cmath>
 #include <iostream>
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 #include "MainWindow.h"
 #include "dlcv_infer.h"
@@ -12,7 +24,466 @@
 #include <dlfcn.h>
 #endif
 
-static std::string GetCppDllPath() {
+namespace {
+
+using json = nlohmann::json;
+
+struct InferOptions {
+    QString modelPath;
+    QString imagePath;
+    QString outputPath;
+    double threshold = 0.0;
+    int device = 0;
+    bool withMask = true;
+    bool hasModel = false;
+    bool hasImage = false;
+    bool hasThreshold = false;
+    bool hasDevice = false;
+    bool hasWithMask = false;
+    bool hasOutput = false;
+};
+
+struct PathSummary {
+    int count = 0;
+    json scores = json::array();
+    json categories = json::array();
+    json belowThreshold = json::array();
+    std::vector<double> comparableScores;
+    std::vector<std::string> comparableCategories;
+};
+
+class FreeAllModelsGuard {
+public:
+    ~FreeAllModelsGuard() {
+        try {
+            dlcv_infer::Utils::FreeAllModels();
+        } catch (...) {
+        }
+    }
+};
+
+class CoutSilencer {
+public:
+    CoutSilencer() : previous_(std::cout.rdbuf(buffer_.rdbuf())) {}
+
+    ~CoutSilencer() {
+        std::cout.rdbuf(previous_);
+    }
+
+    CoutSilencer(const CoutSilencer&) = delete;
+    CoutSilencer& operator=(const CoutSilencer&) = delete;
+
+private:
+    std::ostringstream buffer_;
+    std::streambuf* previous_ = nullptr;
+};
+
+std::string ToUtf8(const QString& value) {
+    const QByteArray bytes = value.toUtf8();
+    return std::string(bytes.constData(), static_cast<size_t>(bytes.size()));
+}
+
+QString FromExceptionMessage(const char* message) {
+    if (message == nullptr) {
+        return QStringLiteral("unknown error");
+    }
+    const QByteArray bytes(message);
+    const QString utf8 = QString::fromUtf8(bytes);
+    if (utf8.toUtf8() == bytes) {
+        return utf8;
+    }
+    return QString::fromLocal8Bit(bytes);
+}
+
+void PrintHelp(const QString& programPath) {
+    const std::string program = ToUtf8(programPath);
+    std::cout
+        << "Usage:\n"
+        << "  " << program << "\n"
+        << "  " << program
+        << " infer --model <path> --image <path> --threshold <0..1>"
+           " [--device <int>] [--with-mask <true|false>] [--output <jsonPath>]\n"
+        << "  " << program << " --help\n\n"
+        << "Exit codes: 0=passed, 1=runtime error, 2=invalid arguments, 3=validation failed\n";
+}
+
+bool ParseBool(const QString& value, bool& parsed) {
+    if (value.compare(QStringLiteral("true"), Qt::CaseInsensitive) == 0) {
+        parsed = true;
+        return true;
+    }
+    if (value.compare(QStringLiteral("false"), Qt::CaseInsensitive) == 0) {
+        parsed = false;
+        return true;
+    }
+    return false;
+}
+
+bool ParseInferOptions(const QStringList& args, InferOptions& options, QString& error) {
+    for (int i = 2; i < args.size(); i++) {
+        const QString option = args.at(i);
+        if (i + 1 >= args.size()) {
+            error = QStringLiteral("missing value for %1").arg(option);
+            return false;
+        }
+        const QString value = args.at(++i);
+
+        if (option == QStringLiteral("--model")) {
+            if (options.hasModel) {
+                error = QStringLiteral("duplicate option: --model");
+                return false;
+            }
+            options.modelPath = value;
+            options.hasModel = true;
+        } else if (option == QStringLiteral("--image")) {
+            if (options.hasImage) {
+                error = QStringLiteral("duplicate option: --image");
+                return false;
+            }
+            options.imagePath = value;
+            options.hasImage = true;
+        } else if (option == QStringLiteral("--threshold")) {
+            if (options.hasThreshold) {
+                error = QStringLiteral("duplicate option: --threshold");
+                return false;
+            }
+            bool ok = false;
+            const double parsed = value.toDouble(&ok);
+            if (!ok || !std::isfinite(parsed) || parsed < 0.0 || parsed > 1.0) {
+                error = QStringLiteral("--threshold must be a number in [0, 1]");
+                return false;
+            }
+            options.threshold = parsed;
+            options.hasThreshold = true;
+        } else if (option == QStringLiteral("--device")) {
+            if (options.hasDevice) {
+                error = QStringLiteral("duplicate option: --device");
+                return false;
+            }
+            bool ok = false;
+            const int parsed = value.toInt(&ok);
+            if (!ok) {
+                error = QStringLiteral("--device must be an integer");
+                return false;
+            }
+            options.device = parsed;
+            options.hasDevice = true;
+        } else if (option == QStringLiteral("--with-mask")) {
+            if (options.hasWithMask) {
+                error = QStringLiteral("duplicate option: --with-mask");
+                return false;
+            }
+            bool parsed = false;
+            if (!ParseBool(value, parsed)) {
+                error = QStringLiteral("--with-mask must be true or false");
+                return false;
+            }
+            options.withMask = parsed;
+            options.hasWithMask = true;
+        } else if (option == QStringLiteral("--output")) {
+            if (options.hasOutput) {
+                error = QStringLiteral("duplicate option: --output");
+                return false;
+            }
+            options.outputPath = value;
+            options.hasOutput = true;
+        } else {
+            error = QStringLiteral("unknown option: %1").arg(option);
+            return false;
+        }
+    }
+
+    if (!options.hasModel || options.modelPath.isEmpty()) {
+        error = QStringLiteral("--model is required");
+        return false;
+    }
+    if (!options.hasImage || options.imagePath.isEmpty()) {
+        error = QStringLiteral("--image is required");
+        return false;
+    }
+    if (!options.hasThreshold) {
+        error = QStringLiteral("--threshold is required");
+        return false;
+    }
+    if (options.hasOutput && options.outputPath.isEmpty()) {
+        error = QStringLiteral("--output cannot be empty");
+        return false;
+    }
+
+    const QFileInfo modelInfo(options.modelPath);
+    if (!modelInfo.exists() || !modelInfo.isFile()) {
+        error = QStringLiteral("model file does not exist");
+        return false;
+    }
+    const QFileInfo imageInfo(options.imagePath);
+    if (!imageInfo.exists() || !imageInfo.isFile()) {
+        error = QStringLiteral("image file does not exist");
+        return false;
+    }
+
+    if (options.hasOutput) {
+        const QFileInfo outputInfo(options.outputPath);
+        const QFileInfo outputDirectory(outputInfo.absolutePath());
+        if (!outputDirectory.exists() || !outputDirectory.isDir()) {
+            error = QStringLiteral("--output parent directory does not exist");
+            return false;
+        }
+
+#ifdef _WIN32
+        constexpr Qt::CaseSensitivity pathCaseSensitivity = Qt::CaseInsensitive;
+#else
+        constexpr Qt::CaseSensitivity pathCaseSensitivity = Qt::CaseSensitive;
+#endif
+        const QString outputFullPath = QDir::cleanPath(outputInfo.absoluteFilePath());
+        const QString modelCanonicalPath = modelInfo.canonicalFilePath();
+        const QString imageCanonicalPath = imageInfo.canonicalFilePath();
+        const QString modelFullPath = QDir::cleanPath(
+            modelCanonicalPath.isEmpty() ? modelInfo.absoluteFilePath() : modelCanonicalPath);
+        const QString imageFullPath = QDir::cleanPath(
+            imageCanonicalPath.isEmpty() ? imageInfo.absoluteFilePath() : imageCanonicalPath);
+        const QString outputCanonicalPath = outputInfo.canonicalFilePath();
+        const QString comparableOutputPath = QDir::cleanPath(
+            outputCanonicalPath.isEmpty() ? outputFullPath : outputCanonicalPath);
+        if (comparableOutputPath.compare(modelFullPath, pathCaseSensitivity) == 0 ||
+            comparableOutputPath.compare(imageFullPath, pathCaseSensitivity) == 0) {
+            error = QStringLiteral("--output cannot overwrite the model or image file");
+            return false;
+        }
+        options.outputPath = outputFullPath;
+    }
+    return true;
+}
+
+cv::Mat LoadImageUnicode(const QString& imagePath) {
+    QFile file(imagePath);
+    if (!file.open(QIODevice::ReadOnly)) {
+        throw std::runtime_error(ToUtf8(
+            QStringLiteral("failed to open image: %1").arg(file.errorString())));
+    }
+
+    const QByteArray encoded = file.readAll();
+    if (encoded.isEmpty()) {
+        throw std::runtime_error("image file is empty");
+    }
+    if (encoded.size() > std::numeric_limits<int>::max()) {
+        throw std::runtime_error("image file is too large");
+    }
+
+    const cv::Mat encodedMat(
+        1,
+        static_cast<int>(encoded.size()),
+        CV_8UC1,
+        const_cast<char*>(encoded.constData()));
+    cv::Mat decoded = cv::imdecode(encodedMat, cv::IMREAD_UNCHANGED);
+    if (decoded.empty()) {
+        throw std::runtime_error("image decode failed");
+    }
+    return decoded;
+}
+
+cv::Mat PrepareImageForInference(const cv::Mat& decodedImage) {
+    if (decodedImage.empty()) {
+        return {};
+    }
+    if (decodedImage.channels() == 3) {
+        cv::Mat rgb;
+        cv::cvtColor(decodedImage, rgb, cv::COLOR_BGR2RGB);
+        return rgb;
+    }
+    if (decodedImage.channels() == 4) {
+        cv::Mat rgb;
+        cv::cvtColor(decodedImage, rgb, cv::COLOR_BGRA2RGB);
+        return rgb;
+    }
+    return decodedImage.clone();
+}
+
+void AddSummaryItem(PathSummary& summary, double score, const std::string& category, double threshold) {
+    const int index = summary.count;
+    summary.count += 1;
+    summary.categories.push_back(category);
+    summary.comparableCategories.push_back(category);
+    summary.comparableScores.push_back(score);
+
+    if (!std::isfinite(score)) {
+        summary.scores.push_back(nullptr);
+        summary.belowThreshold.push_back(json{
+            {"index", index},
+            {"score", nullptr},
+            {"category", category}
+        });
+        return;
+    }
+
+    summary.scores.push_back(score);
+    if (score < threshold) {
+        summary.belowThreshold.push_back(json{
+            {"index", index},
+            {"score", score},
+            {"category", category}
+        });
+    }
+}
+
+PathSummary SummarizeStructured(const dlcv_infer::Result& result, double threshold) {
+    PathSummary summary;
+    for (const auto& sample : result.sampleResults) {
+        for (const auto& object : sample.results) {
+            AddSummaryItem(
+                summary,
+                static_cast<double>(object.score),
+                dlcv_infer::convertGbkToUtf8(object.categoryName),
+                threshold);
+        }
+    }
+    return summary;
+}
+
+bool TryReadJsonScore(const json& token, double& score) {
+    try {
+        if (!token.is_object() || !token.contains("score")) {
+            return false;
+        }
+        const json& value = token.at("score");
+        if (value.is_number()) {
+            score = value.get<double>();
+            return std::isfinite(score);
+        }
+        if (value.is_string()) {
+            size_t consumed = 0;
+            const std::string text = value.get<std::string>();
+            score = std::stod(text, &consumed);
+            return consumed == text.size() && std::isfinite(score);
+        }
+    } catch (...) {
+    }
+    return false;
+}
+
+PathSummary SummarizeJson(const json& result, double threshold) {
+    if (!result.is_array()) {
+        throw std::runtime_error("InferOneOutJson did not return a JSON array");
+    }
+
+    PathSummary summary;
+    for (const auto& token : result) {
+        if (!token.is_object()) {
+            AddSummaryItem(summary, std::numeric_limits<double>::quiet_NaN(), std::string(), threshold);
+            continue;
+        }
+
+        std::string category;
+        try {
+            if (token.contains("category_name") && token.at("category_name").is_string()) {
+                category = token.at("category_name").get<std::string>();
+            }
+        } catch (...) {
+        }
+
+        double score = std::numeric_limits<double>::quiet_NaN();
+        (void)TryReadJsonScore(token, score);
+        AddSummaryItem(summary, score, category, threshold);
+    }
+    return summary;
+}
+
+json PathSummaryToJson(const PathSummary& summary) {
+    return json{
+        {"count", summary.count},
+        {"scores", summary.scores},
+        {"categories", summary.categories},
+        {"below_threshold", summary.belowThreshold}
+    };
+}
+
+bool AreConsistent(const PathSummary& left, const PathSummary& right) {
+    if (left.count != right.count) {
+        return false;
+    }
+    if (left.comparableScores.size() != right.comparableScores.size() ||
+        left.comparableCategories != right.comparableCategories) {
+        return false;
+    }
+    for (size_t i = 0; i < left.comparableScores.size(); i++) {
+        if (!std::isfinite(left.comparableScores[i]) || !std::isfinite(right.comparableScores[i])) {
+            return false;
+        }
+        if (std::abs(left.comparableScores[i] - right.comparableScores[i]) > 1e-6) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void WriteJsonFile(const QString& outputPath, const std::string& jsonText) {
+    QSaveFile file(outputPath);
+    if (!file.open(QIODevice::WriteOnly)) {
+        throw std::runtime_error(ToUtf8(
+            QStringLiteral("failed to open output: %1").arg(file.errorString())));
+    }
+
+    const QByteArray bytes(jsonText.data(), static_cast<int>(jsonText.size()));
+    if (file.write(bytes) != bytes.size()) {
+        throw std::runtime_error(ToUtf8(
+            QStringLiteral("failed to write output: %1").arg(file.errorString())));
+    }
+    if (!file.commit()) {
+        throw std::runtime_error(ToUtf8(
+            QStringLiteral("failed to commit output: %1").arg(file.errorString())));
+    }
+}
+
+int RunInferCommand(const InferOptions& options) {
+    FreeAllModelsGuard cleanup;
+    PathSummary structuredSummary;
+    PathSummary jsonSummary;
+    {
+        CoutSilencer silenceApiLogs;
+        dlcv_infer::Model model(options.modelPath.toStdWString(), options.device);
+        const cv::Mat decoded = LoadImageUnicode(options.imagePath);
+        const cv::Mat inferImage = PrepareImageForInference(decoded);
+        if (inferImage.empty()) {
+            throw std::runtime_error("input image channel conversion failed");
+        }
+
+    json params = {
+        {"threshold", options.threshold},
+        {"with_mask", options.withMask}
+    };
+
+        const dlcv_infer::Result structuredResult = model.Infer(inferImage, params);
+        const json jsonResult = model.InferOneOutJson(inferImage, params);
+        structuredSummary = SummarizeStructured(structuredResult, options.threshold);
+        jsonSummary = SummarizeJson(jsonResult, options.threshold);
+    }
+
+    const bool consistent = AreConsistent(structuredSummary, jsonSummary);
+    const bool thresholdCheckPassed =
+        structuredSummary.belowThreshold.empty() && jsonSummary.belowThreshold.empty();
+
+    const json summary = {
+        {"language", "cpp"},
+        {"model", ToUtf8(options.modelPath)},
+        {"image", ToUtf8(options.imagePath)},
+        {"threshold", options.threshold},
+        {"device", options.device},
+        {"with_mask", options.withMask},
+        {"structured", PathSummaryToJson(structuredSummary)},
+        {"json", PathSummaryToJson(jsonSummary)},
+        {"consistent", consistent},
+        {"threshold_check_passed", thresholdCheckPassed}
+    };
+
+    const std::string output = summary.dump(2) + "\n";
+    std::cout << output;
+    std::cout.flush();
+    if (options.hasOutput) {
+        WriteJsonFile(options.outputPath, output);
+    }
+    return consistent && thresholdCheckPassed ? 0 : 3;
+}
+
+std::string GetCppDllPath() {
 #ifdef _WIN32
     char path[MAX_PATH];
     HMODULE hModule = nullptr;
@@ -31,11 +502,65 @@ static std::string GetCppDllPath() {
     return "";
 }
 
+}  // namespace
+
 int main(int argc, char* argv[]) {
+#ifdef _WIN32
+    SetConsoleOutputCP(CP_UTF8);
+    SetConsoleCP(CP_UTF8);
+#endif
+
     QApplication app(argc, argv);
     app.setApplicationName("C++测试程序");
     app.setOrganizationName("dlcv");
     app.setFont(QFont("Microsoft YaHei", 9));
+
+    const QStringList args = app.arguments();
+    if (args.size() > 1) {
+        if (args.at(1) == QStringLiteral("--help") ||
+            (args.at(1) == QStringLiteral("infer") && args.contains(QStringLiteral("--help")))) {
+            PrintHelp(args.at(0));
+            return 0;
+        }
+        if (args.at(1) != QStringLiteral("infer")) {
+            std::cerr << "error: expected 'infer' or '--help'\n";
+            PrintHelp(args.at(0));
+            return 2;
+        }
+
+        InferOptions options;
+        QString error;
+        if (!ParseInferOptions(args, options, error)) {
+            std::cerr << "error: " << ToUtf8(error) << "\n";
+            PrintHelp(args.at(0));
+            return 2;
+        }
+
+        try {
+            return RunInferCommand(options);
+        } catch (const std::exception& ex) {
+            const json errorJson = {
+                {"language", "cpp"},
+                {"model", ToUtf8(options.modelPath)},
+                {"image", ToUtf8(options.imagePath)},
+                {"threshold", options.threshold},
+                {"error", ToUtf8(FromExceptionMessage(ex.what()))}
+            };
+            std::cerr << errorJson.dump(2) << "\n";
+            return 1;
+        } catch (...) {
+            const json errorJson = {
+                {"language", "cpp"},
+                {"model", ToUtf8(options.modelPath)},
+                {"image", ToUtf8(options.imagePath)},
+                {"threshold", options.threshold},
+                {"error", "unknown error"}
+            };
+            std::cerr << errorJson.dump(2) << "\n";
+            return 1;
+        }
+    }
+
     QObject::connect(&app, &QCoreApplication::aboutToQuit, []() {
         dlcv_infer::Utils::FreeAllModels();
     });

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import shutil
 
 from setuptools import setup
 
-version = '2026.7.13.0'
+version = '2026.7.19.0a0'
 
 package_name = "dlcvpro_infer_csharp"  # 包名
 packages: list = [package_name]  # 需要打包的包

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import shutil
 
 from setuptools import setup
 
-version = '2026.7.19.0a0'
+version = '2026.7.19.1a0'
 
 package_name = "dlcvpro_infer_csharp"  # 包名
 packages: list = [package_name]  # 需要打包的包

--- a/开发文档.md
+++ b/开发文档.md
@@ -43,9 +43,17 @@
 - 构建目标、输出目录与运行入口仍以各子文档记录的工程文件、解决方案和产物为准。
 - 本节为各子文档中编译说明的统一引用位置。
 
+## C# 正式编译、打包与安装
+
+- C# 测试程序的正式编译打包入口为仓库根目录 `build_package.py`。
+- `python build_package.py` 依次同步程序集版本，通过 `.cursor/skills/vs-build/scripts/build.py` 以 `Release`、`x64`、`Build`、`minimal` 构建 `DlcvDemo/DlcvDemo.csproj`，重建 `dlcvpro_infer_csharp` 暂存目录，复制程序文件，签名 `C# 测试程序.exe`，并在 `dist/` 生成 wheel。
+- `python build_package.py --install` 在完成上述步骤后，使用当前 Python 环境的 `pip --force-reinstall` 安装本次生成的 wheel。
+- 脚本任一步骤失败时以非零状态退出；成功时输出最终 wheel 路径和安装状态。
+- C++ Qt 测试程序不进入 C# wheel，仍通过 `.cursor/skills/vs-build/scripts/build.py` 单独构建 `dlcv_infer_cpp_qt_demo/dlcv_infer_cpp_qt_demo.vcxproj`。
+
 ## 统一运行与验证输入规则
 
-- 本仓库所有程序、测试程序、自测入口、验证入口和临时排查入口均禁止使用命令行传参覆盖模型路径、图片路径、batch、阈值、运行次数、线程数或其他业务输入。
-- 需要切换验证输入时，只修改源码中的固定变量、常量字符串或配置对象字段。
-- 控制台测试程序也遵守该规则；验证时不通过 shell 命令行追加参数。
+- `DlcvDemo` 与 `dlcv_infer_cpp_qt_demo` 的 `infer` 命令行模式接受模型路径、图片路径、阈值、设备、mask 开关和可选 JSON 输出路径，用于无界面自动验证。
+- 两个实际测试程序无参数启动时保持原 GUI 行为。
+- 其他程序和专项自测只接受各自文档中已经定义的命令行参数；未记录的业务输入通过源码固定变量或配置对象字段设置。
 - 本节为各子文档中运行、验证和排查输入规则的统一引用位置。

--- a/模块、流程与模型推理标准文档.md
+++ b/模块、流程与模型推理标准文档.md
@@ -325,7 +325,7 @@ Flow 中的所有模块都围绕同一套运行时对象工作。这样做的直
 | 链路路由 | 预先建立 `linkId -> (srcNodeId, srcOutIdx)` 映射 |
 | 主通道与额外通道 | 每两个输入端口形成一组通道；第 0 组为主通道，其余进入 `ExtraInputsIn` |
 | 标量注入 | 把上游标量结果写入 `ScalarInputsByIndex` 和 `ScalarInputsByName` |
-| 入口参数覆盖 | `infer_params` 中的布尔、数字、字符串和空值覆盖节点同名属性；`with_mask` 只控制最终返回内容，不覆盖流程内部节点属性 |
+| 入口参数 | C# 节点使用流程配置属性；C++ 保留其他基础类型入口参数覆盖同名属性的既有行为。两端均不使用 `with_mask` 和 `threshold` 覆盖节点：`with_mask` 只控制最终返回内容，`threshold` 只在流程聚合完成后筛选最终对外结果 |
 | 模型预加载 | `LoadModels()` 只对 `model/*` 节点调用 `LoadModel()` |
 | 输出发布 | 每个节点执行后，把主输出写入公共输出表，把额外输出写入 `ExtraOutputs` |
 | 时间记录 | 记录图搭建、节点执行、输出发布等耗时 |

--- a/模块、流程与模型推理标准文档.md
+++ b/模块、流程与模型推理标准文档.md
@@ -325,6 +325,7 @@ Flow 中的所有模块都围绕同一套运行时对象工作。这样做的直
 | 链路路由 | 预先建立 `linkId -> (srcNodeId, srcOutIdx)` 映射 |
 | 主通道与额外通道 | 每两个输入端口形成一组通道；第 0 组为主通道，其余进入 `ExtraInputsIn` |
 | 标量注入 | 把上游标量结果写入 `ScalarInputsByIndex` 和 `ScalarInputsByName` |
+| 入口参数覆盖 | `infer_params` 中的布尔、数字、字符串和空值覆盖节点同名属性；`with_mask` 只控制最终返回内容，不覆盖流程内部节点属性 |
 | 模型预加载 | `LoadModels()` 只对 `model/*` 节点调用 `LoadModel()` |
 | 输出发布 | 每个节点执行后，把主输出写入公共输出表，把额外输出写入 `ExtraOutputs` |
 | 时间记录 | 记录图搭建、节点执行、输出发布等耗时 |


### PR DESCRIPTION
## 问题

流程归档模型的入口阈值与流程节点阈值职责不一致：

- C# 流程推理会执行流程节点自身配置，但最终对外结果没有按调用方传入的 `threshold` 过滤。
- C++ 流程执行器会把入口 `threshold` 覆盖到流程节点，导致流程文件中各模型节点保存的阈值失效。

本次统一语义为：流程作者负责配置各模型节点的推理阈值，调用方传入的 `threshold` 只筛选流程执行完成后的最终对外结果。

## 变更内容

### 流程模型阈值

- C# 流程节点继续使用流程文件中的 `properties.threshold`，不使用入口阈值改写节点属性。
- C++ 将 `threshold` 从入口参数覆盖逻辑中排除，保留流程节点自身阈值。
- C#、C++ 均在流程结果聚合完成后，按 `score >= threshold` 过滤最终结果。
- 单图、Batch、结构化结果和 JSON 结果复用同一过滤语义。
- 未传入有限数值 `threshold` 时不追加过滤；结果分数等于阈值时保留。
- 普通 `.dvt` / `.dvo` 模型的既有阈值行为不变。

### C# / C++ 实际测试程序命令行入口

- `DlcvDemo` 和 `dlcv_infer_cpp_qt_demo` 新增无界面 `infer` 模式，支持模型、图片、阈值、设备、mask 开关和 JSON 输出文件参数。
- 同一次命令分别执行结构化接口和 JSON 接口，并输出数量、分数、类别、一致性及低阈值结果摘要。
- 使用退出码区分成功、运行异常、参数错误和验证失败。
- 无参数启动时继续进入原 GUI，不改变现有桌面交互。
- C# WinExe 输出文件和 C++ 输出文件均使用 UTF-8，便于自动化读取。

### 构建、版本与文档

- 新增 C# 正式编译、签名、wheel 打包和安装入口 `build_package.py`。
- 测试版本更新为 `2026.7.19.1a0`，程序集数值版本为 `2026.7.19.1`。
- 调整 C++ Qt Demo 工程依赖与命令行构建产物配置。
- 同步更新 API、测试程序、统一构建和流程推理语义文档。

## 验证结果

测试输入：`AOI_120_50_s.dvst`、`AOI-1.jpg`。

| 程序 | threshold | 结构化结果 | JSON 结果 | 最低分 | 低于阈值 | 一致性 | 退出码 |
| --- | ---: | ---: | ---: | ---: | ---: | --- | ---: |
| 安装后 C# EXE | `0.8` | 13 | 13 | `0.94970703125` | 0 | 通过 | 0 |
| 安装后 C# EXE | `0.5` | 14 | 14 | `0.73876953125` | 0 | 通过 | 0 |
| C++ Release EXE | `0.8` | 13 | 13 | `0.94970703125` | 0 | 通过 | 0 |
| C++ Release EXE | `0.5` | 14 | 14 | `0.73876953125` | 0 | 通过 | 0 |

构建与安装：

- `python build_package.py --install`：C# Release x64 构建、EXE 签名、wheel 打包及安装成功。
- `.cursor/skills/vs-build/scripts/build.py dlcv_infer_cpp_qt_demo/dlcv_infer_cpp_qt_demo.vcxproj --configuration Release --platform x64 --target Build --verbosity minimal`：C++ Release x64 构建成功。
- 已安装包版本为 `2026.7.19.1a0`，安装后 C# EXE 产品版本为 `2026.7.19.1a0`，Authenticode 状态为 `Valid`。

## 兼容性

- 无参数启动 C# / C++ 测试程序时仍进入原 GUI。
- 普通模型推理路径未修改。
- 流程内部后处理仍能看到由流程节点阈值产生的完整中间结果，入口阈值只影响最终返回内容。
