### PR TITLE
功能: 完善印刷模版创建与匹配

### DIFF
--- a/C# API文档.md
+++ b/C# API文档.md
@@ -635,3 +635,6 @@ C# 侧额外处理 `DV\n` 文件头校验、归档解包、`pipeline.json` 中 `
 - 读盘和写盘遵循 OpenCV 的 BGR 语义；调用方负责把三/四通道颜色图整理为 RGB；`Model` 与 `FlowGraphModel` 入口会按模型输入自动做最小必要的通道规整，例如把灰度图补成 RGB、或把三/四通道图压成灰度，但不负责 BGR/BGRA 到 RGB 的颜色顺序转换。
 - 当前显式使用的标量键包括 `filename`、`has_positive`、`ok`、`detail`、`kept_count`、`removed_count`。
 - 模板相关类型为 `SimpleOcrItem`、`SimpleTemplate` 和 `SimpleTemplateMatchDetail`。
+- C# `features/printed_template_match` 从执行上下文读取 `defer_template_creation`。该值为 `true` 且磁盘模板不存在时，模块返回 `template_candidate=true`、`Candidate` OCR 状态、`ok=false` 和空 `TemplateList`，不直接写入模板；关闭时保持自动保存并自匹配的既有行为。
+- C# `features/template_match` 与 `features/printed_template_match` 支持节点属性 `count_priority`。启用后按类别分别比较有效项数量，各类别数量一致时直接通过，否则回到普通模板匹配；结果 `detail` 增加 `detected_count`、`expected_count` 和 `image_level_status`。
+- 数量优先的类别比较去除首尾空白并忽略大小写，不执行 OCR 易混字符替换；D 面保留 `NG` 类别，A/B/C 面保持印刷 `NG` 文本过滤。完整字段与 C++ 能力边界见共享标准文档第 7.6 节。

--- a/C++ API文档.md
+++ b/C++ API文档.md
@@ -649,7 +649,7 @@ auto nodes = dlcv_infer::Model::GetLastFlowNodeTimings();
 
 ### 23.6 已注册 Flow 节点
 
-C++ Flow 节点实现位于 `flow/modules/InputModules.cpp`、`flow/modules/ModelModules.cpp`、`flow/modules/OutputModules.cpp`、`flow/modules/SlidingModules.cpp`、`flow/modules/FeatureModules.cpp`、`flow/modules/PostProcessModules.cpp`、`flow/modules/RegionStrokeVisualizeTemplateModules.cpp`。当前注册集覆盖输入、模型、预处理/特征、后处理、输出与模板模块；`features/printed_template_match` 由 `features/template_match` 兼容实现。当前实现中，`input/*` 从磁盘读图时会把三/四通道输入统一整理为 RGB 语义后再入 Flow，`model/*` 入口不再隐式执行 BGR→RGB 转换，但仍会按模型输入做最小必要的通道规整，`output/save_image` 按内部固定 RGB 语义把三通道/四通道图像转换回 OpenCV 写盘所需的 BGR 语义。
+C++ Flow 节点实现位于 `flow/modules/InputModules.cpp`、`flow/modules/ModelModules.cpp`、`flow/modules/OutputModules.cpp`、`flow/modules/SlidingModules.cpp`、`flow/modules/FeatureModules.cpp`、`flow/modules/PostProcessModules.cpp`、`flow/modules/RegionStrokeVisualizeTemplateModules.cpp`。当前注册集覆盖输入、模型、预处理/特征、后处理、输出与模板模块；`features/printed_template_match` 由 `features/template_match` 兼容实现，不包含 C# Flow 的 `defer_template_creation` 候选事务、`count_priority` 数量优先和相应扩展结果字段。当前实现中，`input/*` 从磁盘读图时会把三/四通道输入统一整理为 RGB 语义后再入 Flow，`model/*` 入口不再隐式执行 BGR→RGB 转换，但仍会按模型输入做最小必要的通道规整，`output/save_image` 按内部固定 RGB 语义把三通道/四通道图像转换回 OpenCV 写盘所需的 BGR 语义。
 
 ---
 

--- a/DlcvCsharpApi/flow/modules/Templates.cs
+++ b/DlcvCsharpApi/flow/modules/Templates.cs
@@ -1180,6 +1180,57 @@ namespace DlcvModules
 			string fname = SimpleTemplateUtils.MakeSafeFileName(templateName);
 			string jsonPath = string.IsNullOrWhiteSpace(saveDir) ? (fname + ".json") : Path.Combine(saveDir, fname + ".json");
 
+			bool deferTemplateCreation = false;
+			try
+			{
+				deferTemplateCreation = this.Context != null &&
+					this.Context.Get<bool>("defer_template_creation", false);
+			}
+			catch { deferTemplateCreation = false; }
+			if (!File.Exists(jsonPath) && deferTemplateCreation)
+			{
+				var ocrArray = new JArray();
+				var list = tpl.OCRResults ?? new List<SimpleOcrItem>();
+				for (int i = 0; i < list.Count; i++)
+				{
+					var item = list[i];
+					if (item == null) continue;
+					ocrArray.Add(new JObject
+					{
+						["text"] = item.Text ?? string.Empty,
+						["x"] = item.X,
+						["y"] = item.Y,
+						["width"] = item.Width,
+						["height"] = item.Height,
+						["confidence"] = (double)item.Confidence,
+						["match_status"] = "Correct"
+					});
+				}
+				var candidate = new JObject
+				{
+					["template_candidate"] = true,
+					["ocr_results"] = ocrArray,
+					["missing_template_items"] = new JArray(),
+					["deviation_template_items"] = new JArray(),
+					["misjudgment_pairs"] = new JArray(),
+					["template_match_info"] = new JObject
+					{
+						["template_name"] = templateName,
+						["product_name"] = productType,
+						["is_match"] = true,
+						["match_score"] = 1.0,
+						["perfect_matches"] = ocrArray.Count,
+						["position_deviations"] = 0,
+						["over_detections"] = 0,
+						["missing_components"] = 0,
+						["misjudgments"] = 0
+					}
+				};
+				this.ScalarOutputsByName["ok"] = true;
+				this.ScalarOutputsByName["detail"] = candidate.ToString(Formatting.None);
+				return new ModuleIO(images, results, new List<SimpleTemplate>());
+			}
+
 			// 分支 B：无现存模版 -> 保存模版与 PNG（PNG 使用首图 OriginalImage），随后与自身匹配
 			if (!File.Exists(jsonPath))
 			{

--- a/DlcvCsharpApi/flow/modules/Templates.cs
+++ b/DlcvCsharpApi/flow/modules/Templates.cs
@@ -555,8 +555,7 @@ namespace DlcvModules
 					textCountResult,
 					countPriority,
 					validDetections.Count,
-					expectedCount,
-					categoryCountsMatch);
+					expectedCount);
 				return textCountResult;
 			}
 				
@@ -774,8 +773,7 @@ namespace DlcvModules
 					root,
 					countPriority,
 					validDetections.Count,
-					expectedCount,
-					categoryCountsMatch);
+					expectedCount);
 				return root;
 			}
 
@@ -864,22 +862,102 @@ namespace DlcvModules
 			JObject detail,
 			bool countPriority,
 			int detectedCount,
