### PR TITLE
修复: 完善错误日志、模板路径与流程模型缓存

### DIFF
--- a/DlcvCsharpApi/Utils.cs
+++ b/DlcvCsharpApi/Utils.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -387,6 +390,105 @@ namespace dlcv_infer_csharp
         public static void FreeAllModels()
         {
             DllLoader.Instance.dlcv_free_all_models?.Invoke();
+        }
+
+        /// <summary>
+        /// 可选的错误日志回调。PrintMatch 可在启动时注入 DLCV.Logging 写入器。
+        /// 签名：callback(scene, modelPath, isDvpMode, rawJson, parsedObject, ex, fieldNotes)
+        /// </summary>
+        public static Action<string, string, bool, string, JObject, Exception, IList<string>> OnDlcvJsonErrorLog { get; set; }
+
+        /// <summary>
+        /// 将 DLCV 推理错误写入 C:\dlcv\logs 结构化 JSON 日志，并触发可选回调。
+        /// </summary>
+        public static string WriteDlcvJsonErrorLog(
+            string scene,
+            string modelPath,
+            bool isDvpMode,
+            string rawJson,
+            JObject parsedObject,
+            Exception ex,
+            IList<string> fieldNotes)
+        {
+            string filePath = null;
+            try
+            {
+                string logDir = @"C:\dlcv\logs";
+                Directory.CreateDirectory(logDir);
+
+                string timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss_fff");
+                int pid = 0;
+                int tid = 0;
+                try { pid = Process.GetCurrentProcess().Id; } catch { pid = 0; }
+                try { tid = System.Threading.Thread.CurrentThread.ManagedThreadId; } catch { tid = 0; }
+
+                filePath = Path.Combine(logDir, $"dlcv_{timestamp}_pid{pid}_tid{tid}.log");
+
+                var notes = new List<string>();
+                if (fieldNotes != null)
+                {
+                    notes.AddRange(fieldNotes.Where(s => !string.IsNullOrWhiteSpace(s)));
+                }
+
+                if (notes.Count == 0 && parsedObject != null)
+                {
+                    try
+                    {
+                        var targetKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                        {
+                            "code",
+                            "model_index",
+                            "category_id",
+                            "score",
+                            "area",
+                            "with_bbox",
+                            "with_mask"
+                        };
+                        foreach (var prop in parsedObject.Properties())
+                        {
+                            if (prop.Value == null || prop.Value.Type == JTokenType.Null)
+                            {
+                                notes.Add($"{prop.Name}: null");
+                            }
+                            else if (targetKeys.Contains(prop.Name) && prop.Value.Type == JTokenType.Undefined)
+                            {
+                                notes.Add($"{prop.Name}: undefined");
+                            }
+                        }
+                    }
+                    catch { }
+                }
+
+                var logObject = new JObject
+                {
+                    ["timestamp"] = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff"),
+                    ["scene"] = scene,
+                    ["model_path"] = modelPath,
+                    ["is_dvp_mode"] = isDvpMode,
+                    ["pid"] = pid,
+                    ["tid"] = tid,
+                    ["exception_type"] = ex?.GetType()?.FullName,
+                    ["exception_message"] = ex?.Message,
+                    ["exception_stacktrace"] = ex?.StackTrace,
+                    ["raw_json"] = rawJson,
+                    ["parsed_object"] = parsedObject,
+                    ["notes"] = JArray.FromObject(notes)
+                };
+
+                File.WriteAllText(filePath, logObject.ToString(Formatting.Indented), Encoding.UTF8);
+
+                // 触发外部注入的日志器（如 DLCV.Logging）
+                try
+                {
+                    OnDlcvJsonErrorLog?.Invoke(scene, modelPath, isDvpMode, rawJson, parsedObject, ex, notes);
+                }
+                catch { }
+            }
+            catch (Exception writeEx)
+            {
+                Console.WriteLine($"WriteDlcvJsonErrorLog 失败: {writeEx.Message}");
+            }
+            return filePath;
         }
 
         public static JObject GetDeviceInfo()

--- a/DlcvCsharpApi/flow/modules/Models.cs
+++ b/DlcvCsharpApi/flow/modules/Models.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -22,9 +23,176 @@ namespace DlcvModules
 		protected JArray _maxShape;
 		protected int _maxBatchSize = 1;
 
