### PR TITLE
fix: DlcvTest 批量预测 RGB 对齐、报表与编译打包

### DIFF
--- a/99_编译打包DlcvTest.bat
+++ b/99_编译打包DlcvTest.bat
@@ -1,0 +1,70 @@
+@echo off
+chcp 936 >nul
+setlocal EnableExtensions
+cd /d "%~dp0"
+
+set "ROOT=%~dp0"
+set "PROJ=%ROOT%DlcvTest\DlcvTest.csproj"
+set "BUILD_PY=%ROOT%.cursor\skills\vs-build\scripts\build.py"
+set "OUT_DIR=%ROOT%DlcvTest\bin\x64\Release"
+set "ZIP_PATH=%ROOT%DlcvTest.zip"
+set "SEVEN_Z=C:\Program Files\7-Zip\7z.exe"
+
+echo ========================================
+echo  编译打包 DlcvTest (Release x64)
+echo ========================================
+echo.
+
+if not exist "%PROJ%" (
+    echo [错误] 未找到项目文件: %PROJ%
+    goto :fail
+)
+
+if not exist "%BUILD_PY%" (
+    echo [错误] 未找到编译脚本: %BUILD_PY%
+    goto :fail
+)
+
+if not exist "%SEVEN_Z%" (
+    echo [错误] 未找到 7-Zip: %SEVEN_Z%
+    goto :fail
+)
+
+echo [1/2] Release x64 编译 DlcvTest ...
+python "%BUILD_PY%" "%PROJ%" --configuration Release --platform x64 --target Build --verbosity minimal
+if errorlevel 1 (
+    echo [错误] 编译失败
+    goto :fail
+)
+
+if not exist "%OUT_DIR%\DlcvTest.exe" (
+    echo [错误] 未找到编译产物: %OUT_DIR%\DlcvTest.exe
+    goto :fail
+)
+
+echo.
+echo [2/2] 7z 打包到仓库根目录 DlcvTest.zip ...
+if exist "%ZIP_PATH%" del /f /q "%ZIP_PATH%"
+"%SEVEN_Z%" a -tzip -mx=9 "%ZIP_PATH%" "%OUT_DIR%\*" -x!*.pdb -x!*.xml
+if errorlevel 1 (
+    echo [错误] 打包失败
+    goto :fail
+)
+
+echo.
+echo ========================================
+echo  完成
+echo  产物目录: %OUT_DIR%
+echo  压缩包:   %ZIP_PATH%
+echo ========================================
+echo.
+pause
+endlocal
+exit /b 0
+
+:fail
+echo.
+echo 失败，已中止。
+pause
+endlocal
+exit /b 1

--- a/99_编译打包DlcvTest.bat
+++ b/99_编译打包DlcvTest.bat
@@ -7,8 +7,14 @@ set "ROOT=%~dp0"
 set "PROJ=%ROOT%DlcvTest\DlcvTest.csproj"
 set "BUILD_PY=%ROOT%.cursor\skills\vs-build\scripts\build.py"
 set "OUT_DIR=%ROOT%DlcvTest\bin\x64\Release"
-set "ZIP_PATH=%ROOT%DlcvTest.zip"
 set "SEVEN_Z=C:\Program Files\7-Zip\7z.exe"
+
+for /f %%i in ('powershell -NoProfile -Command "Get-Date -Format yyyyMMdd"') do set "DATE_TAG=%%i"
+if not defined DATE_TAG (
+    echo [错误] 无法获取日期
+    goto :fail
+)
+set "ZIP_PATH=%ROOT%DlcvTest_%DATE_TAG%.zip"
 
 echo ========================================
 echo  编译打包 DlcvTest (Release x64)
@@ -43,7 +49,7 @@ if not exist "%OUT_DIR%\DlcvTest.exe" (
 )
 
 echo.
-echo [2/2] 7z 打包到仓库根目录 DlcvTest.zip ...
+echo [2/2] 7z 打包到仓库根目录 DlcvTest_%DATE_TAG%.zip ...
 echo      排除: dll\ 目录、*.pdb、OpenCvSharpExtern.dll、opencv_videoio_ffmpeg*.dll
 if exist "%ZIP_PATH%" del /f /q "%ZIP_PATH%"
 

