### PR TITLE
修复: 支持枚举Virbox离线软锁

### DIFF
--- a/C# API文档.md
+++ b/C# API文档.md
@@ -612,7 +612,7 @@ C# 侧额外处理 `DV\n` 文件头校验、归档解包、`pipeline.json` 中 `
 
 ### 14.5 `sntl_admin_csharp`
 
-`sntl_admin_csharp` 对外提供状态枚举 `SntlAdminStatus`、原生加载器 `SNTLDllLoader`、运行时访问类 `SNTL`、工具类 `SNTLUtils`、`DogProvider` 枚举、`DogInfo` 与 `DogUtils`。`SNTL` 负责建立上下文并提供 `Get()`、`GetSntlInfo()`、`GetDeviceList()`、`GetFeatureList()`、`Dispose()`；`SNTLUtils` 提供静态的 Sentinel 设备列表与特征列表查询，不再自动回退到 Virbox。`Virbox` 提供独立的 Virbox 设备列表与特征列表查询。`DogUtils` 提供 `GetSentinelInfo()`、`GetVirboxInfo()`、`GetAvailableProviders()` 与 `GetAllDogInfo()`，用于同时查询两类加密狗信息。OpenIVS 不解密模型包内 `dlcv.json`。
+`sntl_admin_csharp` 对外提供状态枚举 `SntlAdminStatus`、原生加载器 `SNTLDllLoader`、运行时访问类 `SNTL`、工具类 `SNTLUtils`、`DogProvider` 枚举、`DogInfo` 与 `DogUtils`。`SNTL` 负责建立上下文并提供 `Get()`、`GetSntlInfo()`、`GetDeviceList()`、`GetFeatureList()`、`Dispose()`；`SNTLUtils` 提供静态的 Sentinel 设备列表与特征列表查询，不再自动回退到 Virbox。`Virbox` 合并 `slm_ctrl_get_all_description` 返回的设备描述与 `slm_ctrl_get_offline_local_desc` 返回的本地软锁描述；授权码软锁使用 `user_guid` 作为唯一锁号，特性列表通过 `slm_ctrl_get_license_id` 读取。`DogUtils` 提供 `GetSentinelInfo()`、`GetVirboxInfo()`、`GetAvailableProviders()` 与 `GetAllDogInfo()`，用于同时查询两类授权信息。OpenIVS 不解密模型包内 `dlcv.json`。
 
 ---
 

--- a/C#测试程序开发文档.md
+++ b/C#测试程序开发文档.md
@@ -422,6 +422,7 @@
 #### 7.12 检查加密狗（按钮：`检查加密狗`）
 
 - 调用：`DogUtils.GetAllDogInfo()`（`ShowDogInfo()`）
+- Virbox 查询同时覆盖实体设备描述和离线本地软锁描述；授权码软锁的设备列表显示唯一锁号，特性列表显示许可 ID。
 - 输出到 `richTextBox1`（格式必须一致）：
   - `Sentinel加密狗ID：\n{sentinelDeviceList}\n\nSentinel加密狗特性：\n{sentinelFeatureList}\n\nVirbox加密狗ID：\n{virboxDeviceList}\n\nVirbox加密狗特性：\n{virboxFeatureList}`
 - 若 Sentinel/Virbox 的 devices 与 features 均为空：在上述内容前追加一行 `未检测到加密狗\n\n`

--- a/C++ API文档.md
+++ b/C++ API文档.md
@@ -621,7 +621,7 @@ auto nodes = dlcv_infer::Model::GetLastFlowNodeTimings();
 
 ## 22. `sntl_admin`
 