-		// 按 (modelPath|deviceId|rpcMode) 缓存 Model 实例，避免 Flow 每次推理重复加载
-		private static readonly Dictionary<string, Model> _modelCache = new Dictionary<string, Model>(StringComparer.OrdinalIgnoreCase);
+		private sealed class CachedModelEntry
+		{
+			public string ModelPath;
+			public int DeviceId;
+			public bool RpcMode;
+			public Model Model;
+			public long FileLength;
+			public DateTime LastWriteTimeUtc;
+		}
+
+		private struct ModelFileVersion
+		{
+			public long FileLength;
+			public DateTime LastWriteTimeUtc;
+
+			public bool Matches(ModelFileVersion other)
+			{
+				return other.FileLength == FileLength &&
+					other.LastWriteTimeUtc == LastWriteTimeUtc;
+			}
+		}
+
+		// 按 (modelPath|deviceId|rpcMode|fileLength|lastWriteTimeUtc) 缓存 Model 实例。
+		// 同一路径热替换后，新旧版本并存，直到所有流程停止并显式调用 ReleaseAllCachedModels。
+		private static readonly Dictionary<string, CachedModelEntry> _modelCache = new Dictionary<string, CachedModelEntry>(StringComparer.OrdinalIgnoreCase);
+		// 回滚释放失败的模型只能等待后续清理重试，不参与任何缓存命中。
+		private static readonly List<CachedModelEntry> _pendingReleaseModels = new List<CachedModelEntry>();
 		private static readonly object _modelCacheLock = new object();