-			int expectedCount,
-			bool categoryCountsMatch)
+			int expectedCount)
 		{
-			if (!countPriority || detail == null) return;
+			if (detail == null) return;
+			ApplyDetailedMismatchReason(detail);
+			if (!countPriority) return;
 			detail["detected_count"] = detectedCount;
 			detail["expected_count"] = expectedCount;
 			var info = detail["template_match_info"] as JObject;
 			var isMatch = info != null && info.Value<bool?>("is_match") == true;
 			detail["image_level_status"] = isMatch ? "OK" : "NG";
-			if (!isMatch && info != null && info["error_reason"] == null)
+		}
+
+		private static void ApplyDetailedMismatchReason(JObject detail)
+		{
+			if (detail == null) return;
+			var info = detail["template_match_info"] as JObject;
+			if (info == null || info.Value<bool?>("is_match") == true)
 			{
-				info["error_reason"] = detectedCount != expectedCount
-					? "检测数量不符：检测到 " + detectedCount +
-						"，模版 " + expectedCount + "；已执行模版匹配"
-					: "检测类别数量不符；已执行模版匹配";
+				if (info != null) info.Remove("error_reason");
+				return;
 			}
+
+			var reasons = new List<string>();
+			var missingTexts = (detail["missing_template_items"] as JArray)?.OfType<JObject>()
+				.Select(item => item["text"]?.ToString())
+				.ToList() ?? new List<string>();
+
+			var ocrItems = (detail["ocr_results"] as JArray)?.OfType<JObject>().ToList() ?? new List<JObject>();
+			var overTexts = ocrItems
+				.Where(item => string.Equals(item["match_status"]?.ToString(), "OverDetection", StringComparison.OrdinalIgnoreCase))
+				.Select(item => item["text"]?.ToString())
+				.ToList();
+
+			var misjudgmentPairs = (detail["misjudgment_pairs"] as JArray)?.OfType<JObject>().ToList() ?? new List<JObject>();
+			foreach (var pair in misjudgmentPairs)
+			{
+				missingTexts.Add(pair["t_text"]?.ToString());
+				overTexts.Add(pair["d_text"]?.ToString());
+			}
+
+			var missing = FormatReasonCounts(missingTexts);
+			if (!string.IsNullOrWhiteSpace(missing)) reasons.Add("缺：" + missing);
+			var over = FormatReasonCounts(overTexts);
+			if (!string.IsNullOrWhiteSpace(over)) reasons.Add("多：" + over);
+
+			var deviation = FormatReasonCounts(ocrItems
+				.Where(item => string.Equals(item["match_status"]?.ToString(), "PositionDeviation", StringComparison.OrdinalIgnoreCase))
+				.Select(item => item["text"]?.ToString()));
+			if (!string.IsNullOrWhiteSpace(deviation)) reasons.Add("位置偏差：" + deviation);
+
+			if ((info.Value<int?>("misjudgments") ?? 0) > 0)
+			{
+				var misjudgments = FormatMisjudgmentCounts(misjudgmentPairs);
+				if (!string.IsNullOrWhiteSpace(misjudgments)) reasons.Add("误判：" + misjudgments);
+			}
+
+			if (reasons.Count == 0)
+			{
+				var missingCount = info.Value<int?>("missing_components") ?? 0;
+				var overCount = info.Value<int?>("over_detections") ?? 0;
+				var deviationCount = info.Value<int?>("position_deviations") ?? 0;
+				var misjudgmentCount = info.Value<int?>("misjudgments") ?? 0;
+				if (missingCount > 0) reasons.Add("缺少项×" + missingCount);
+				if (overCount > 0) reasons.Add("多出项×" + overCount);
+				if (deviationCount > 0) reasons.Add("位置偏差项×" + deviationCount);
+				if (misjudgmentCount > 0) reasons.Add("误判项×" + misjudgmentCount);
+			}
+
+			info["error_reason"] = reasons.Count > 0
+				? string.Join("；", reasons)
+				: "模版匹配失败";
+		}
+
+		private static string FormatReasonCounts(IEnumerable<string> values)
+		{
+			var counts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+			foreach (var value in values ?? Enumerable.Empty<string>())
+			{
+				var text = string.IsNullOrWhiteSpace(value) ? "(空)" : value.Trim();
+				counts[text] = counts.TryGetValue(text, out int count) ? count + 1 : 1;
+			}
+			return string.Join("、", counts
+				.Select(pair => pair.Key + "×" + pair.Value));
+		}
+
+		private static string FormatMisjudgmentCounts(IEnumerable<JObject> pairs)
+		{
+			var values = (pairs ?? Enumerable.Empty<JObject>())
+				.Select(pair =>
+				{
+					var templateText = pair["t_text"]?.ToString();
+					var detectionText = pair["d_text"]?.ToString();
+					return "模版 " + (string.IsNullOrWhiteSpace(templateText) ? "(空)" : templateText.Trim()) +
+						"→检测 " + (string.IsNullOrWhiteSpace(detectionText) ? "(空)" : detectionText.Trim());
+				});
+			return FormatReasonCounts(values);
 		}
 
 		private static List<SimpleOcrItem> ExtractOcrFromLocal(JArray results)
@@ -1146,19 +1224,7 @@ namespace DlcvModules
 			}
 			root["missing_template_items"] = missingArr;
 			root["deviation_template_items"] = new JArray();
-			// 构造误判配对：按个数成对输出（用于“错：模型：x，模版：y”）
-			var misPairsArr = new JArray();
-			int pairCount = Math.Min(missList.Count, overList.Count);
-			for (int i = 0; i < pairCount; i++)
-			{
-				var pair = new JObject
-				{
-					["t_text"] = missList[i].Text ?? string.Empty,
-					["d_text"] = overList[i].Text ?? string.Empty
-				};
-				misPairsArr.Add(pair);
-			}
-			root["misjudgment_pairs"] = misPairsArr;
+			root["misjudgment_pairs"] = new JArray();
 			
 			root["template_match_info"] = new JObject
 			{

--- a/DlcvCsharpApi/flow/modules/Templates.cs
+++ b/DlcvCsharpApi/flow/modules/Templates.cs
@@ -440,9 +440,17 @@ namespace DlcvModules
 				double posTolY = ReadDoubleOr("position_tolerance_y", 20.0);
 				double minConf = ReadDoubleOr("min_confidence_threshold", 0.5);
 				bool checkPosition = ReadBoolOr("check_position", true);
+				bool countPriority = ReadBoolOr("count_priority", false);
 				
 				// 使用与 PrintMatch 一致的匹配逻辑与输出结构
-				var pmDetail = MatchAsPrintMatch(golden, toCheck.OCRResults ?? new List<SimpleOcrItem>(), posTolX, posTolY, minConf, checkPosition);
+				var pmDetail = MatchAsPrintMatch(
+					golden,
+					toCheck.OCRResults ?? new List<SimpleOcrItem>(),
+					posTolX,
+					posTolY,
+					minConf,
+					checkPosition,
+					countPriority);
 				bool ok = pmDetail?["template_match_info"] != null && pmDetail["template_match_info"]["is_match"] != null && pmDetail["template_match_info"]["is_match"].Value<bool>();
 				try
 				{
@@ -510,18 +518,33 @@ namespace DlcvModules
 				return !(ax2 < d.X || bx2 < t.X || ay2 < d.Y || by2 < t.Y);
 			}
 
-		private static JObject MatchAsPrintMatch(SimpleTemplate golden, List<SimpleOcrItem> det, double posTolXVal, double posTolYVal, double minConf, bool checkPosition)
+		private static JObject MatchAsPrintMatch(
+			SimpleTemplate golden,
+			List<SimpleOcrItem> det,
+			double posTolXVal,
+			double posTolYVal,
+			double minConf,
+			bool checkPosition,
+			bool countPriority)
 		{
 			if (golden == null) return new JObject();
 			var templateItems = (golden.OCRResults ?? new List<SimpleOcrItem>()).Where(r => r != null && !string.IsNullOrWhiteSpace(r.Text)).ToList();
 			var detectionItemsAll = (det ?? new List<SimpleOcrItem>()).Where(r => r != null && !string.IsNullOrWhiteSpace(r.Text)).ToList();
 			// 置信度过滤（与 PrintMatch 一致）
 			var validDetections = detectionItemsAll.Where(r => r.Confidence >= (float)minConf && r.Width > 0 && r.Height > 0).ToList();
+			var expectedCount = templateItems.Count;
+
+			if (countPriority && validDetections.Count == expectedCount)
+			{
+				return BuildCountPrioritySuccess(golden, validDetections, expectedCount);
+			}
 			
 			// 不检查位置时：只按文本内容和数量匹配
 			if (!checkPosition)
 			{
-				return MatchByTextAndCountOnly(golden, validDetections, templateItems);
+				var textCountResult = MatchByTextAndCountOnly(golden, validDetections, templateItems);
+				AppendCountPrioritySummary(textCountResult, countPriority, validDetections.Count, expectedCount);
+				return textCountResult;
 			}
 				
 				// 按规范化文本分组
@@ -734,8 +757,72 @@ namespace DlcvModules
 				["missing_components"] = missCount,
 				["misjudgments"] = misjudgeCount
 			};
+				AppendCountPrioritySummary(root, countPriority, validDetections.Count, expectedCount);
 				return root;
 			}