-公开类型为 `SntlAdminStatus`、`SNTLDllLoader`、`SNTL`、`SNTLUtils`、`Virbox`、`DogProvider`、`DogInfo`、`DogUtils` 和 `ParseXmlToJson()`。固定 XML 常量中，`DefaultScope` 的厂商 ID 固定为 `26146`，`HaspIdFormat` 读取 `haspid`，`FeatureIdFormat` 读取 `featureid` 与 `haspid`。`SNTL` 构造时调用 `sntl_admin_context_new`，析构时调用 `Dispose()`，`Dispose()` 再调 `sntl_admin_context_delete`；`Get()` 调 `sntl_admin_get`，成功时返回 `{ "code": 0, "message": "成功", "data": ... }`，失败时返回 `{ "code": <status>, "message": "<状态描述>" }`。`SNTLUtils::GetDeviceList()` 返回 Sentinel 加密狗 ID 数组，`GetFeatureList()` 返回 Sentinel 特性 ID 数组，任一异常都返回空数组 `[]`，不再自动回退到 Virbox。`Virbox` 提供独立的 Virbox 设备列表与特征列表查询。`DogUtils::GetAllDogInfo()` 返回同时包含 Sentinel 与 Virbox 信息的 JSON。
+公开类型为 `SntlAdminStatus`、`SNTLDllLoader`、`SNTL`、`SNTLUtils`、`Virbox`、`DogProvider`、`DogInfo`、`DogUtils` 和 `ParseXmlToJson()`。固定 XML 常量中，`DefaultScope` 的厂商 ID 固定为 `26146`，`HaspIdFormat` 读取 `haspid`，`FeatureIdFormat` 读取 `featureid` 与 `haspid`。`SNTL` 构造时调用 `sntl_admin_context_new`，析构时调用 `Dispose()`，`Dispose()` 再调 `sntl_admin_context_delete`；`Get()` 调 `sntl_admin_get`，成功时返回 `{ "code": 0, "message": "成功", "data": ... }`，失败时返回 `{ "code": <status>, "message": "<状态描述>" }`。`SNTLUtils::GetDeviceList()` 返回 Sentinel 加密狗 ID 数组，`GetFeatureList()` 返回 Sentinel 特性 ID 数组，任一异常都返回空数组 `[]`，不再自动回退到 Virbox。`Virbox` 合并 `slm_ctrl_get_all_description` 返回的设备描述与 `slm_ctrl_get_offline_local_desc` 返回的本地软锁描述；授权码软锁使用 `user_guid` 作为唯一锁号，特性列表通过 `slm_ctrl_get_license_id` 读取。`DogUtils::GetAllDogInfo()` 返回同时包含 Sentinel 与 Virbox 信息的 JSON。
 
 ---
 

--- a/C++测试程序开发文档.md
+++ b/C++测试程序开发文档.md
@@ -174,6 +174,7 @@ dlcv_infer_cpp_qt_demo.exe --help
 
 1. 点击 **检查加密狗**。
 2. 文本区显示 Sentinel 和 Virbox 的设备和特性列表。
+   - Virbox 查询同时覆盖实体设备描述和离线本地软锁描述；授权码软锁显示唯一锁号与许可 ID。
 3. 若两者均为空，表示未检测到加密狗；此时 `DllLoader` 不加载推理 DLL。
 
 **代码路径**：`MainWindow::onCheckDog()`