+
+		private static string NormalizeModelPath(string modelPath)
+		{
+			if (string.IsNullOrWhiteSpace(modelPath))
+				throw new InvalidOperationException("模型路径为空");
+			return Path.GetFullPath(modelPath).Trim();
+		}
+
+		private static string BuildModelCacheKey(
+			string modelPath,
+			int deviceId,
+			bool rpcMode,
+			ModelFileVersion fileVersion)
+		{
+			return modelPath + "|" +
+				deviceId.ToString(CultureInfo.InvariantCulture) + "|" +
+				(rpcMode ? "rpc" : "local") + "|" +
+				fileVersion.FileLength.ToString(CultureInfo.InvariantCulture) + "|" +
+				fileVersion.LastWriteTimeUtc.Ticks.ToString(CultureInfo.InvariantCulture);
+		}
+
+		private static ModelFileVersion ReadModelFileVersion(string modelPath)
+		{
+			var file = new FileInfo(modelPath);
+			if (!file.Exists)
+				throw new FileNotFoundException("模型文件不存在", modelPath);
+			return new ModelFileVersion
+			{
+				FileLength = file.Length,
+				LastWriteTimeUtc = file.LastWriteTimeUtc
+			};
+		}
+
+		/// <summary>
+		/// 释放全部 Flow 模型缓存。
+		/// 调用前必须先停止所有流程执行。
+		/// </summary>
+		public static int ReleaseAllCachedModels()
+		{
+			lock (_modelCacheLock)
+			{
+				var cachedEntries = new List<KeyValuePair<string, CachedModelEntry>>(_modelCache);
+				var pendingEntries = new List<CachedModelEntry>(_pendingReleaseModels);
+				List<Exception> errors = null;
+				int disposedCount = 0;
+				foreach (var pair in cachedEntries)
+				{
+					var entry = pair.Value;
+					if (entry == null || entry.Model == null)
+					{
+						_modelCache.Remove(pair.Key);
+						continue;
+					}
+					try
+					{
+						ReleaseCachedModel(entry.Model);
+						CachedModelEntry current;
+						if (_modelCache.TryGetValue(pair.Key, out current) && object.ReferenceEquals(current, entry))
+							_modelCache.Remove(pair.Key);
+						disposedCount++;
+					}
+					catch (Exception ex)
+					{
+						if (errors == null) errors = new List<Exception>();
+						errors.Add(CreateReleaseException(entry, ex));
+					}
+				}
+				foreach (var entry in pendingEntries)
+				{
+					if (entry == null || entry.Model == null)
+					{
+						RemovePendingReleaseLocked(entry);
+						continue;
+					}
+					try
+					{
+						ReleaseCachedModel(entry.Model);
+						RemovePendingReleaseLocked(entry);
+						disposedCount++;
+					}
+					catch (Exception ex)
+					{
+						if (errors == null) errors = new List<Exception>();
+						errors.Add(CreateReleaseException(entry, ex));
+					}
+				}
+				if (errors != null)
+				{
+					throw new AggregateException(
+						"释放 Flow 模型缓存失败: total=" + (cachedEntries.Count + pendingEntries.Count).ToString(CultureInfo.InvariantCulture) +
+						", disposed=" + disposedCount.ToString(CultureInfo.InvariantCulture) +
+						", failed=" + errors.Count.ToString(CultureInfo.InvariantCulture),
+						errors);
+				}
+				return disposedCount;
+			}
+		}
+
+		private static void AddPendingReleaseLocked(CachedModelEntry entry)
+		{
+			if (entry == null || entry.Model == null) return;
+			for (int i = 0; i < _pendingReleaseModels.Count; i++)
+			{
+				var pending = _pendingReleaseModels[i];
+				if (pending != null && object.ReferenceEquals(pending.Model, entry.Model))
+					return;
+			}
+			_pendingReleaseModels.Add(entry);
+		}
+
+		private static void RemovePendingReleaseLocked(CachedModelEntry entry)
+		{
+			for (int i = _pendingReleaseModels.Count - 1; i >= 0; i--)
+			{
+				if (object.ReferenceEquals(_pendingReleaseModels[i], entry))
+					_pendingReleaseModels.RemoveAt(i);
+			}
+		}
+
+		private static void ReleaseCachedModel(Model model)
+		{
+			if (model == null) return;
+			model.FreeModel();
+			if (model.modelIndex != -1)
+			{
+				throw new InvalidOperationException(
+					"Model.FreeModel 返回后 modelIndex 仍有效: " +
+					model.modelIndex.ToString(CultureInfo.InvariantCulture));
+			}
+			model.Dispose();
+		}
+
+		private static Exception CreateReleaseException(CachedModelEntry entry, Exception error)
+		{
+			return new InvalidOperationException(
+				"释放 Flow 模型缓存条目失败: path=" + entry.ModelPath +
+				", device_id=" + entry.DeviceId.ToString(CultureInfo.InvariantCulture) +
+				", rpc_mode=" + entry.RpcMode +
+				", file_length=" + entry.FileLength.ToString(CultureInfo.InvariantCulture) +
+				", last_write_utc=" + entry.LastWriteTimeUtc.ToString("O", CultureInfo.InvariantCulture),
+				error);
+		}
 
 		protected BaseModelModule(int nodeId, string title = null, Dictionary<string, object> properties = null, ExecutionContext context = null)
 			: base(nodeId, title, properties, context)
@@ -68,15 +236,80 @@ namespace DlcvModules
 					try { _modelPath = Context.Get<string>("model_path", null); } catch { }
 				}
 