+
+		private static JObject BuildCountPrioritySuccess(
+			SimpleTemplate golden,
+			List<SimpleOcrItem> validDetections,
+			int expectedCount)
+		{
+			var ocrArray = new JArray();
+			foreach (var item in validDetections)
+			{
+				ocrArray.Add(new JObject
+				{
+					["text"] = item.Text ?? string.Empty,
+					["x"] = item.X,
+					["y"] = item.Y,
+					["width"] = item.Width,
+					["height"] = item.Height,
+					["confidence"] = (double)item.Confidence,
+					["match_status"] = "Correct"
+				});
+			}
+
+			return new JObject
+			{
+				["ocr_results"] = ocrArray,
+				["missing_template_items"] = new JArray(),
+				["deviation_template_items"] = new JArray(),
+				["misjudgment_pairs"] = new JArray(),
+				["detected_count"] = validDetections.Count,
+				["expected_count"] = expectedCount,
+				["image_level_status"] = "OK",
+				["template_match_info"] = new JObject
+				{
+					["template_name"] = golden.TemplateName ?? string.Empty,
+					["product_name"] = golden.ProductName ?? string.Empty,
+					["is_match"] = true,
+					["match_score"] = 1.0,
+					["perfect_matches"] = validDetections.Count,
+					["position_deviations"] = 0,
+					["over_detections"] = 0,
+					["missing_components"] = 0,
+					["misjudgments"] = 0
+				}
+			};
+		}
+
+		private static void AppendCountPrioritySummary(
+			JObject detail,
+			bool countPriority,
+			int detectedCount,
+			int expectedCount)
+		{
+			if (!countPriority || detail == null) return;
+			detail["detected_count"] = detectedCount;
+			detail["expected_count"] = expectedCount;
+			var info = detail["template_match_info"] as JObject;
+			var isMatch = info != null && info.Value<bool?>("is_match") == true;
+			detail["image_level_status"] = isMatch ? "OK" : "NG";
+			if (!isMatch && info != null && info["error_reason"] == null)
+			{
+				info["error_reason"] = "检测数量不符：检测到 " + detectedCount +
+					"，期望 " + expectedCount + "；已执行模版匹配";
+			}
+		}
 
 		private static List<SimpleOcrItem> ExtractOcrFromLocal(JArray results)
 		{
@@ -1037,7 +1124,7 @@ namespace DlcvModules
 	/// type: features/printed_template_match
 	/// properties:
 	/// - product_type(string): 产品型号
-	/// 可透传：position_tolerance_x(double), position_tolerance_y(double), min_confidence_threshold(double), check_position(bool)
+	/// 可透传：position_tolerance_x(double), position_tolerance_y(double), min_confidence_threshold(double), check_position(bool), count_priority(bool)
 	/// 输出：Scalar ok(bool), detail(string)；TemplateList 按条件返回。
 	/// </summary>
 	public class PrintedTemplateMatch : BaseModule
@@ -1203,7 +1290,7 @@ namespace DlcvModules
 						["width"] = item.Width,
 						["height"] = item.Height,
 						["confidence"] = (double)item.Confidence,
-						["match_status"] = "Correct"
+						["match_status"] = "Candidate"
 					});
 				}
 				var candidate = new JObject
@@ -1217,16 +1304,17 @@ namespace DlcvModules
 					{
 						["template_name"] = templateName,
 						["product_name"] = productType,
-						["is_match"] = true,
-						["match_score"] = 1.0,
-						["perfect_matches"] = ocrArray.Count,
+						["is_match"] = false,
+						["match_score"] = 0.0,
+						["perfect_matches"] = 0,
 						["position_deviations"] = 0,
 						["over_detections"] = 0,
 						["missing_components"] = 0,
-						["misjudgments"] = 0
+						["misjudgments"] = 0,
+						["error_reason"] = "模版待创建"
 					}
 				};
-				this.ScalarOutputsByName["ok"] = true;
+				this.ScalarOutputsByName["ok"] = false;
 				this.ScalarOutputsByName["detail"] = candidate.ToString(Formatting.None);
 				return new ModuleIO(images, results, new List<SimpleTemplate>());
 			}
@@ -1277,7 +1365,8 @@ namespace DlcvModules
 					["position_tolerance_x"] = ReadDoubleOr("position_tolerance_x", 20.0),
 					["position_tolerance_y"] = ReadDoubleOr("position_tolerance_y", 20.0),
 					["min_confidence_threshold"] = ReadDoubleOr("min_confidence_threshold", 0.5),
-					["check_position"] = checkPosSelf
+					["check_position"] = checkPosSelf,
+					["count_priority"] = ReadBoolOr("count_priority", false)
 				});
 				matcherSelf.MainTemplateList = new List<SimpleTemplate> { tpl };
 				matcherSelf.ExtraInputsIn.Add(new ModuleChannel(new List<ModuleImage>(), new JArray(), goldenListSelf));
@@ -1307,7 +1396,8 @@ namespace DlcvModules
 				["position_tolerance_x"] = ReadDoubleOr("position_tolerance_x", 20.0),
 				["position_tolerance_y"] = ReadDoubleOr("position_tolerance_y", 20.0),
 				["min_confidence_threshold"] = ReadDoubleOr("min_confidence_threshold", 0.5),
-				["check_position"] = checkPos
+				["check_position"] = checkPos,
+				["count_priority"] = ReadBoolOr("count_priority", false)
 			});
 			matcher.MainTemplateList = new List<SimpleTemplate> { tpl };
 			matcher.ExtraInputsIn.Add(new ModuleChannel(new List<ModuleImage>(), new JArray(), goldenList));
@@ -1328,6 +1418,16 @@ namespace DlcvModules
 			}
 			return dv;
 		}
+
+		private bool ReadBoolOr(string key, bool dv)
+		{
+			if (Properties != null && Properties.TryGetValue(key, out object v) && v != null)
+			{
+				bool x; if (bool.TryParse(v.ToString(), out x)) return x;
+			}
+			return dv;
+		}
+
 	}
 }
 

--- a/DlcvCsharpApi/flow/modules/Templates.cs
+++ b/DlcvCsharpApi/flow/modules/Templates.cs
@@ -331,7 +331,10 @@ namespace DlcvModules
 			{
 				if (original != null)
 				{
-					var filtered = original.Where(x => x == null || ((x.Text ?? string.Empty).IndexOf("NG", StringComparison.OrdinalIgnoreCase) < 0)).ToList();
+					var preserveNgCategory = tpl.CameraPosition == 3;
+					var filtered = preserveNgCategory
+						? original.ToList()
+						: original.Where(x => x == null || ((x.Text ?? string.Empty).IndexOf("NG", StringComparison.OrdinalIgnoreCase) < 0)).ToList();
 					tpl.OCRResults = filtered;
 				}
 			}
@@ -533,8 +536,9 @@ namespace DlcvModules
 			// 置信度过滤（与 PrintMatch 一致）
 			var validDetections = detectionItemsAll.Where(r => r.Confidence >= (float)minConf && r.Width > 0 && r.Height > 0).ToList();
 			var expectedCount = templateItems.Count;
+			var categoryCountsMatch = HaveSameCategoryCounts(templateItems, validDetections);
 
-			if (countPriority && validDetections.Count == expectedCount)
+			if (countPriority && categoryCountsMatch)
 			{
 				return BuildCountPrioritySuccess(golden, validDetections, expectedCount);
 			}