--- a/DlcvCsharpApi/sntl_admin_csharp.cs
+++ b/DlcvCsharpApi/sntl_admin_csharp.cs
@@ -474,8 +474,7 @@ namespace sntl_admin_csharp
                         IntPtr infoPtr = IntPtr.Zero;
                         if (getDeviceInfo(ipc, desc.ToString(Newtonsoft.Json.Formatting.None), ref infoPtr) == SS_OK)
                         {
-                            string infoJson = Marshal.PtrToStringAnsi(infoPtr);
-                            freeBuffer(infoPtr);
+                            string infoJson = ReadAndFree(infoPtr);
                             JObject infoObj = JObject.Parse(infoJson);
                             if (infoObj["shell_num"] != null)
                             {

--- a/DlcvCsharpApi/sntl_admin_csharp.cs
+++ b/DlcvCsharpApi/sntl_admin_csharp.cs
@@ -393,6 +393,9 @@ namespace sntl_admin_csharp
         private delegate uint GetAllDescriptionDelegate(IntPtr ipc, uint format, ref IntPtr desc);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        private delegate uint GetOfflineLocalDescriptionDelegate(IntPtr ipc, ref IntPtr desc);
+
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         private delegate uint GetLicenseIdDelegate(IntPtr ipc, uint format, string desc, ref IntPtr result);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
@@ -405,6 +408,7 @@ namespace sntl_admin_csharp
         private readonly ClientOpenDelegate clientOpen;
         private readonly ClientCloseDelegate clientClose;
         private readonly GetAllDescriptionDelegate getAllDescription;
+        private readonly GetOfflineLocalDescriptionDelegate getOfflineLocalDescription;
         private readonly GetLicenseIdDelegate getLicenseId;
         private readonly GetDeviceInfoDelegate getDeviceInfo;
         private readonly FreeDelegate freeBuffer;
@@ -424,6 +428,7 @@ namespace sntl_admin_csharp
             clientOpen = GetDelegate<ClientOpenDelegate>("slm_ctrl_client_open");
             clientClose = GetDelegate<ClientCloseDelegate>("slm_ctrl_client_close");
             getAllDescription = GetDelegate<GetAllDescriptionDelegate>("slm_ctrl_get_all_description");
+            getOfflineLocalDescription = GetDelegate<GetOfflineLocalDescriptionDelegate>("slm_ctrl_get_offline_local_desc");
             getLicenseId = GetDelegate<GetLicenseIdDelegate>("slm_ctrl_get_license_id");
             getDeviceInfo = GetDelegate<GetDeviceInfoDelegate>("slm_ctrl_get_device_info");
             freeBuffer = GetDelegate<FreeDelegate>("slm_ctrl_free");
@@ -433,9 +438,8 @@ namespace sntl_admin_csharp
             hModule != IntPtr.Zero &&
             clientOpen != null &&
             clientClose != null &&
-            getAllDescription != null &&
+            (getAllDescription != null || getOfflineLocalDescription != null) &&
             getLicenseId != null &&
-            getDeviceInfo != null &&
             freeBuffer != null;
 
         public JArray GetDeviceList()
@@ -458,6 +462,15 @@ namespace sntl_admin_csharp
                 {
                     try
                     {
+                        if (string.Equals(desc["type"]?.ToString(), "slock", StringComparison.OrdinalIgnoreCase))
+                        {
+                            AddUnique(result, FirstStringByKeys(desc, new[] { "user_guid" }));
+                            continue;
+                        }
+                        if (getDeviceInfo == null)
+                        {
+                            continue;
+                        }
                         IntPtr infoPtr = IntPtr.Zero;
                         if (getDeviceInfo(ipc, desc.ToString(Newtonsoft.Json.Formatting.None), ref infoPtr) == SS_OK)
                         {
@@ -520,32 +533,61 @@ namespace sntl_admin_csharp
         private List<JObject> GetDescriptions(IntPtr ipc)
         {
             List<JObject> result = new List<JObject>();
-            IntPtr descPtr = IntPtr.Zero;
-            if (getAllDescription(ipc, INFO_FORMAT_JSON, ref descPtr) != SS_OK)
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            if (getAllDescription != null)
             {
-                return result;
+                IntPtr descPtr = IntPtr.Zero;
+                if (getAllDescription(ipc, INFO_FORMAT_JSON, ref descPtr) == SS_OK)
+                {
+                    AppendDescriptions(ParseJson(ReadAndFree(descPtr)), result, seen);
+                }
             }
+            if (getOfflineLocalDescription != null)
+            {
+                IntPtr descPtr = IntPtr.Zero;
+                if (getOfflineLocalDescription(ipc, ref descPtr) == SS_OK)
+                {
+                    AppendDescriptions(ParseJson(ReadAndFree(descPtr)), result, seen);
+                }
+            }
+            return result;
+        }
 
-            JToken root = ParseJson(ReadAndFree(descPtr));
-            // 仅保留深度视觉开发商的锁
+        private static void AppendDescriptions(
+            JToken root,
+            List<JObject> result,
+            HashSet<string> seen)
+        {
             if (root is JObject obj)
             {
-                if (IsDlcvDeveloper(obj))
-                {
-                    result.Add(obj);
-                }
+                AppendDescription(obj, result, seen);
             }
             else if (root is JArray array)
             {
                 foreach (JToken item in array)
                 {
-                    if (item is JObject itemObj && IsDlcvDeveloper(itemObj))
+                    if (item is JObject itemObj)
                     {
-                        result.Add(itemObj);
+                        AppendDescription(itemObj, result, seen);
                     }
                 }
             }
-            return result;
+        }
+
+        private static void AppendDescription(
+            JObject description,
+            List<JObject> result,
+            HashSet<string> seen)
+        {
+            if (!IsDlcvDeveloper(description))
+            {
+                return;
+            }
+            string key = description.ToString(Newtonsoft.Json.Formatting.None);
+            if (seen.Add(key))
+            {
+                result.Add(description);
+            }
         }
 
         private static bool IsDlcvDeveloper(JObject desc)

--- a/dlcv_infer_cpp_dll/dlcv_sntl_admin.cpp
+++ b/dlcv_infer_cpp_dll/dlcv_sntl_admin.cpp
@@ -1,5 +1,7 @@
 ﻿#include "dlcv_sntl_admin.h"
 
+#include <set>
+
 #ifndef _WIN32
 #include <dlfcn.h>
 #endif
@@ -16,6 +18,7 @@ namespace {
     using VirboxClientOpenFunc = int(DLCV_STDCALL *)(void** ipc);
     using VirboxClientCloseFunc = int(DLCV_STDCALL *)(void* ipc);
     using VirboxGetAllDescriptionFunc = int(DLCV_STDCALL *)(void* ipc, int format, char** desc);
+    using VirboxGetOfflineLocalDescriptionFunc = int(DLCV_STDCALL *)(void* ipc, char** desc);
     using VirboxGetLicenseIdFunc = int(DLCV_STDCALL *)(void* ipc, int format, const char* desc, char** result);
     using VirboxGetDeviceInfoFunc = int(DLCV_STDCALL *)(void* ipc, const char* desc, char** result);
     using VirboxFreeFunc = void(DLCV_STDCALL *)(void* buffer);
@@ -61,6 +64,7 @@ namespace {
         VirboxClientOpenFunc client_open = nullptr;
         VirboxClientCloseFunc client_close = nullptr;
         VirboxGetAllDescriptionFunc get_all_description = nullptr;
+        VirboxGetOfflineLocalDescriptionFunc get_offline_local_description = nullptr;
         VirboxGetLicenseIdFunc get_license_id = nullptr;
         VirboxGetDeviceInfoFunc get_device_info = nullptr;
         VirboxFreeFunc free_buffer = nullptr;
@@ -87,11 +91,14 @@ namespace {
             client_open = reinterpret_cast<VirboxClientOpenFunc>(ResolveSymbol(module, "slm_ctrl_client_open"));
             client_close = reinterpret_cast<VirboxClientCloseFunc>(ResolveSymbol(module, "slm_ctrl_client_close"));
             get_all_description = reinterpret_cast<VirboxGetAllDescriptionFunc>(ResolveSymbol(module, "slm_ctrl_get_all_description"));
+            get_offline_local_description = reinterpret_cast<VirboxGetOfflineLocalDescriptionFunc>(ResolveSymbol(module, "slm_ctrl_get_offline_local_desc"));
             get_license_id = reinterpret_cast<VirboxGetLicenseIdFunc>(ResolveSymbol(module, "slm_ctrl_get_license_id"));
             get_device_info = reinterpret_cast<VirboxGetDeviceInfoFunc>(ResolveSymbol(module, "slm_ctrl_get_device_info"));
             free_buffer = reinterpret_cast<VirboxFreeFunc>(ResolveSymbol(module, "slm_ctrl_free"));
 
-            if (!client_open || !client_close || !get_all_description || !get_license_id || !get_device_info || !free_buffer)
+            if (!client_open || !client_close
+                || (!get_all_description && !get_offline_local_description)
+                || !get_license_id || !free_buffer)
             {
                 FreeModuleHandle(module);
 #ifdef _WIN32
@@ -102,6 +109,7 @@ namespace {
                 client_open = nullptr;
                 client_close = nullptr;
                 get_all_description = nullptr;
+                get_offline_local_description = nullptr;
                 get_license_id = nullptr;
                 get_device_info = nullptr;
                 free_buffer = nullptr;
@@ -160,34 +168,46 @@ namespace {
     }
 
     std::vector<nlohmann::json> GetVirboxDescriptions(void* ipc, VirboxControlApi& api) {
-        char* desc = nullptr;
-        int status = api.get_all_description(ipc, VIRBOX_JSON, &desc);
-        if (status != VIRBOX_OK)
-        {
-            return {};
-        }
-
-        nlohmann::json root = ParseJsonSafe(ReadAndFree(api, desc));
-        // 仅保留深度视觉开发商的锁
-        if (root.is_object())
-        {
-            if (IsDlcvDeveloper(root))
-            {
-                return { root };
-            }
-            return {};
-        }
-        if (!root.is_array())
-        {
-            return {};
-        }
-
         std::vector<nlohmann::json> result;
-        for (const auto& item : root)
-        {
-            if (item.is_object() && IsDlcvDeveloper(item))
+        std::set<std::string> seen;
+        auto append = [&](const nlohmann::json& root) {
+            auto append_one = [&](const nlohmann::json& item) {
+                if (item.is_object() && IsDlcvDeveloper(item))
+                {
+                    std::string key = item.dump();
+                    if (seen.insert(key).second)
+                    {
+                        result.push_back(item);
+                    }
+                }
+            };
+            if (root.is_object())
             {
-                result.push_back(item);
+                append_one(root);
+            }
+            else if (root.is_array())
+            {
+                for (const auto& item : root)
+                {
+                    append_one(item);
+                }
+            }
+        };
+
+        if (api.get_all_description)
+        {
+            char* desc = nullptr;
+            if (api.get_all_description(ipc, VIRBOX_JSON, &desc) == VIRBOX_OK)
+            {
+                append(ParseJsonSafe(ReadAndFree(api, desc)));
+            }
+        }
+        if (api.get_offline_local_description)
+        {
+            char* desc = nullptr;
+            if (api.get_offline_local_description(ipc, &desc) == VIRBOX_OK)
+            {
+                append(ParseJsonSafe(ReadAndFree(api, desc)));
             }
         }
         return result;
@@ -308,6 +328,15 @@ nlohmann::json sntl_admin::Virbox::GetDeviceList() {
         {
             try
             {
+                if (desc.value("type", std::string{}) == "slock")
+                {
+                    AddUnique(devices, FirstStringByKeys(desc, { "user_guid" }));
+                    continue;
+                }
+                if (!api.get_device_info)
+                {
+                    continue;
+                }
                 char* info = nullptr;
                 int status = api.get_device_info(ipc, desc.dump().c_str(), &info);
                 if (status == VIRBOX_OK)


### PR DESCRIPTION
## 变更
- 合并 Virbox 实体设备描述与离线本地软锁描述
- 授权码软锁使用唯一锁号作为设备 ID，并通过 Control API 读取 license ID
- C# 与 C++ 查询实现保持一致并更新开发文档

## 验证
- DlcvDemo Debug/x64 构建通过
- dlcv_infer_cpp_dll Debug/x64 构建通过
- 本机聚合查询同时识别 Sentinel 实体狗与 Virbox 本地软锁，Virbox license ID 为 0、2、3、10120