-				string cacheKey = (_modelPath ?? "") + "|" + deviceId + "|" + rpcMode;
-				bool cacheHit = false;
+				_modelPath = NormalizeModelPath(_modelPath);
+				var fileVersion = ReadModelFileVersion(_modelPath);
+				string cacheKey = BuildModelCacheKey(_modelPath, deviceId, rpcMode, fileVersion);
 				lock (_modelCacheLock)
 				{
-					cacheHit = _modelCache.TryGetValue(cacheKey, out _model);
-					if (!cacheHit)
+					CachedModelEntry cached;
+					if (_modelCache.TryGetValue(cacheKey, out cached) && cached != null && cached.Model != null)
 					{
-						_model = new Model(_modelPath, deviceId, rpcMode, true);
-						_modelCache[cacheKey] = _model;
+						_model = cached.Model;
+					}
+					else
+					{
+						Model loadedModel = null;
+						CachedModelEntry loadedEntry = null;
+						try
+						{
+							loadedModel = new Model(_modelPath, deviceId, rpcMode, false);
+							loadedEntry = new CachedModelEntry
+							{
+								ModelPath = _modelPath,
+								DeviceId = deviceId,
+								RpcMode = rpcMode,
+								Model = loadedModel,
+								FileLength = fileVersion.FileLength,
+								LastWriteTimeUtc = fileVersion.LastWriteTimeUtc
+							};
+							var loadedVersion = ReadModelFileVersion(_modelPath);
+							loadedEntry.FileLength = loadedVersion.FileLength;
+							loadedEntry.LastWriteTimeUtc = loadedVersion.LastWriteTimeUtc;
+							if (!fileVersion.Matches(loadedVersion))
+								throw new InvalidOperationException("模型文件在加载过程中发生变化: " + _modelPath);
+
+							_modelCache[cacheKey] = loadedEntry;
+							_model = loadedModel;
+						}
+						catch (Exception loadError)
+						{
+							_model = null;
+							if (loadedModel != null)
+							{
+								if (loadedEntry == null)
+								{
+									loadedEntry = new CachedModelEntry
+									{
+										ModelPath = _modelPath,
+										DeviceId = deviceId,
+										RpcMode = rpcMode,
+										Model = loadedModel,
+										FileLength = fileVersion.FileLength,
+										LastWriteTimeUtc = fileVersion.LastWriteTimeUtc
+									};
+								}
+								CachedModelEntry current;
+								if (_modelCache.TryGetValue(cacheKey, out current) && object.ReferenceEquals(current, loadedEntry))
+									_modelCache.Remove(cacheKey);
+								try
+								{
+									ReleaseCachedModel(loadedModel);
+								}
+								catch (Exception disposeError)
+								{
+									AddPendingReleaseLocked(loadedEntry);
+									throw new AggregateException(
+										"Flow 模型加载失败且回滚释放未完成: path=" + _modelPath +
+										", device_id=" + deviceId.ToString(CultureInfo.InvariantCulture) +
+										", rpc_mode=" + rpcMode +
+										", file_length=" + loadedEntry.FileLength.ToString(CultureInfo.InvariantCulture) +
+										", last_write_utc=" + loadedEntry.LastWriteTimeUtc.ToString("O", CultureInfo.InvariantCulture),
+										loadError,
+										CreateReleaseException(loadedEntry, disposeError));
+								}
+							}
+							throw;
+						}
 					}
 				}
 				SyncModelMeta();

--- a/DlcvCsharpApi/flow/modules/Templates.cs
+++ b/DlcvCsharpApi/flow/modules/Templates.cs
@@ -261,6 +261,32 @@ namespace DlcvModules
 
 	}
 
+
+	internal static class TemplatePathResolver
+	{
+		internal static string ResolveTemplatesDirectory(ExecutionContext context)
+		{
+			string dir = context != null ? context.Get<string>("templates_dir", null) : null;
+			if (string.IsNullOrWhiteSpace(dir))
+				throw new InvalidOperationException("templates_dir is empty");
+
+			string fullPath;
+			try
+			{
+				fullPath = Path.GetFullPath(dir);
+				Directory.CreateDirectory(fullPath);
+			}
+			catch (Exception ex)
+			{
+				throw new InvalidOperationException("templates_dir is unavailable: path=" + dir + ", " + ex.Message, ex);
+			}
+
+			if (!Directory.Exists(fullPath))
+				throw new InvalidOperationException("templates_dir was not created: path=" + fullPath);
+			return fullPath;
+		}
+	}
+
 	/// <summary>
 	/// 2) 存储模版：将 SimpleTemplate 写入 JSON 文件；如有首张图像则保存 PNG 同名文件。
 	/// type: features/template_save
@@ -282,21 +308,7 @@ namespace DlcvModules
 		{
 			var images = imageList ?? new List<ModuleImage>();
 			var results = resultList != null ? new JArray(resultList) : new JArray();
-			string dir = this.Context != null ? this.Context.Get<string>("templates_dir", null) : null;
-			string effDir = dir;
-			try
-			{
-				if (string.IsNullOrWhiteSpace(effDir))
-				{
-					effDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "模版");
-				}
-				else if (!Path.IsPathRooted(effDir))
-				{
-					effDir = Path.GetFullPath(effDir);
-				}
-			}
-			catch { }
-			try { if (!string.IsNullOrWhiteSpace(effDir)) Directory.CreateDirectory(effDir); } catch { }
+			string effDir = TemplatePathResolver.ResolveTemplatesDirectory(this.Context);
 
 			// 从模版主通道读取
 			SimpleTemplate tpl = null;