@@ -542,25 +546,34 @@ namespace DlcvModules
 			// 不检查位置时：只按文本内容和数量匹配
 			if (!checkPosition)
 			{
-				var textCountResult = MatchByTextAndCountOnly(golden, validDetections, templateItems);
-				AppendCountPrioritySummary(textCountResult, countPriority, validDetections.Count, expectedCount);
+				var textCountResult = MatchByTextAndCountOnly(
+					golden,
+					validDetections,
+					templateItems,
+					countPriority);
+				AppendCountPrioritySummary(
+					textCountResult,
+					countPriority,
+					validDetections.Count,
+					expectedCount,
+					categoryCountsMatch);
 				return textCountResult;
 			}
 				
-				// 按规范化文本分组
+				// 按当前匹配规则生成的类别键分组
 				var allTexts = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 				var tplGroups = new Dictionary<string, List<SimpleOcrItem>>(StringComparer.OrdinalIgnoreCase);
 				var detGroups = new Dictionary<string, List<SimpleOcrItem>>(StringComparer.OrdinalIgnoreCase);
 				for (int i = 0; i < templateItems.Count; i++)
 				{
-					string key = NormalizeTextPM(templateItems[i].Text);
+					string key = GetMatchCategoryKey(templateItems[i].Text, countPriority);
 					allTexts.Add(key);
 					if (!tplGroups.ContainsKey(key)) tplGroups[key] = new List<SimpleOcrItem>();
 					tplGroups[key].Add(templateItems[i]);
 				}
 				for (int i = 0; i < validDetections.Count; i++)
 				{
-					string key = NormalizeTextPM(validDetections[i].Text);
+					string key = GetMatchCategoryKey(validDetections[i].Text, countPriority);
 					allTexts.Add(key);
 					if (!detGroups.ContainsKey(key)) detGroups[key] = new List<SimpleOcrItem>();
 					detGroups[key].Add(validDetections[i]);
@@ -757,9 +770,51 @@ namespace DlcvModules
 				["missing_components"] = missCount,
 				["misjudgments"] = misjudgeCount
 			};
-				AppendCountPrioritySummary(root, countPriority, validDetections.Count, expectedCount);
+				AppendCountPrioritySummary(
+					root,
+					countPriority,
+					validDetections.Count,
+					expectedCount,
+					categoryCountsMatch);
 				return root;
 			}
+
+		private static bool HaveSameCategoryCounts(
+			IEnumerable<SimpleOcrItem> templateItems,
+			IEnumerable<SimpleOcrItem> detectionItems)
+		{
+			var templateCounts = BuildCategoryCounts(templateItems);
+			var detectionCounts = BuildCategoryCounts(detectionItems);
+			return templateCounts.Count == detectionCounts.Count &&
+				templateCounts.All(pair => detectionCounts.TryGetValue(pair.Key, out int count) && count == pair.Value);
+		}
+
+		private static Dictionary<string, int> BuildCategoryCounts(IEnumerable<SimpleOcrItem> items)
+		{
+			var counts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+			foreach (var item in items ?? Enumerable.Empty<SimpleOcrItem>())
+			{
+				if (item == null) continue;
+				var category = NormalizeCategoryName(item.Text);
+				if (string.IsNullOrWhiteSpace(category)) continue;
+				counts[category] = counts.TryGetValue(category, out int count) ? count + 1 : 1;
+			}
+			return counts;
+		}
+
+		private static string NormalizeCategoryName(string category)
+		{
+			return string.IsNullOrWhiteSpace(category)
+				? string.Empty
+				: category.Trim();
+		}
+
+		private static string GetMatchCategoryKey(string category, bool useExactCategory)
+		{
+			return useExactCategory
+				? NormalizeCategoryName(category)
+				: NormalizeTextPM(category);
+		}
 
 		private static JObject BuildCountPrioritySuccess(
 			SimpleTemplate golden,
@@ -809,7 +864,8 @@ namespace DlcvModules
 			JObject detail,
 			bool countPriority,
 			int detectedCount,
-			int expectedCount)
+			int expectedCount,
+			bool categoryCountsMatch)
 		{
 			if (!countPriority || detail == null) return;
 			detail["detected_count"] = detectedCount;
@@ -819,8 +875,10 @@ namespace DlcvModules
 			detail["image_level_status"] = isMatch ? "OK" : "NG";
 			if (!isMatch && info != null && info["error_reason"] == null)
 			{
-				info["error_reason"] = "检测数量不符：检测到 " + detectedCount +
-					"，期望 " + expectedCount + "；已执行模版匹配";
+				info["error_reason"] = detectedCount != expectedCount
+					? "检测数量不符：检测到 " + detectedCount +
+						"，模版 " + expectedCount + "；已执行模版匹配"
+					: "检测类别数量不符；已执行模版匹配";
 			}
 		}
 
@@ -992,21 +1050,25 @@ namespace DlcvModules
 			return dv;
 		}
 
-		private static JObject MatchByTextAndCountOnly(SimpleTemplate golden, List<SimpleOcrItem> validDetections, List<SimpleOcrItem> templateItems)
+		private static JObject MatchByTextAndCountOnly(
+			SimpleTemplate golden,
+			List<SimpleOcrItem> validDetections,
+			List<SimpleOcrItem> templateItems,
+			bool useExactCategory)
 		{
 			var tplTextCount = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 			var detTextCount = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 			
 			foreach (var t in templateItems)
 			{
-				string key = NormalizeTextPM(t.Text);
+				string key = GetMatchCategoryKey(t.Text, useExactCategory);
 				if (!tplTextCount.ContainsKey(key)) tplTextCount[key] = 0;
 				tplTextCount[key]++;
 			}
 			
 			foreach (var d in validDetections)
 			{
-				string key = NormalizeTextPM(d.Text);
+				string key = GetMatchCategoryKey(d.Text, useExactCategory);
 				if (!detTextCount.ContainsKey(key)) detTextCount[key] = 0;
 				detTextCount[key]++;
 			}
@@ -1031,17 +1093,17 @@ namespace DlcvModules
 				if (detCount > tplCount)
 				{
 					overCount += (detCount - tplCount);
-					var items = validDetections.Where(d => string.Equals(NormalizeTextPM(d.Text), text, StringComparison.OrdinalIgnoreCase)).ToList();
+					var items = validDetections.Where(d => string.Equals(GetMatchCategoryKey(d.Text, useExactCategory), text, StringComparison.OrdinalIgnoreCase)).ToList();
 					for (int i = matched; i < items.Count; i++) overList.Add(items[i]);
 				}
 				else if (tplCount > detCount)
 				{
 					missCount += (tplCount - detCount);
-					var items = templateItems.Where(t => string.Equals(NormalizeTextPM(t.Text), text, StringComparison.OrdinalIgnoreCase)).ToList();
+					var items = templateItems.Where(t => string.Equals(GetMatchCategoryKey(t.Text, useExactCategory), text, StringComparison.OrdinalIgnoreCase)).ToList();
 					for (int i = matched; i < items.Count; i++) missList.Add(items[i]);
 				}
 				
-				var matchedDet = validDetections.Where(d => string.Equals(NormalizeTextPM(d.Text), text, StringComparison.OrdinalIgnoreCase)).Take(matched).ToList();
+				var matchedDet = validDetections.Where(d => string.Equals(GetMatchCategoryKey(d.Text, useExactCategory), text, StringComparison.OrdinalIgnoreCase)).Take(matched).ToList();
 				correctList.AddRange(matchedDet);
 			}
 			

--- a/Test/DlcvCSharpTest/Program.cs
+++ b/Test/DlcvCSharpTest/Program.cs
@@ -3466,8 +3466,8 @@ namespace DlcvCSharpTest
                     OCRResults = new List<SimpleOcrItem>
                     {
                         MakeTemplateSelfTestItem("A", 0, 0),
-                        MakeTemplateSelfTestItem("B", 20, 0),
-                        MakeTemplateSelfTestItem("C", 40, 0),
+                        MakeTemplateSelfTestItem("A", 20, 0),
+                        MakeTemplateSelfTestItem("B", 40, 0),
                         MakeTemplateSelfTestItem(" ", 60, 0),
                         null
                     }