--- a/99_编译打包DlcvTest.bat
+++ b/99_编译打包DlcvTest.bat
@@ -44,9 +44,25 @@ if not exist "%OUT_DIR%\DlcvTest.exe" (
 
 echo.
 echo [2/2] 7z 打包到仓库根目录 DlcvTest.zip ...
+echo      排除: dll\ 目录、*.pdb、OpenCvSharpExtern.dll、opencv_videoio_ffmpeg*.dll
 if exist "%ZIP_PATH%" del /f /q "%ZIP_PATH%"
-"%SEVEN_Z%" a -tzip -mx=9 "%ZIP_PATH%" "%OUT_DIR%\*" -x!*.pdb -x!*.xml
+
+pushd "%OUT_DIR%"
 if errorlevel 1 (
+    echo [错误] 无法进入输出目录: %OUT_DIR%
+    goto :fail
+)
+
+"%SEVEN_Z%" a -tzip -mx=9 "%ZIP_PATH%" * ^
+  -x!*.pdb ^
+  -x!*.xml ^
+  -xr!dll ^
+  -x!OpenCvSharpExtern.dll ^
+  -x!opencv_videoio_ffmpeg4100_64.dll ^
+  -x!opencv_videoio_ffmpeg*.dll
+set "PACK_ERR=%ERRORLEVEL%"
+popd
+if not "%PACK_ERR%"=="0" (
     echo [错误] 打包失败
     goto :fail
 )

--- a/DlcvTest/DlcvTest.csproj
+++ b/DlcvTest/DlcvTest.csproj
@@ -124,6 +124,7 @@
       <DependentUpon>MainWindow.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Views\MainWindow\BatchReport.cs" />
     <Compile Include="Views\MainWindow\MainWindow.Diagnostics.cs" />
     <Compile Include="Views\MainWindow\MainWindow.Events.cs" />
     <Compile Include="Views\MainWindow\MainWindow.Infer.cs" />

--- a/DlcvTest/Properties/Settings.cs
+++ b/DlcvTest/Properties/Settings.cs
@@ -151,6 +151,21 @@ namespace DlcvTest.Properties
         /// </summary>
         public int ThreadCount { get; set; } = 4;
 
+        /// <summary>
+        /// 批量推测：是否输出汇总简报（耗时/OK·NG/类别分布等）。
+        /// </summary>
+        public bool RunEvaluation { get; set; } = true;
+
+        /// <summary>
+        /// 批量推测：是否输出每张图的逐目标详细统计。
+        /// </summary>
+        public bool SaveDetailedPredictData { get; set; } = false;
+
+        /// <summary>
+        /// 批量推测：是否输出过漏检分析（依赖同名 LabelMe JSON；建议同时开启详细统计）。
+        /// </summary>
+        public bool SaveMissedData { get; set; } = false;
+
         public void Save()
         {
             try

--- a/DlcvTest/Views/MainWindow/BatchReport.cs
+++ b/DlcvTest/Views/MainWindow/BatchReport.cs
@@ -1,0 +1,561 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json.Linq;
+
+namespace DlcvTest
+{
+    /// <summary>
+    /// 批量预测报表：汇总简报、详细统计、过漏检分析（对齐 dlcv_test_2 的 txt 报表语义）。
+    /// </summary>
+    internal static class BatchReport
+    {
+        public sealed class PredObject
+        {
+            public string CategoryName { get; set; }
+            public float Score { get; set; }
+            public List<double> Bbox { get; set; }
+        }
+
+        public sealed class ImageRecord
+        {
+            public string ImagePath { get; set; }
+            public bool Success { get; set; }
+            public bool HasResults { get; set; }
+            public double InferMs { get; set; }
+            public List<PredObject> Objects { get; set; } = new List<PredObject>();
+        }
+
+        public sealed class SummaryInput
+        {
+            public string OutputDir { get; set; }
+            public string ReportName { get; set; }
+            public string SrcDir { get; set; }
+            public string ModelPath { get; set; }
+            public double Threshold { get; set; }
+            public DateTime StartTime { get; set; }
+            public TimeSpan Elapsed { get; set; }
+            public IList<ImageRecord> Records { get; set; }
+            public bool WriteSummary { get; set; } = true;
+            public bool WriteDetailed { get; set; }
+            public bool WriteMissed { get; set; }
+            public double IouThreshold { get; set; } = 0.5;
+        }
+
+        public static void WriteAll(SummaryInput input)
+        {
+            if (input == null) throw new ArgumentNullException(nameof(input));
+            if (string.IsNullOrWhiteSpace(input.OutputDir)) throw new ArgumentException("OutputDir 为空", nameof(input));
+            if (input.Records == null) input.Records = Array.Empty<ImageRecord>();
+
+            Directory.CreateDirectory(input.OutputDir);
+
+            string reportName = string.IsNullOrWhiteSpace(input.ReportName) ? "batch_report" : SanitizeFileName(input.ReportName);
+            if (input.WriteSummary)
+            {
+                string summaryPath = Path.Combine(input.OutputDir, reportName + ".txt");
+                WriteSummary(summaryPath, input);
+            }
+
+            if (input.WriteDetailed)
+            {
+                string detailDir = Path.Combine(input.OutputDir, "详细统计");
+                Directory.CreateDirectory(detailDir);
+                string detailPath = Path.Combine(detailDir, reportName + "_详细统计.txt");
+                WriteDetailedStatistics(detailPath, input.Records);
+
+                if (input.WriteMissed)
+                {
+                    string missedDir = Path.Combine(detailDir, "过漏检分析");
+                    Directory.CreateDirectory(missedDir);
+                    string missedPath = Path.Combine(missedDir, reportName + "_过漏检分析.txt");
+                    WriteMissedDetectionAnalysis(missedPath, input.Records, input.SrcDir, input.IouThreshold);
+                }
+            }
+        }
+
+        private static void WriteSummary(string path, SummaryInput input)
+        {
+            var records = input.Records;
+            int total = records.Count;
+            int ok = records.Count(r => r.Success && !r.HasResults);
+            int ng = records.Count(r => r.Success && r.HasResults);
+            int failed = records.Count(r => !r.Success);
+
+            var categoryDist = new Dictionary<string, int>(StringComparer.Ordinal);
+            int resultCount = 0;
+            foreach (var rec in records)
+            {
+                if (rec?.Objects == null) continue;
+                foreach (var obj in rec.Objects)
+                {
+                    string name = string.IsNullOrWhiteSpace(obj.CategoryName) ? "未知" : obj.CategoryName.Trim();
+                    if (!categoryDist.ContainsKey(name)) categoryDist[name] = 0;
+                    categoryDist[name]++;
+                    resultCount++;
+                }
+            }
+
+            var inferMsList = records.Where(r => r.Success && r.InferMs > 0).Select(r => r.InferMs).ToList();
+            double avgInfer = inferMsList.Count > 0 ? inferMsList.Average() : 0.0;
+            double minInfer = inferMsList.Count > 0 ? inferMsList.Min() : 0.0;
+            double maxInfer = inferMsList.Count > 0 ? inferMsList.Max() : 0.0;
+
+            string elapsedText = FormatElapsed(input.Elapsed);
+            double okPct = total > 0 ? ok * 100.0 / total : 0.0;
+            double ngPct = total > 0 ? ng * 100.0 / total : 0.0;
+
+            var sb = new StringBuilder();
+            sb.AppendLine("测试时间: " + input.StartTime.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture));
+            sb.AppendLine("预测耗时: " + elapsedText);
+            sb.AppendLine("数据集路径: " + (input.SrcDir ?? string.Empty));
+            sb.AppendLine("模型路径: " + (input.ModelPath ?? string.Empty));
+            sb.AppendLine("阈值: " + input.Threshold.ToString("0.####", CultureInfo.InvariantCulture));
+            sb.AppendLine("图片数量: " + total.ToString(CultureInfo.InvariantCulture));
+            sb.AppendLine("OK图片数量: " + ok.ToString(CultureInfo.InvariantCulture));
+            sb.AppendLine("NG图片数量: " + ng.ToString(CultureInfo.InvariantCulture));
+            sb.AppendLine("失败图片数量: " + failed.ToString(CultureInfo.InvariantCulture));
+            sb.AppendLine("结果数量: " + resultCount.ToString(CultureInfo.InvariantCulture));
+            sb.AppendLine("OK图片百分比: " + okPct.ToString("0.00", CultureInfo.InvariantCulture) + "%");
+            sb.AppendLine("NG图片百分比: " + ngPct.ToString("0.00", CultureInfo.InvariantCulture) + "%");
+            if (inferMsList.Count > 0)
+            {
+                sb.AppendLine("平均推理耗时(ms): " + avgInfer.ToString("0.00", CultureInfo.InvariantCulture));
+                sb.AppendLine("最小推理耗时(ms): " + minInfer.ToString("0.00", CultureInfo.InvariantCulture));
+                sb.AppendLine("最大推理耗时(ms): " + maxInfer.ToString("0.00", CultureInfo.InvariantCulture));
+            }
+
+            sb.AppendLine();
+            sb.AppendLine("类别分布（降序）：");
+            foreach (var kv in categoryDist.OrderByDescending(x => x.Value).ThenBy(x => x.Key, StringComparer.Ordinal))
+            {
+                sb.AppendLine(kv.Key + ": " + kv.Value.ToString(CultureInfo.InvariantCulture));
+            }
+
+            File.WriteAllText(path, sb.ToString(), new UTF8Encoding(false));
+        }
+
+        private static void WriteDetailedStatistics(string path, IList<ImageRecord> records)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("=== 详细预测统计 ===");
+            sb.AppendLine();
+
+            for (int idx = 0; idx < records.Count; idx++)
+            {
+                var rec = records[idx];
+                string imgName = rec?.ImagePath != null ? Path.GetFileName(rec.ImagePath) : string.Empty;
+                sb.AppendLine("图片 " + (idx + 1).ToString(CultureInfo.InvariantCulture) + ": " + imgName);
+
+                if (rec == null || !rec.Success)
+                {
+                    sb.AppendLine("  处理失败");
+                    sb.AppendLine();
+                    continue;
+                }
+
+                if (rec.Objects == null || rec.Objects.Count == 0)
+                {
+                    sb.AppendLine("  无检测结果");
+                    sb.AppendLine();
+                    continue;
+                }
+
+                sb.AppendLine("  检测目标数量: " + rec.Objects.Count.ToString(CultureInfo.InvariantCulture));
+                for (int i = 0; i < rec.Objects.Count; i++)
+                {
+                    var item = rec.Objects[i];
+                    sb.AppendLine("  目标 " + (i + 1).ToString(CultureInfo.InvariantCulture) + ":");
+                    sb.AppendLine("    类别: " + (string.IsNullOrWhiteSpace(item.CategoryName) ? "未知" : item.CategoryName));
+                    sb.AppendLine("    置信度: " + item.Score.ToString("0.0000", CultureInfo.InvariantCulture));
+                    if (item.Bbox != null && item.Bbox.Count > 0)
+                    {
+                        sb.AppendLine("    bbox: [" + string.Join(", ", item.Bbox.Select(v => v.ToString("0.###", CultureInfo.InvariantCulture))) + "]");
+                    }
+                }
+                sb.AppendLine();
+            }
+
+            File.WriteAllText(path, sb.ToString(), new UTF8Encoding(false));
+        }
+
+        private static void WriteMissedDetectionAnalysis(string path, IList<ImageRecord> records, string srcDir, double iouThreshold)
+        {
+            int totalImages = records.Count;
+            int annotatedImages = 0;
+            int totalMissed = 0;
+            int totalOver = 0;
+            int totalMisclass = 0;
+
+            string parentDir = Path.GetDirectoryName(path) ?? ".";
+            string missedImageDir = Path.Combine(parentDir, "漏检图片");
+            string overImageDir = Path.Combine(parentDir, "过检图片");
+            string misclassImageDir = Path.Combine(parentDir, "误检图片");
+
+            var sb = new StringBuilder();
+            sb.AppendLine("=== 过漏检分析报告 ===");
+            sb.AppendLine("IoU 阈值: " + iouThreshold.ToString("0.###", CultureInfo.InvariantCulture));
+            sb.AppendLine();
+
+            foreach (var rec in records)
+            {
+                if (rec == null || string.IsNullOrWhiteSpace(rec.ImagePath) || !rec.Success) continue;
+
+                string jsonPath = Path.ChangeExtension(rec.ImagePath, ".json");
+                if (!File.Exists(jsonPath)) continue;
+
+                var gtShapes = LoadLabelMeShapes(jsonPath);
+                if (gtShapes == null || gtShapes.Count == 0) continue;
+
+                annotatedImages++;
+                var preds = (rec.Objects ?? new List<PredObject>())
+                    .Select(o => new PredObject
+                    {
+                        CategoryName = o.CategoryName ?? string.Empty,
+                        Score = o.Score,
+                        Bbox = ToRect(o.Bbox)
+                    })
+                    .Where(o => o.Bbox != null)
+                    .ToList();
+
+                CompareWithAnnotations(preds, gtShapes, iouThreshold,
+                    out var missedList, out var overList, out var misclassList);
+
+                if (missedList.Count == 0 && overList.Count == 0 && misclassList.Count == 0) continue;
+
+                sb.AppendLine("图片: " + Path.GetFileName(rec.ImagePath));
+
+                if (missedList.Count > 0)
+                {
+                    totalMissed += missedList.Count;
+                    sb.AppendLine("  漏检 (" + missedList.Count.ToString(CultureInfo.InvariantCulture) + "):");
+                    foreach (var item in missedList)
+                    {
+                        sb.AppendLine("    - 标注类别: " + item.Label + ", bbox: " + FormatBbox(item.Bbox));
+                    }
+                    TryCopyErrorImage(missedImageDir, rec.ImagePath, "漏检");
+                }
+
+                if (overList.Count > 0)
+                {
+                    totalOver += overList.Count;
+                    sb.AppendLine("  过检 (" + overList.Count.ToString(CultureInfo.InvariantCulture) + "):");
+                    foreach (var item in overList)
+                    {
+                        sb.AppendLine(
+                            "    - 预测类别: " + item.CategoryName +
+                            ", 置信度: " + item.Score.ToString("0.0000", CultureInfo.InvariantCulture) +
+                            ", bbox: " + FormatBbox(item.Bbox));
+                    }
+                    TryCopyErrorImage(overImageDir, rec.ImagePath, "过检");
+                }
+
+                if (misclassList.Count > 0)
+                {
+                    totalMisclass += misclassList.Count;
+                    sb.AppendLine("  误检 (" + misclassList.Count.ToString(CultureInfo.InvariantCulture) + "):");
+                    foreach (var item in misclassList)
+                    {
+                        sb.AppendLine(
+                            "    - 标注类别: " + item.GtLabel +
+                            ", 预测类别: " + item.PredLabel +
+                            ", 置信度: " + item.Score.ToString("0.0000", CultureInfo.InvariantCulture) +
+                            ", bbox: " + FormatBbox(item.Bbox));
+                    }
+                    TryCopyErrorImage(misclassImageDir, rec.ImagePath, "误检");
+                }
+
+                sb.AppendLine();
+            }
+
+            sb.AppendLine();
+            sb.AppendLine("总计:");
+            sb.AppendLine("  总图片数: " + totalImages.ToString(CultureInfo.InvariantCulture));
+            sb.AppendLine("  有标注的图片数: " + annotatedImages.ToString(CultureInfo.InvariantCulture));
+            sb.AppendLine("  漏检总数: " + totalMissed.ToString(CultureInfo.InvariantCulture));
+            sb.AppendLine("  过检总数: " + totalOver.ToString(CultureInfo.InvariantCulture));
+            sb.AppendLine("  误检总数: " + totalMisclass.ToString(CultureInfo.InvariantCulture));
+
+            File.WriteAllText(path, sb.ToString(), new UTF8Encoding(false));
+        }
+
+        private sealed class GtItem
+        {
+            public string Label { get; set; }
+            public List<double> Bbox { get; set; }
+        }
+
+        private sealed class MissItem
+        {
+            public string Label { get; set; }
+            public List<double> Bbox { get; set; }
+        }
+
+        private sealed class OverItem
+        {
+            public string CategoryName { get; set; }
+            public float Score { get; set; }
+            public List<double> Bbox { get; set; }
+        }
+
+        private sealed class MisclassItem
+        {
+            public string GtLabel { get; set; }
+            public string PredLabel { get; set; }
+            public float Score { get; set; }
+            public List<double> Bbox { get; set; }
+        }
+
+        private static List<GtItem> LoadLabelMeShapes(string jsonPath)
+        {
+            var list = new List<GtItem>();
+            try
+            {
+                var json = JObject.Parse(File.ReadAllText(jsonPath, Encoding.UTF8));
+                var shapes = json["shapes"] as JArray;
+                if (shapes == null) return list;
+
+                foreach (var shape in shapes)
+                {
+                    if (!(shape is JObject shapeObj)) continue;
+                    string label = shapeObj["label"]?.ToString();
+                    if (string.IsNullOrWhiteSpace(label)) continue;
+                    var points = shapeObj["points"] as JArray;
+                    var bbox = BboxFromPoints(points);
+                    if (bbox == null) continue;
+                    list.Add(new GtItem { Label = label, Bbox = bbox });
+                }
+            }
+            catch
+            {
+                // ignore broken annotation
+            }
+            return list;
+        }
+
+        private static List<double> BboxFromPoints(JArray points)
+        {
+            if (points == null || points.Count < 2) return null;
+            double minX = double.MaxValue, minY = double.MaxValue;
+            double maxX = double.MinValue, maxY = double.MinValue;
+            int valid = 0;
+            foreach (var pt in points)
+            {
+                if (!(pt is JArray arr) || arr.Count < 2) continue;
+                double x = arr[0].Value<double>();
+                double y = arr[1].Value<double>();
+                if (x < minX) minX = x;
+                if (y < minY) minY = y;
+                if (x > maxX) maxX = x;
+                if (y > maxY) maxY = y;
+                valid++;
+            }
+            if (valid < 2) return null;
+            return new List<double> { minX, minY, maxX - minX, maxY - minY };
+        }
+
+        /// <summary>
+        /// 将预测 bbox 规整为 [x, y, w, h]。
+        /// 4 元：若像 [x1,y1,x2,y2] 则转换；否则视为已是 [x,y,w,h]。
+        /// 5 元：旋转框 [cx,cy,w,h,angle] 取外接轴对齐近似。
+        /// </summary>
+        private static List<double> ToRect(List<double> bbox)
+        {
+            if (bbox == null) return null;
+            if (bbox.Count == 4)
+            {
+                if (bbox[2] > bbox[0] && bbox[3] > bbox[1])
+                {
+                    return new List<double> { bbox[0], bbox[1], bbox[2] - bbox[0], bbox[3] - bbox[1] };
+                }
+                return new List<double> { bbox[0], bbox[1], bbox[2], bbox[3] };
+            }
+            if (bbox.Count >= 5)
+            {
+                double cx = bbox[0], cy = bbox[1], w = bbox[2], h = bbox[3];
+                return new List<double> { cx - w / 2.0, cy - h / 2.0, w, h };
+            }
+            return null;
+        }
+
+        private static double CalculateIou(List<double> a, List<double> b)
+        {
+            if (a == null || b == null || a.Count < 4 || b.Count < 4) return 0.0;
+            double ax1 = a[0], ay1 = a[1], aw = a[2], ah = a[3];
+            double bx1 = b[0], by1 = b[1], bw = b[2], bh = b[3];
+            double ax2 = ax1 + aw, ay2 = ay1 + ah;
+            double bx2 = bx1 + bw, by2 = by1 + bh;
+
+            double ix1 = Math.Max(ax1, bx1);
+            double iy1 = Math.Max(ay1, by1);
+            double ix2 = Math.Min(ax2, bx2);
+            double iy2 = Math.Min(ay2, by2);
+            double iw = Math.Max(0.0, ix2 - ix1);
+            double ih = Math.Max(0.0, iy2 - iy1);
+            double inter = iw * ih;
+            double union = aw * ah + bw * bh - inter;
+            if (union <= 0.0) return 0.0;
+            return inter / union;
+        }
+
+        private static void CompareWithAnnotations(
+            List<PredObject> preds,
+            List<GtItem> gts,
+            double iouThreshold,
+            out List<MissItem> missed,
+            out List<OverItem> over,
+            out List<MisclassItem> misclass)
+        {
+            missed = new List<MissItem>();
+            over = new List<OverItem>();
+            misclass = new List<MisclassItem>();
+
+            var predMatched = new bool[preds.Count];
+
+            foreach (var gt in gts)
+            {
+                int bestIdx = -1;
+                double bestIou = 0.0;
+                for (int i = 0; i < preds.Count; i++)
+                {
+                    if (predMatched[i]) continue;
+                    double iou = CalculateIou(gt.Bbox, preds[i].Bbox);
+                    if (iou > bestIou)
+                    {
+                        bestIou = iou;
+                        bestIdx = i;
+                    }
+                }
+
+                if (bestIdx < 0 || bestIou < iouThreshold)
+                {
+                    missed.Add(new MissItem { Label = gt.Label, Bbox = gt.Bbox });
+                }
+                else
+                {
+                    predMatched[bestIdx] = true;
+                    string predLabel = preds[bestIdx].CategoryName ?? string.Empty;
+                    if (!string.Equals(predLabel, gt.Label, StringComparison.Ordinal))
+                    {
+                        misclass.Add(new MisclassItem
+                        {
+                            GtLabel = gt.Label,
+                            PredLabel = predLabel,
+                            Score = preds[bestIdx].Score,
+                            Bbox = preds[bestIdx].Bbox
+                        });
+                    }
+                }
+            }
+
+            for (int i = 0; i < preds.Count; i++)
+            {
+                if (predMatched[i]) continue;
+                over.Add(new OverItem
+                {
+                    CategoryName = preds[i].CategoryName,
+                    Score = preds[i].Score,
+                    Bbox = preds[i].Bbox
+                });
+            }
+        }
+
+        private static void TryCopyErrorImage(string dstDir, string imgPath, string errorType)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(imgPath) || !File.Exists(imgPath)) return;
+                Directory.CreateDirectory(dstDir);
+                string stem = Path.GetFileNameWithoutExtension(imgPath);
+                string ext = Path.GetExtension(imgPath);
+                string name = string.IsNullOrEmpty(errorType)
+                    ? Path.GetFileName(imgPath)
+                    : stem + "_" + errorType + ext;
+                string dst = Path.Combine(dstDir, name);
+                File.Copy(imgPath, dst, true);
+            }
+            catch
+            {
+                // ignore copy failure
+            }
+        }
+
+        private static string FormatBbox(List<double> bbox)
+        {
+            if (bbox == null || bbox.Count == 0) return "[]";
+            return "[" + string.Join(", ", bbox.Select(v => v.ToString("0.###", CultureInfo.InvariantCulture))) + "]";
+        }
+
+        private static string FormatElapsed(TimeSpan elapsed)
+        {
+            if (elapsed.TotalSeconds < 60.0)
+            {
+                return elapsed.TotalSeconds.ToString("0.00", CultureInfo.InvariantCulture) + "秒";
+            }
+            return (elapsed.TotalSeconds / 60.0).ToString("0.00", CultureInfo.InvariantCulture) + "分钟";
+        }
+
+        private static string SanitizeFileName(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name)) return "batch_report";
+            var invalid = Path.GetInvalidFileNameChars();
+            var sb = new StringBuilder(name.Length);
+            foreach (var ch in name)
+            {
+                sb.Append(invalid.Contains(ch) ? '_' : ch);
+            }
+            var cleaned = sb.ToString().Trim().TrimEnd(' ', '.');
+            return string.IsNullOrWhiteSpace(cleaned) ? "batch_report" : cleaned;
+        }
+
+        /// <summary>
+        /// 从推理结果提取轻量目标列表（不持有 Mask，避免批量占用显存/内存）。
+        /// </summary>
+        public static ImageRecord FromResult(string imagePath, bool success, double inferMs, dlcv_infer_csharp.Utils.CSharpResult? result)
+        {
+            var rec = new ImageRecord
+            {
+                ImagePath = imagePath,
+                Success = success,
+                InferMs = inferMs,
+                HasResults = false,
+                Objects = new List<PredObject>()
+            };
+
+            if (!success || !result.HasValue) return rec;
+
+            try
+            {
+                var samples = result.Value.SampleResults;
+                if (samples == null || samples.Count == 0) return rec;
+                var objs = samples[0].Results;
+                if (objs == null || objs.Count == 0) return rec;
+
+                rec.HasResults = true;
+                foreach (var o in objs)
+                {
+                    List<double> bboxCopy = null;
+                    if (o.Bbox != null)
+                    {
+                        bboxCopy = new List<double>(o.Bbox);
+                    }
+                    rec.Objects.Add(new PredObject
+                    {
+                        CategoryName = o.CategoryName,
+                        Score = o.Score,
+                        Bbox = bboxCopy
+                    });
+                }
+            }
+            catch
+            {
+                // keep empty objects
+            }
+
+            return rec;
+        }
+    }
+}