@@ -1055,8 +1067,7 @@ namespace DlcvModules
 			var images = imageList ?? new List<ModuleImage>();
 			var results = resultList ?? new JArray();
 
-			string saveDir = this.Context != null ? this.Context.Get<string>("templates_dir", null) : null;
-			if (!string.IsNullOrWhiteSpace(saveDir)) { try { Directory.CreateDirectory(saveDir); } catch { } }
+			string saveDir = TemplatePathResolver.ResolveTemplatesDirectory(this.Context);
 			string productType = ReadStringOrDefault("product_type", null);
 			productType = productType ?? string.Empty;
 
@@ -1178,7 +1189,7 @@ namespace DlcvModules
 
 			// 计算模版文件路径（固定使用执行上下文中的 templates_dir）
 			string fname = SimpleTemplateUtils.MakeSafeFileName(templateName);
-			string jsonPath = string.IsNullOrWhiteSpace(saveDir) ? (fname + ".json") : Path.Combine(saveDir, fname + ".json");
+			string jsonPath = Path.Combine(saveDir, fname + ".json");
 
 			// 分支 B：无现存模版 -> 保存模版与 PNG（PNG 使用首图 OriginalImage），随后与自身匹配
 			if (!File.Exists(jsonPath))
@@ -1201,7 +1212,18 @@ namespace DlcvModules
 					["file_name"] = fname
 				});
 				saver.MainTemplateList = new List<SimpleTemplate> { tpl };
-				try { saver.Process(imagesForSave, results); } catch { }
+				try
+				{
+					saver.Process(imagesForSave, results);
+				}
+				catch (Exception ex)
+				{
+					throw new InvalidOperationException(
+						"template save failed: template=" + templateName +
+						", face=" + (face ?? string.Empty) +
+						", path=" + jsonPath + ", " + ex.Message,
+						ex);
+				}
 
 				// 自匹配：golden 使用磁盘上已保存（已过滤）的模版文件
 				var goldenListSelf = new List<SimpleTemplate>();
@@ -1212,7 +1234,10 @@ namespace DlcvModules
 				// 保存完成后校验文件存在
 				if (!File.Exists(jsonPath))
 				{
-					throw new Exception("template save failed: file not found");
+					throw new Exception(
+						"template save failed: file not found, template=" + templateName +
+						", face=" + (face ?? string.Empty) +
+						", path=" + jsonPath);
 				}
 				var loSelf = loaderSelf.Process(images, results);
 				if (loSelf == null || loSelf.TemplateList == null || loSelf.TemplateList.Count == 0)


### PR DESCRIPTION
## 目标

完善 OpenIVS C# Flow 在错误日志、模板路径和流程模型缓存方面的生命周期边界。

## 最终变更

- 恢复 DLCV JSON 错误日志回调，使 PrintMatch 可统一接收底层解析错误。
- 统一模板保存与加载目录，避免同一模板在不同路径间错位。
- Flow 模型缓存按规范化路径、设备、RPC 模式、文件长度和修改时间区分版本。
- 同一路径热替换时不释放仍可能被推理使用的旧模型，统一在流程停止后的 Shutdown 阶段释放。
- 模型加载回滚释放失败时进入不可参与命中的 pending 列表，后续 Shutdown 重试；成功后才移除。
- 释放失败同时保留加载异常与清理异常，不再让原生/GPU 模型实例从缓存跟踪中失联。

## 验证

- PrintMatch.sln：Debug、x64、Build、minimal，0 error，2 条既有 CS1998 warning。
- PrintMatch SequenceGraph：151 passed、0 failed、1 skipped。
- BACD、BD、D-B、ACD-B 使用四个独立 PrintMatchUI 进程串行完成 12 轮软件验收，四进程退出码均为 0。
- 四进程结束后显存回到各自启动前基线，DVST 临时目录计数保持 181，日志无 ERROR/CRITICAL。