@@ -3477,9 +3477,9 @@ namespace DlcvCSharpTest
                     golden,
                     new List<SimpleOcrItem>
                     {
-                        MakeTemplateSelfTestItem("X", 100, 100),
-                        MakeTemplateSelfTestItem("Y", 120, 100),
-                        MakeTemplateSelfTestItem("Z", 140, 100)
+                        MakeTemplateSelfTestItem(" a ", 100, 100),
+                        MakeTemplateSelfTestItem("A", 120, 100),
+                        MakeTemplateSelfTestItem("B", 140, 100)
                     },
                     true);
                 RequireTemplateCountPriority(
@@ -3489,42 +3489,141 @@ namespace DlcvCSharpTest
                     equalButDifferent["detail"]?["ocr_results"] is JArray equalItems &&
                     equalItems.Count == 3 &&
                     equalItems.All(item => item?["match_status"]?.ToString() == "Correct"),
-                    "count_priority=true should accept equal effective counts and mark every detection Correct");
+                    "count_priority=true should accept equal normalized category counts despite position changes");
 
-                var mismatch = RunTemplateCountPriorityCase(
+                var categoryDistributionMismatch = RunTemplateCountPriorityCase(
                     golden,
                     new List<SimpleOcrItem>
                     {
                         MakeTemplateSelfTestItem("A", 0, 0),
-                        MakeTemplateSelfTestItem("X", 80, 80)
+                        MakeTemplateSelfTestItem("B", 20, 0),
+                        MakeTemplateSelfTestItem("B", 40, 0)
                     },
                     true);
-                var mismatchDetail = mismatch["detail"] as JObject;
-                var mismatchItems = mismatchDetail?["ocr_results"] as JArray;
+                var distributionDetail = categoryDistributionMismatch["detail"] as JObject;
                 RequireTemplateCountPriority(
-                    !mismatch.Value<bool>("ok") &&
-                    mismatchDetail?["template_match_info"]?.Value<int>("perfect_matches") == 1 &&
-                    mismatchDetail?["template_match_info"]?.Value<int>("over_detections") == 1 &&
-                    mismatchDetail?["template_match_info"]?.Value<int>("missing_components") == 2 &&
-                    mismatchItems != null &&
-                    mismatchItems.Any(item => item?["match_status"]?.ToString() == "Correct") &&
-                    mismatchItems.Any(item => item?["match_status"]?.ToString() == "OverDetection"),
-                    "unequal counts should fall back to ordinary matching with correct, over-detection and missing items");
+                    !categoryDistributionMismatch.Value<bool>("ok") &&
+                    distributionDetail?["template_match_info"]?.Value<int>("perfect_matches") == 2 &&
+                    distributionDetail?["template_match_info"]?.Value<int>("over_detections") == 1 &&
+                    distributionDetail?["template_match_info"]?.Value<int>("missing_components") == 1,
+                    "equal totals with different normalized category distributions should fall back and fail");
+
+                var totalMismatch = RunTemplateCountPriorityCase(
+                    golden,
+                    new List<SimpleOcrItem>
+                    {
+                        MakeTemplateSelfTestItem("A", 0, 0),
+                        MakeTemplateSelfTestItem("A", 20, 0)
+                    },
+                    true);
+                RequireTemplateCountPriority(
+                    !totalMismatch.Value<bool>("ok") &&
+                    totalMismatch["detail"]?["template_match_info"]?.Value<int>("missing_components") == 1,
+                    "different totals should fall back to ordinary matching and fail");
 
                 var disabled = RunTemplateCountPriorityCase(
                     golden,
                     new List<SimpleOcrItem>
                     {
-                        MakeTemplateSelfTestItem("X", 100, 100),
-                        MakeTemplateSelfTestItem("Y", 120, 100),
-                        MakeTemplateSelfTestItem("Z", 140, 100)
+                        MakeTemplateSelfTestItem("A", 100, 100),
+                        MakeTemplateSelfTestItem("A", 120, 100),
+                        MakeTemplateSelfTestItem("B", 140, 100)
                     },
                     false);
                 RequireTemplateCountPriority(
                     !disabled.Value<bool>("ok") &&
                     disabled["detail"]?["template_match_info"]?.Value<int>("over_detections") == 3 &&
                     disabled["detail"]?["template_match_info"]?.Value<int>("missing_components") == 3,
-                    "count_priority=false should preserve ordinary template matching");
+                    "count_priority=false should preserve ordinary position-sensitive matching");
+
+                var bGolden = new SimpleTemplate
+                {
+                    TemplateName = "EXACT-B",
+                    OCRResults = new List<SimpleOcrItem>
+                    {
+                        MakeTemplateSelfTestItem("B", 0, 0)
+                    }
+                };
+                var bVsEight = RunTemplateCountPriorityCase(
+                    bGolden,
+                    new List<SimpleOcrItem> { MakeTemplateSelfTestItem("8", 0, 0) },
+                    true);
+                RequireTemplateCountPriority(
+                    !bVsEight.Value<bool>("ok"),
+                    "count_priority fallback must keep B distinct from 8");
+
+                var okGolden = new SimpleTemplate
+                {
+                    TemplateName = "EXACT-OK",
+                    OCRResults = new List<SimpleOcrItem>
+                    {
+                        MakeTemplateSelfTestItem("OK", 0, 0)
+                    }
+                };
+                var okVsZeroK = RunTemplateCountPriorityCase(
+                    okGolden,
+                    new List<SimpleOcrItem> { MakeTemplateSelfTestItem("0K", 0, 0) },
+                    true,
+                    false);
+                RequireTemplateCountPriority(
+                    !okVsZeroK.Value<bool>("ok"),
+                    "count_priority fallback must keep OK distinct from 0K");
+
+                var legacyBVsEight = RunTemplateCountPriorityCase(
+                    bGolden,
+                    new List<SimpleOcrItem> { MakeTemplateSelfTestItem("8", 0, 0) },
+                    false);
+                RequireTemplateCountPriority(
+                    legacyBVsEight.Value<bool>("ok"),
+                    "count_priority=false should preserve ordinary ambiguous-character normalization");
+
+                var dGolden = new SimpleTemplate
+                {
+                    TemplateName = "COUNT-PRIORITY-D",
+                    ProductName = "COUNT-PRIORITY-D",
+                    CameraPosition = 3,
+                    OCRResults = new List<SimpleOcrItem>
+                    {
+                        MakeTemplateSelfTestItem("OK", 0, 0),
+                        MakeTemplateSelfTestItem("OK", 20, 0),
+                        MakeTemplateSelfTestItem("OK", 40, 0),
+                        MakeTemplateSelfTestItem("NG", 60, 0)
+                    }
+                };
+                var dSameDistribution = RunTemplateCountPriorityCase(
+                    dGolden,
+                    new List<SimpleOcrItem>
+                    {
+                        MakeTemplateSelfTestItem("OK", 100, 100),
+                        MakeTemplateSelfTestItem("OK", 120, 100),
+                        MakeTemplateSelfTestItem("OK", 140, 100),
+                        MakeTemplateSelfTestItem("NG", 160, 100)
+                    },
+                    true);
+                RequireTemplateCountPriority(
+                    dSameDistribution.Value<bool>("ok") &&
+                    dSameDistribution["detail"]?["ocr_results"] is JArray dItems &&
+                    dItems.All(item => item?["match_status"]?.ToString() == "Correct"),
+                    "D count priority should accept OK x3 plus NG x1 only when category counts match");
+
+                var dWrongDistribution = RunTemplateCountPriorityCase(
+                    dGolden,
+                    new List<SimpleOcrItem>
+                    {
+                        MakeTemplateSelfTestItem("OK", 0, 0),
+                        MakeTemplateSelfTestItem("OK", 20, 0),
+                        MakeTemplateSelfTestItem("OK", 40, 0),
+                        MakeTemplateSelfTestItem("OK", 60, 0)
+                    },
+                    true);
+                RequireTemplateCountPriority(
+                    !dWrongDistribution.Value<bool>("ok") &&
+                    ((dWrongDistribution["detail"]?["template_match_info"]?.Value<int>("over_detections") ?? 0) +
+                     (dWrongDistribution["detail"]?["template_match_info"]?.Value<int>("missing_components") ?? 0) +
+                     (dWrongDistribution["detail"]?["template_match_info"]?.Value<int>("misjudgments") ?? 0)) > 0,
+                    "D count priority must reject OK x4 when the template is OK x3 plus NG x1");
+
+                VerifyTemplateSaveNgPolicy();
 
                 Console.WriteLine("template count priority selftest passed");
                 return 0;