--- a/DlcvTest/Views/MainWindow/MainWindow.Infer.cs
+++ b/DlcvTest/Views/MainWindow/MainWindow.Infer.cs
@@ -343,8 +343,46 @@ namespace DlcvTest
                                 return;
                             }
 
-                            // 推理（显式声明类型，避免 dynamic 推断导致 lambda 表达式错误）
-                            Utils.CSharpResult result = model.Infer(mat);
+                            // 与单张推理一致：BGR/BGRA/GRAY → RGB，并传入 threshold / with_mask
+                            Utils.CSharpResult result = default(Utils.CSharpResult);
+                            Mat inferMat = null;
+                            try
+                            {
+                                var ch = mat.Channels();
+                                if (ch == 3)
+                                {
+                                    inferMat = new Mat();
+                                    Cv2.CvtColor(mat, inferMat, ColorConversionCodes.BGR2RGB);
+                                }
+                                else if (ch == 4)
+                                {
+                                    inferMat = new Mat();
+                                    Cv2.CvtColor(mat, inferMat, ColorConversionCodes.BGRA2RGB);
+                                }
+                                else if (ch == 1)
+                                {
+                                    inferMat = new Mat();
+                                    Cv2.CvtColor(mat, inferMat, ColorConversionCodes.GRAY2RGB);
+                                }
+                                else
+                                {
+                                    inferMat = mat;
+                                }
+
+                                var inferenceParams = new JObject
+                                {
+                                    ["threshold"] = (float)threshold,
+                                    ["with_mask"] = true
+                                };
+                                result = model.Infer(inferMat, inferenceParams);
+                            }
+                            finally
+                            {
+                                if (inferMat != null && !ReferenceEquals(inferMat, mat))
+                                {
+                                    try { inferMat.Dispose(); } catch { }
+                                }
+                            }
 
                             // 保存原图
                             if (saveImg)