@@ -3539,7 +3638,8 @@ namespace DlcvCSharpTest
         private static JObject RunTemplateCountPriorityCase(
             SimpleTemplate golden,
             List<SimpleOcrItem> detections,
-            bool countPriority)
+            bool countPriority,
+            bool checkPosition = true)
         {
             var module = new TemplateMatch(
                 9001,
@@ -3547,7 +3647,7 @@ namespace DlcvCSharpTest
                 {
                     { "count_priority", countPriority },
                     { "expected_count", 999 },
-                    { "check_position", false },
+                    { "check_position", checkPosition },
                     { "min_confidence_threshold", 0.5 }
                 });
             module.MainTemplateList = new List<SimpleTemplate>
@@ -3590,6 +3690,68 @@ namespace DlcvCSharpTest
         private static void RequireTemplateCountPriority(bool condition, string message)
         {
             if (!condition) throw new InvalidOperationException(message);
+        }
+
+        private static void VerifyTemplateSaveNgPolicy()
+        {
+            var root = Path.Combine(Path.GetTempPath(), "DlcvTemplateSaveNg_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(root);
+            try
+            {
+                var context = new DlcvModules.ExecutionContext();
+                context.Set("templates_dir", root);
+                var dTemplate = new SimpleTemplate
+                {
+                    TemplateId = "D-NG-POLICY",
+                    TemplateName = "D-NG-POLICY",
+                    CameraPosition = 3,
+                    OCRResults = new List<SimpleOcrItem>
+                    {
+                        MakeTemplateSelfTestItem("OK", 0, 0),
+                        MakeTemplateSelfTestItem("OK", 20, 0),
+                        MakeTemplateSelfTestItem("OK", 40, 0),
+                        MakeTemplateSelfTestItem("NG", 60, 0)
+                    }
+                };
+                var dSaver = new TemplateSave(
+                    9101,
+                    properties: new Dictionary<string, object> { { "file_name", "D-NG-POLICY" } },
+                    context: context);
+                dSaver.MainTemplateList = new List<SimpleTemplate> { dTemplate };
+                dSaver.Process(new List<ModuleImage>(), new JArray());
+                var savedD = JsonConvert.DeserializeObject<SimpleTemplate>(
+                    File.ReadAllText(Path.Combine(root, "D-NG-POLICY.json")));
+                RequireTemplateCountPriority(
+                    savedD != null && savedD.OCRResults.Count == 4 && savedD.OCRResults.Count(x => x.Text == "NG") == 1,
+                    "TemplateSave should preserve NG categories for D templates");
+
+                var aTemplate = new SimpleTemplate
+                {
+                    TemplateId = "A-NG-POLICY",
+                    TemplateName = "A-NG-POLICY",
+                    CameraPosition = 0,
+                    OCRResults = new List<SimpleOcrItem>
+                    {
+                        MakeTemplateSelfTestItem("PRINT", 0, 0),
+                        MakeTemplateSelfTestItem("NG-PRINT", 20, 0)
+                    }
+                };
+                var aSaver = new TemplateSave(
+                    9102,
+                    properties: new Dictionary<string, object> { { "file_name", "A-NG-POLICY" } },
+                    context: context);
+                aSaver.MainTemplateList = new List<SimpleTemplate> { aTemplate };
+                aSaver.Process(new List<ModuleImage>(), new JArray());
+                var savedA = JsonConvert.DeserializeObject<SimpleTemplate>(
+                    File.ReadAllText(Path.Combine(root, "A-NG-POLICY.json")));
+                RequireTemplateCountPriority(
+                    savedA != null && savedA.OCRResults.Count == 1 && savedA.OCRResults[0].Text == "PRINT",
+                    "TemplateSave should keep the existing A/B/C NG text filter");
+            }
+            finally
+            {
+                try { Directory.Delete(root, true); } catch { }
+            }
         }
 
         [DllImport("psapi.dll", SetLastError = true)]

--- a/Test/DlcvCSharpTest/Program.cs
+++ b/Test/DlcvCSharpTest/Program.cs
@@ -3501,11 +3501,14 @@ namespace DlcvCSharpTest
                     },
                     true);
                 var distributionDetail = categoryDistributionMismatch["detail"] as JObject;
+                var distributionReason = distributionDetail?["template_match_info"]?["error_reason"]?.ToString();
                 RequireTemplateCountPriority(
                     !categoryDistributionMismatch.Value<bool>("ok") &&
                     distributionDetail?["template_match_info"]?.Value<int>("perfect_matches") == 2 &&
                     distributionDetail?["template_match_info"]?.Value<int>("over_detections") == 1 &&
-                    distributionDetail?["template_match_info"]?.Value<int>("missing_components") == 1,
+                    distributionDetail?["template_match_info"]?.Value<int>("missing_components") == 1 &&
+					distributionReason == "缺：A×1；多：B×1" &&
+                    distributionReason.IndexOf("已执行模版匹配", StringComparison.Ordinal) < 0,
                     "equal totals with different normalized category distributions should fall back and fail");
 
                 var totalMismatch = RunTemplateCountPriorityCase(
@@ -3518,7 +3521,8 @@ namespace DlcvCSharpTest
                     true);
                 RequireTemplateCountPriority(
                     !totalMismatch.Value<bool>("ok") &&
-                    totalMismatch["detail"]?["template_match_info"]?.Value<int>("missing_components") == 1,
+                    totalMismatch["detail"]?["template_match_info"]?.Value<int>("missing_components") == 1 &&
+					totalMismatch["detail"]?["template_match_info"]?["error_reason"]?.ToString() == "缺：B×1",
                     "different totals should fall back to ordinary matching and fail");
 
                 var disabled = RunTemplateCountPriorityCase(
@@ -3533,7 +3537,9 @@ namespace DlcvCSharpTest
                 RequireTemplateCountPriority(
                     !disabled.Value<bool>("ok") &&
                     disabled["detail"]?["template_match_info"]?.Value<int>("over_detections") == 3 &&
-                    disabled["detail"]?["template_match_info"]?.Value<int>("missing_components") == 3,
+                    disabled["detail"]?["template_match_info"]?.Value<int>("missing_components") == 3 &&
+                    disabled["detail"]?["template_match_info"]?["error_reason"]?.ToString() ==
+						"缺：A×2、B×1；多：A×2、B×1",
                     "count_priority=false should preserve ordinary position-sensitive matching");
 
                 var bGolden = new SimpleTemplate
@@ -3549,7 +3555,9 @@ namespace DlcvCSharpTest
                     new List<SimpleOcrItem> { MakeTemplateSelfTestItem("8", 0, 0) },
                     true);
                 RequireTemplateCountPriority(
-                    !bVsEight.Value<bool>("ok"),
+                    !bVsEight.Value<bool>("ok") &&
+					bVsEight["detail"]?["template_match_info"]?["error_reason"]?.ToString() ==
+						"缺：B×1；多：8×1；误判：模版 B→检测 8×1",
                     "count_priority fallback must keep B distinct from 8");
 
                 var okGolden = new SimpleTemplate
@@ -3566,7 +3574,9 @@ namespace DlcvCSharpTest
                     true,
                     false);
                 RequireTemplateCountPriority(
-                    !okVsZeroK.Value<bool>("ok"),
+                    !okVsZeroK.Value<bool>("ok") &&
+					okVsZeroK["detail"]?["template_match_info"]?["error_reason"]?.ToString() ==
+						"缺：OK×1；多：0K×1",
                     "count_priority fallback must keep OK distinct from 0K");
 
                 var legacyBVsEight = RunTemplateCountPriorityCase(
@@ -3576,6 +3586,29 @@ namespace DlcvCSharpTest
                 RequireTemplateCountPriority(
                     legacyBVsEight.Value<bool>("ok"),
                     "count_priority=false should preserve ordinary ambiguous-character normalization");
+
+                var deviationTemplateItem = MakeTemplateSelfTestItem("A", 0, 0);
+                deviationTemplateItem.Width = 100;
+                var deviationDetectionItem = MakeTemplateSelfTestItem("A", 40, 0);
+                deviationDetectionItem.Width = 100;
+                var deviationGolden = new SimpleTemplate
+                {
+                    TemplateName = "POSITION-REASON",
+                    OCRResults = new List<SimpleOcrItem>
+                    {
+                        deviationTemplateItem,
+                        MakeTemplateSelfTestItem("B", 200, 0)
+                    }
+                };
+                var deviationMismatch = RunTemplateCountPriorityCase(
+                    deviationGolden,
+                    new List<SimpleOcrItem> { deviationDetectionItem },
+                    true);
+                RequireTemplateCountPriority(
+                    !deviationMismatch.Value<bool>("ok") &&
+					deviationMismatch["detail"]?["template_match_info"]?["error_reason"]?.ToString() ==
+						"缺：B×1；位置偏差：A×1",
+                    "ordinary fallback should include concrete position deviation details when the result is NG");
 
                 var dGolden = new SimpleTemplate
                 {
@@ -3620,7 +3653,9 @@ namespace DlcvCSharpTest
                     !dWrongDistribution.Value<bool>("ok") &&
                     ((dWrongDistribution["detail"]?["template_match_info"]?.Value<int>("over_detections") ?? 0) +
                      (dWrongDistribution["detail"]?["template_match_info"]?.Value<int>("missing_components") ?? 0) +
-                     (dWrongDistribution["detail"]?["template_match_info"]?.Value<int>("misjudgments") ?? 0)) > 0,
+                     (dWrongDistribution["detail"]?["template_match_info"]?.Value<int>("misjudgments") ?? 0)) > 0 &&
+					dWrongDistribution["detail"]?["template_match_info"]?["error_reason"]?.ToString() ==
+						"缺：NG×1；多：OK×1；误判：模版 NG→检测 OK×1",
                     "D count priority must reject OK x4 when the template is OK x3 plus NG x1");
 
                 VerifyTemplateSaveNgPolicy();

--- a/Test/DlcvCSharpTest/Program.cs
+++ b/Test/DlcvCSharpTest/Program.cs
@@ -78,6 +78,11 @@ namespace DlcvCSharpTest
                     return RunBBoxIoUDedupSelfTest();
                 }
 
+                if (args != null && args.Length >= 1 && string.Equals(args[0], "template-count-priority-selftest", StringComparison.OrdinalIgnoreCase))
+                {
+                    return RunTemplateCountPrioritySelfTest();
+                }
+
                 if (args != null && args.Length >= 1 && string.Equals(args[0], "image-generation-expand-selftest", StringComparison.OrdinalIgnoreCase))
                 {
                     return RunImageGenerationExpandSelfTest();
@@ -3448,6 +3453,143 @@ namespace DlcvCSharpTest
             }
             Console.WriteLine("==== with_mask 参数透传自测 失败数=" + globalFail + " ====");
             return 1;
+        }
+
+        private static int RunTemplateCountPrioritySelfTest()
+        {
+            try
+            {
+                var golden = new SimpleTemplate
+                {
+                    TemplateName = "COUNT-PRIORITY",
+                    ProductName = "COUNT-PRIORITY",
+                    OCRResults = new List<SimpleOcrItem>
+                    {
+                        MakeTemplateSelfTestItem("A", 0, 0),
+                        MakeTemplateSelfTestItem("B", 20, 0),
+                        MakeTemplateSelfTestItem("C", 40, 0),
+                        MakeTemplateSelfTestItem(" ", 60, 0),
+                        null
+                    }
+                };
+
+                var equalButDifferent = RunTemplateCountPriorityCase(
+                    golden,
+                    new List<SimpleOcrItem>
+                    {
+                        MakeTemplateSelfTestItem("X", 100, 100),
+                        MakeTemplateSelfTestItem("Y", 120, 100),
+                        MakeTemplateSelfTestItem("Z", 140, 100)
+                    },
+                    true);
+                RequireTemplateCountPriority(
+                    equalButDifferent.Value<bool>("ok") &&
+                    equalButDifferent["detail"]?["template_match_info"]?.Value<bool>("is_match") == true &&
+                    equalButDifferent["detail"]?.Value<int>("expected_count") == 3 &&
+                    equalButDifferent["detail"]?["ocr_results"] is JArray equalItems &&
+                    equalItems.Count == 3 &&
+                    equalItems.All(item => item?["match_status"]?.ToString() == "Correct"),
+                    "count_priority=true should accept equal effective counts and mark every detection Correct");
+
+                var mismatch = RunTemplateCountPriorityCase(
+                    golden,
+                    new List<SimpleOcrItem>
+                    {
+                        MakeTemplateSelfTestItem("A", 0, 0),
+                        MakeTemplateSelfTestItem("X", 80, 80)
+                    },
+                    true);
+                var mismatchDetail = mismatch["detail"] as JObject;
+                var mismatchItems = mismatchDetail?["ocr_results"] as JArray;
+                RequireTemplateCountPriority(
+                    !mismatch.Value<bool>("ok") &&
+                    mismatchDetail?["template_match_info"]?.Value<int>("perfect_matches") == 1 &&
+                    mismatchDetail?["template_match_info"]?.Value<int>("over_detections") == 1 &&
+                    mismatchDetail?["template_match_info"]?.Value<int>("missing_components") == 2 &&
+                    mismatchItems != null &&
+                    mismatchItems.Any(item => item?["match_status"]?.ToString() == "Correct") &&
+                    mismatchItems.Any(item => item?["match_status"]?.ToString() == "OverDetection"),
+                    "unequal counts should fall back to ordinary matching with correct, over-detection and missing items");
+
+                var disabled = RunTemplateCountPriorityCase(
+                    golden,
+                    new List<SimpleOcrItem>
+                    {
+                        MakeTemplateSelfTestItem("X", 100, 100),
+                        MakeTemplateSelfTestItem("Y", 120, 100),
+                        MakeTemplateSelfTestItem("Z", 140, 100)
+                    },
+                    false);
+                RequireTemplateCountPriority(
+                    !disabled.Value<bool>("ok") &&
+                    disabled["detail"]?["template_match_info"]?.Value<int>("over_detections") == 3 &&
+                    disabled["detail"]?["template_match_info"]?.Value<int>("missing_components") == 3,
+                    "count_priority=false should preserve ordinary template matching");
+
+                Console.WriteLine("template count priority selftest passed");
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("template count priority selftest failed: " + ex.Message);
+                return 1;
+            }
+        }
+
+        private static JObject RunTemplateCountPriorityCase(
+            SimpleTemplate golden,
+            List<SimpleOcrItem> detections,
+            bool countPriority)
+        {
+            var module = new TemplateMatch(
+                9001,
+                properties: new Dictionary<string, object>
+                {
+                    { "count_priority", countPriority },
+                    { "expected_count", 999 },
+                    { "check_position", false },
+                    { "min_confidence_threshold", 0.5 }
+                });
+            module.MainTemplateList = new List<SimpleTemplate>
+            {
+                new SimpleTemplate { OCRResults = detections }
+            };
+            module.ExtraInputsIn.Add(new ModuleChannel(
+                new List<ModuleImage>(),
+                new JArray(),
+                new List<SimpleTemplate> { golden }));
+            module.Process(new List<ModuleImage>(), new JArray());
+
+            var ok = module.ScalarOutputsByName.ContainsKey("ok") &&
+                Convert.ToBoolean(module.ScalarOutputsByName["ok"]);
+            var detailText = module.ScalarOutputsByName.ContainsKey("detail")
+                ? Convert.ToString(module.ScalarOutputsByName["detail"])
+                : string.Empty;
+            return new JObject
+            {
+                ["ok"] = ok,
+                ["detail"] = string.IsNullOrWhiteSpace(detailText)
+                    ? new JObject()
+                    : JObject.Parse(detailText)
+            };
+        }
+
+        private static SimpleOcrItem MakeTemplateSelfTestItem(string text, int x, int y)
+        {
+            return new SimpleOcrItem
+            {
+                Text = text,
+                X = x,
+                Y = y,
+                Width = 10,
+                Height = 10,
+                Confidence = 0.99f
+            };
+        }
+
+        private static void RequireTemplateCountPriority(bool condition, string message)
+        {
+            if (!condition) throw new InvalidOperationException(message);
         }
 
         [DllImport("psapi.dll", SetLastError = true)]