--- a/DlcvTest/Views/MainWindow/MainWindow.Infer.cs
+++ b/DlcvTest/Views/MainWindow/MainWindow.Infer.cs
@@ -313,6 +313,20 @@ namespace DlcvTest
             int processedCount = 0;
             long lastProgressUpdateTicks = 0; // 用于节流进度更新
             const long ProgressUpdateIntervalTicks = 500000; // 50ms 节流间隔（1 tick = 100ns）
+            bool runEvaluation = false;
+            bool saveDetailed = false;
+            bool saveMissed = false;
+            try { runEvaluation = Settings.Default.RunEvaluation; } catch { }
+            try { saveDetailed = Settings.Default.SaveDetailedPredictData; } catch { }
+            try { saveMissed = Settings.Default.SaveMissedData; } catch { }
+            // 过漏检依赖详细结果记录；勾选过漏检时自动收集
+            bool collectRecords = runEvaluation || saveDetailed || saveMissed;
+            var batchRecords = collectRecords ? new ConcurrentDictionary<string, BatchReport.ImageRecord>(StringComparer.OrdinalIgnoreCase) : null;
+            string modelPathForReport = null;
+            try { modelPathForReport = Settings.Default.LastModelPath; } catch { }
+            var batchStartTime = DateTime.Now;
+            var batchSw = Stopwatch.StartNew();
+
             await Task.Run(() =>
             {
                 // 使用并行处理，从设置中读取最大并行度（默认 4，范围 1-16）
@@ -329,6 +343,9 @@ namespace DlcvTest
 
                     string baseName = Path.GetFileNameWithoutExtension(imgPath);
                     string ext = Path.GetExtension(imgPath);
+                    double inferMs = 0.0;
+                    bool inferOk = false;
+                    Utils.CSharpResult? resultForReport = null;
 
                     try
                     {
@@ -337,15 +354,14 @@ namespace DlcvTest
                             if (mat == null || mat.Empty())
                             {
                                 System.Diagnostics.Debug.WriteLine($"[批量推理] 无法读取图片: {imgPath}");
-                                int currentCount = Interlocked.Increment(ref processedCount);
-                                if (!batchStopFlag)
-                                    Dispatcher.BeginInvoke(new Action(() => UpdateBatchProgress(progressRunId, currentCount, total)));
+                                inferOk = false;
+                                // 进度与报表记录统一在 finally / 循环尾部处理，避免重复计数
                                 return;
                             }
 
-                            // 与单张推理一致：BGR/BGRA/GRAY → RGB，并传入 threshold / with_mask
                             Utils.CSharpResult result = default(Utils.CSharpResult);
                             Mat inferMat = null;
+
                             try
                             {
                                 var ch = mat.Channels();
@@ -374,7 +390,16 @@ namespace DlcvTest
                                     ["threshold"] = (float)threshold,
                                     ["with_mask"] = true
                                 };
+
+                                var swInfer = Stopwatch.StartNew();
                                 result = model.Infer(inferMat, inferenceParams);
+                                swInfer.Stop();
+                                inferMs = swInfer.Elapsed.TotalMilliseconds;
+                                inferOk = true;
+                                if (batchRecords != null)
+                                {
+                                    resultForReport = result;
+                                }
                             }
                             finally
                             {
@@ -383,8 +408,6 @@ namespace DlcvTest
                                     try { inferMat.Dispose(); } catch { }
                                 }
                             }
-
-                            // 保存原图
                             if (saveImg)
                             {
                                 // 提取图中所有类别名（去重）并判断是否有结果
@@ -599,19 +622,40 @@ namespace DlcvTest
                     catch (Exception ex)
                     {
                         System.Diagnostics.Debug.WriteLine($"[批量推理] 处理图片失败 {imgPath}: {ex.Message}");
+                        inferOk = false;
+                    }
+                    finally
+                    {
+                        if (batchRecords != null)
+                        {
+                            try
+                            {
+                                batchRecords[imgPath] = BatchReport.FromResult(imgPath, inferOk, inferMs, resultForReport);
+                            }
+                            catch
+                            {
+                                batchRecords[imgPath] = BatchReport.FromResult(imgPath, false, inferMs, null);
+                            }
+                        }
+
+                        // 报表已抽取轻量字段，及时释放 mask，避免大批量占内存
+                        if (resultForReport.HasValue)
+                        {
+                            DisposeCSharpResultMasks(resultForReport);
+                        }
                     }
 
                     // 线程安全更新进度（停止时不更新，添加节流减少 Dispatcher 队列压力）
                     if (!batchStopFlag)
                     {
                         int currentCount = Interlocked.Increment(ref processedCount);
-                        
+
                         // 节流：每 50ms 最多更新一次进度，或者是最后一张图片时强制更新
                         long nowTicks = DateTime.UtcNow.Ticks;
                         long lastTicks = Interlocked.Read(ref lastProgressUpdateTicks);
                         bool isLastImage = (currentCount >= total);
                         bool shouldUpdate = isLastImage || (nowTicks - lastTicks >= ProgressUpdateIntervalTicks);
-                        
+
                         if (shouldUpdate && Interlocked.CompareExchange(ref lastProgressUpdateTicks, nowTicks, lastTicks) == lastTicks)
                         {
                             Dispatcher.BeginInvoke(new Action(() => UpdateBatchProgress(progressRunId, currentCount, total)));
@@ -620,7 +664,57 @@ namespace DlcvTest
                 });
             });
 
-            // 4. 打开输出目录
+            batchSw.Stop();
+
+            // 4. 输出批量报表（汇总 / 详细统计 / 过漏检）
+            if (collectRecords && batchRecords != null && !batchStopFlag)
+            {
+                try
+                {
+                    // 按输入列表顺序整理，保证报表顺序稳定
+                    var ordered = new List<BatchReport.ImageRecord>(imageFiles.Count);
+                    foreach (var p in imageFiles)
+                    {
+                        if (batchRecords.TryGetValue(p, out var rec) && rec != null)
+                        {
+                            ordered.Add(rec);
+                        }
+                        else
+                        {
+                            ordered.Add(BatchReport.FromResult(p, false, 0.0, null));
+                        }
+                    }
+
+                    // 详细/过漏检需要结果明细；汇总简报在 runEvaluation 时写出
+                    bool writeDetailed = saveDetailed || saveMissed;
+                    bool writeMissed = saveMissed;
+                    bool writeAnything = runEvaluation || writeDetailed;
+                    if (writeAnything)
+                    {
+                        BatchReport.WriteAll(new BatchReport.SummaryInput
+                        {
+                            OutputDir = outputDir,
+                            ReportName = modelName + "_" + timestamp,
+                            SrcDir = srcDir,
+                            ModelPath = modelPathForReport,
+                            Threshold = threshold,
+                            StartTime = batchStartTime,
+                            Elapsed = batchSw.Elapsed,
+                            Records = ordered,
+                            WriteSummary = runEvaluation,
+                            WriteDetailed = writeDetailed,
+                            WriteMissed = writeMissed,
+                            IouThreshold = 0.5
+                        });
+                    }
+                }
+                catch (Exception reportEx)
+                {
+                    System.Diagnostics.Debug.WriteLine($"[批量推理] 写报表失败: {reportEx.Message}");
+                }
+            }
+
+            // 5. 打开输出目录
             if (openDstDir)
             {
                 try

--- a/DlcvTest/Views/Settings/StandardSettingsView.xaml
+++ b/DlcvTest/Views/Settings/StandardSettingsView.xaml
@@ -131,19 +131,55 @@
                     </Grid>
                 </Grid>
 
-                <!-- 5. 运行评估流程 -->
-                <Grid Margin="0,0,0,20">
+                <!-- 5. 运行评估流程（输出汇总简报） -->
+                <Grid Margin="0,0,0,15">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" SharedSizeGroup="LabelColumn"/>
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
                     <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
                         <TextBlock Text="运行评估流程" VerticalAlignment="Center" FontSize="15" Foreground="#555"/>
-                        <Border Margin="5,0,0,0" Width="16" Height="16" CornerRadius="8" BorderBrush="#999" BorderThickness="1" VerticalAlignment="Center" ToolTip="是否运行评估流程">
+                        <Border Margin="5,0,0,0" Width="16" Height="16" CornerRadius="8" BorderBrush="#999" BorderThickness="1" VerticalAlignment="Center" ToolTip="输出批量汇总简报：耗时、OK/NG、类别分布、推理耗时统计">
                             <TextBlock Text="?" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="10" Foreground="#999"/>
                         </Border>
                     </StackPanel>
-                    <controls:AnimatedCheckBox Grid.Column="1" IsChecked="True" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="16,0,0,0"/>
+                    <controls:AnimatedCheckBox Grid.Column="1" x:Name="chkRunEvaluation" IsChecked="True" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="16,0,0,0"
+                                              Checked="ChkRunEvaluation_Checked"
+                                              Unchecked="ChkRunEvaluation_Unchecked"/>
+                </Grid>
+
+                <!-- 5.1 输出预测统计数据 -->
+                <Grid Margin="0,0,0,15">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" SharedSizeGroup="LabelColumn"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
+                        <TextBlock Text="输出预测统计数据" VerticalAlignment="Center" FontSize="15" Foreground="#555"/>
+                        <Border Margin="5,0,0,0" Width="16" Height="16" CornerRadius="8" BorderBrush="#999" BorderThickness="1" VerticalAlignment="Center" ToolTip="输出每张图片的逐目标详细统计（类别、置信度、bbox）">
+                            <TextBlock Text="?" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="10" Foreground="#999"/>
+                        </Border>
+                    </StackPanel>
+                    <controls:AnimatedCheckBox Grid.Column="1" x:Name="chkSaveDetailedPredictData" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="16,0,0,0"
+                                              Checked="ChkSaveDetailedPredictData_Checked"
+                                              Unchecked="ChkSaveDetailedPredictData_Unchecked"/>
+                </Grid>
+
+                <!-- 5.2 输出过漏检数据 -->
+                <Grid Margin="0,0,0,20">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" SharedSizeGroup="LabelColumn"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
+                        <TextBlock Text="输出过漏检数据" VerticalAlignment="Center" FontSize="15" Foreground="#555"/>
+                        <Border Margin="5,0,0,0" Width="16" Height="16" CornerRadius="8" BorderBrush="#999" BorderThickness="1" VerticalAlignment="Center" ToolTip="基于同名 LabelMe JSON 做 IoU 匹配，输出漏检/过检/误检分析（建议同时开启预测统计数据）">
+                            <TextBlock Text="?" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="10" Foreground="#999"/>
+                        </Border>
+                    </StackPanel>
+                    <controls:AnimatedCheckBox Grid.Column="1" x:Name="chkSaveMissedData" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="16,0,0,0"
+                                              Checked="ChkSaveMissedData_Checked"
+                                              Unchecked="ChkSaveMissedData_Unchecked"/>
                 </Grid>
 
                 <!-- 6. 保存数据路径 -->

--- a/DlcvTest/Views/Settings/StandardSettingsView.xaml.cs
+++ b/DlcvTest/Views/Settings/StandardSettingsView.xaml.cs
@@ -46,6 +46,18 @@ namespace DlcvTest
                 {
                     chkSaveNg.IsChecked = Settings.Default.SaveNg;
                 }
+                if (chkRunEvaluation != null)
+                {
+                    chkRunEvaluation.IsChecked = Settings.Default.RunEvaluation;
+                }
+                if (chkSaveDetailedPredictData != null)
+                {
+                    chkSaveDetailedPredictData.IsChecked = Settings.Default.SaveDetailedPredictData;
+                }
+                if (chkSaveMissedData != null)
+                {
+                    chkSaveMissedData.IsChecked = Settings.Default.SaveMissedData;
+                }
 
                 // 加载输出目录
                 try
@@ -181,6 +193,48 @@ namespace DlcvTest
         {
             if (_isInitializing) return;
             Settings.Default.SaveNg = false;
+            Settings.Default.Save();
+        }
+
+        private void ChkRunEvaluation_Checked(object sender, RoutedEventArgs e)
+        {
+            if (_isInitializing) return;
+            Settings.Default.RunEvaluation = true;
+            Settings.Default.Save();
+        }
+
+        private void ChkRunEvaluation_Unchecked(object sender, RoutedEventArgs e)
+        {
+            if (_isInitializing) return;
+            Settings.Default.RunEvaluation = false;
+            Settings.Default.Save();
+        }
+
+        private void ChkSaveDetailedPredictData_Checked(object sender, RoutedEventArgs e)
+        {
+            if (_isInitializing) return;
+            Settings.Default.SaveDetailedPredictData = true;
+            Settings.Default.Save();
+        }
+
+        private void ChkSaveDetailedPredictData_Unchecked(object sender, RoutedEventArgs e)
+        {
+            if (_isInitializing) return;
+            Settings.Default.SaveDetailedPredictData = false;
+            Settings.Default.Save();
+        }
+
+        private void ChkSaveMissedData_Checked(object sender, RoutedEventArgs e)
+        {
+            if (_isInitializing) return;
+            Settings.Default.SaveMissedData = true;
+            Settings.Default.Save();
+        }
+
+        private void ChkSaveMissedData_Unchecked(object sender, RoutedEventArgs e)
+        {
+            if (_isInitializing) return;
+            Settings.Default.SaveMissedData = false;
             Settings.Default.Save();
         }
 


### PR DESCRIPTION
## 摘要

1. **批量预测与单张不一致修复**：批量路径原先对 `Cv2.ImRead` 的 BGR 直接 `Infer`，且未传 `threshold`/`with_mask`；现与单张对齐为 BGR/BGRA/GRAY→RGB（仅必要通道转换，无多余 Copy），并传入相同推理参数。
2. **批量报表（参考 dlcv_test_2）**：新增 `BatchReport`，支持汇总简报、逐目标详细统计、基于同名 LabelMe JSON 的过漏检分析（IoU=0.5）；设置页补齐三个开关绑定。
3. **Release 编译打包脚本**：新增 `99_编译打包DlcvTest.bat`（GBK+CRLF），Release x64 编译后 7z 打包到仓库根目录，文件名带日期。

## 变更说明

### 1. 批量推理 RGB / 阈值（`MainWindow.Infer.cs`）

| 修复前 | 修复后 |
| --- | --- |
| `model.Infer(mat)`，输入为 BGR | 1/3/4 通道 `CvtColor` 到 RGB 后再 Infer |
| 未传推理参数 | `threshold` + `with_mask=true`，与单张一致 |
| — | 转换 Mat 与原图不同引用时才 Dispose |

### 2. 批量报表

| 设置项 | 默认 | 产物 |
| --- | --- | --- |
| 运行评估流程 (`RunEvaluation`) | 开 | `{model}_{timestamp}.txt` 汇总（耗时、OK/NG、类别分布、推理耗时） |
| 输出预测统计数据 (`SaveDetailedPredictData`) | 关 | `详细统计/*_详细统计.txt`（每图逐目标） |
| 输出过漏检数据 (`SaveMissedData`) | 关 | `详细统计/过漏检分析/*` + 漏检/过检/误检图片复制（需同名 LabelMe JSON，IoU=0.5） |

- 新增 `DlcvTest/Views/MainWindow/BatchReport.cs`
- 批量循环收集轻量 `ImageRecord`，写报表后释放 mask
- 设置：`Settings.cs` + `StandardSettingsView.xaml/.cs` 绑定
- 未移植 mmengine mAP/混淆矩阵（C# 侧无该评估器）

### 3. 编译打包 bat

- 文件：`99_编译打包DlcvTest.bat`（GBK + CRLF）
- 编译：`.cursor/skills/vs-build/scripts/build.py`，`Release` + `x64`，目标 `DlcvTest`
- 打包：`C:\Program Files\7-Zip\7z.exe`，输出仓库根目录 `DlcvTest_yyyyMMdd.zip`（如 `DlcvTest_20260721.zip`）
- **排除**：`dll\` 整目录、`*.pdb`、`*.xml`、`OpenCvSharpExtern.dll`、`opencv_videoio_ffmpeg4100_64.dll` / `opencv_videoio_ffmpeg*.dll`
- 在 Release 输出目录 `pushd` 后相对打包，保证排除规则生效

## 涉及文件

- `DlcvTest/Views/MainWindow/MainWindow.Infer.cs`
- `DlcvTest/Views/MainWindow/BatchReport.cs`（新增）
- `DlcvTest/Properties/Settings.cs`
- `DlcvTest/Views/Settings/StandardSettingsView.xaml`
- `DlcvTest/Views/Settings/StandardSettingsView.xaml.cs`
- `DlcvTest/DlcvTest.csproj`
- `99_编译打包DlcvTest.bat`（新增）

## Commits

1. `fix: DlcvTest 批量预测对齐单张 RGB 与阈值参数`
2. `feat: DlcvTest 批量预测输出汇总/详细/过漏检报表`
3. `build: 新增 DlcvTest Release x64 编译打包 bat`
4. `build: 收紧 DlcvTest zip 排除项`
5. `build: DlcvTest zip 文件名带日期`

## 测试计划

- [x] Debug x64 编译 DlcvTest
- [x] 7z 排除规则实测
- [x] 同模型同图对比单张与批量结果类别/分数一致
- [x] 批量报表代码路径接通（汇总 / 详细 / 过漏检）
- [x] 编译打包 bat 与 zip 命名、排除项验证