--- a/模块、流程与模型推理标准文档.md
+++ b/模块、流程与模型推理标准文档.md
@@ -424,8 +424,8 @@ Flow 中的模块围绕四类数据工作：
 | `features/template_from_results` | 根据 OCR 结果生成模板对象 | 图像、OCR 结果 | 模板对象 |
 | `features/template_save` | 保存模板 JSON，可同时保存首张图 | 模板对象、图像、文件名 | 模板文件、图片文件 |
 | `features/template_load` | 从 JSON 文件中读取模板 | 模板路径 | 模板对象 |
-| `features/template_match` | 比较当前 OCR 结果和模板对象，输出匹配结果和明细 | 当前模板或 OCR 结果、目标模板、匹配参数 | `ok`、`detail`、匹配明细 |
-| `features/printed_template_match` | 组织印刷模板的生成、保存、加载和匹配流程 | 图像、OCR 结果、模板参数 | 模板匹配结果与明细 |
+| `features/template_match` | 比较当前 OCR 结果和模板对象，输出匹配结果和明细；C# Flow 支持按类别数量优先判定 | 当前模板或 OCR 结果、目标模板、匹配参数 | `ok`、`detail`、匹配明细及可选数量汇总 |
+| `features/printed_template_match` | 组织印刷模板的生成、保存、加载和匹配流程；C# Flow 支持延迟创建候选 | 图像、OCR 结果、模板参数 | 模板匹配结果、候选状态与明细 |
 
 ## 7. 模板与模板匹配
 
@@ -514,6 +514,28 @@ Flow 中的模块围绕四类数据工作：
 6. `OverDetectionItems` 表示出现了模板外的额外识别项。
 7. `MissedTemplateItems` 表示模板里应出现但本次没识别到的项。
 8. `MisjudgmentPairs` 表示模板项和识别项被配错的情况。
+
+### 7.6 C# Flow 的印刷模板扩展
+
+以下能力当前由 `DlcvCsharpApi/flow/modules/Templates.cs` 实现，属于 C# Flow 行为；C++ Flow 的 `features/printed_template_match` 仍按 `features/template_match` 兼容处理，不包含本节的候选事务与数量优先扩展。
+
+| 配置 | 默认值 | 行为 |
+| --- | --- | --- |
+| 执行上下文 `defer_template_creation` | `false` | 为 `true` 且磁盘模板不存在时，不直接保存模板，返回建模候选与空 `TemplateList`；为 `false` 时沿用自动保存并自匹配的既有流程 |
+| 节点属性 `count_priority` | `false` | 为 `true` 时按类别分别比较通过置信度与尺寸过滤后的有效项数量；各类别数量全部一致时直接通过，任一类别不一致时执行普通模板匹配 |
+| 节点属性 `check_position` | `true` | 控制普通模板匹配是否检查位置；关闭时不生成缺少位置依据的误判配对 |
+
+数量优先比较会去除类别名首尾空白并忽略大小写，不执行 OCR 易混字符替换，因此 `B` 与 `8`、`OK` 与 `0K` 保持不同类别。D 面模板保留包括 `NG` 在内的检测类别；A/B/C 面保持印刷 `NG` 文本过滤。
+
+| `detail` 字段 | 出现条件 | 含义 |
+| --- | --- | --- |
+| `template_candidate=true` | 延迟创建且磁盘模板不存在 | 当前结果是待上层提交的建模候选，不是正式匹配结果 |
+| `ocr_results[].match_status=Candidate` | 建模候选 | 当前 OCR 项属于候选模板 |
+| `detected_count` | 启用数量优先 | 本轮有效检测项总数 |
+| `expected_count` | 启用数量优先 | 黄金模板有效项总数 |
+| `image_level_status` | 启用数量优先 | 当前图片级 `OK` 或 `NG` 状态 |
+
+候选分支同时输出 `ok=false`、`template_match_info.is_match=false` 和错误原因“模版待创建”，由上层在完整产品事务中决定是否保存。
 
 ## 8. 计时与诊断
 


### PR DESCRIPTION
## 变更概览

本 PR 完善 C# Flow 的印刷模版创建与匹配能力：

- 磁盘中没有模版时，支持先返回本次检测生成的模版数据，由调用方决定保存时机
- 支持先按类别比较检测数量；数量完全一致时直接通过，数量不一致时继续执行完整匹配
- 统一输出漏检、多检、位置偏差和误判原因

## 主要修改

### 1. 支持由调用方统一保存模版

- C# Flow 的 `features/printed_template_match` 支持由调用方控制模版保存时机。
- 当执行上下文设置 `defer_template_creation=true` 且磁盘中没有模版时，节点只返回本次检测生成的模版数据，不立即写入模版文件。
- 返回结果使用 `template_candidate=true` 标识待保存的模版数据；此时 `ok` 与 `template_match_info.is_match` 为 `false`，OCR 项状态为 `Candidate`，`TemplateList` 为空。
- 调用方可在所需数据全部准备完成后统一保存，避免分步保存失败时留下不完整模版。
- 未启用该选项时保持原有行为：节点立即保存模版，并使用本次检测结果完成匹配。

### 2. 支持先按类别比较检测数量

- C# Flow 的 `features/template_match` 与 `features/printed_template_match` 支持 `count_priority`。
- 有效检测项按类别分别计数。类别名称比较时去除首尾空白并忽略大小写，但不替换字符、不合并不同类别，因此 `B/8`、`OK/0K` 仍分别统计。
- 当前检测结果与黄金模版的各类别数量完全一致时，直接判定匹配成功，并将有效检测项标记为 `Correct`。
- 任一类别数量不一致时，继续执行原有完整匹配，检查位置和类别差异。
- 结果增加以下字段：
  - `detected_count`：当前检测数量
  - `expected_count`：模版要求数量
  - `image_level_status`：整张图片的匹配状态

### 3. 统一不匹配原因

- 普通匹配和数量不一致后的完整匹配，统一输出按类别统计的漏检、多检、位置偏差和误判原因。
- 关闭位置检查时，只输出有直接依据的漏检和多检项，不生成缺少位置依据的误判配对。
- 印刷模版生成时继续按现有相机位规则处理 `NG` 类别。

### 4. C# 与 C++ 支持范围

- 同步更新 C# API、共享流程标准和 C++ API 文档。
- 本 PR 新增的模版保存时机控制、按类别比较数量和结果字段由 C# Flow 提供。
- C++ Flow 的 `features/printed_template_match` 仍按 `features/template_match` 兼容处理，不包含上述新增能力和字段。

## 验证结果

- `template-count-priority-selftest`：通过。
- 黄金模版为 `OK×3、NG×1`，当前检测类别数量一致时直接通过。
- 当前检测为 `OK×4` 或 `OK×2、NG×2` 时，继续执行完整匹配并判定为 NG。
- `B/8`、`OK/0K` 分别统计，不合并类别。
