### PR TITLE
fix: Virbox 软锁显示账号标识

### DIFF
--- a/DlcvCsharpApi/Properties/AssemblyInfo.cs
+++ b/DlcvCsharpApi/Properties/AssemblyInfo.cs
@@ -29,6 +29,6 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.7.19.1")]
-[assembly: AssemblyFileVersion("2026.7.19.1")]
-[assembly: AssemblyInformationalVersion("2026.7.19.1a0")]
+[assembly: AssemblyVersion("2026.7.25.0")]
+[assembly: AssemblyFileVersion("2026.7.25.0")]
+[assembly: AssemblyInformationalVersion("2026.7.25.0a0")]

--- a/DlcvCsharpApi/sntl_admin_csharp.cs
+++ b/DlcvCsharpApi/sntl_admin_csharp.cs
@@ -464,7 +464,7 @@ namespace sntl_admin_csharp
                     {
                         if (string.Equals(desc["type"]?.ToString(), "slock", StringComparison.OrdinalIgnoreCase))
                         {
-                            AddUnique(result, FirstStringByKeys(desc, new[] { "user_guid" }));
+                            AddUnique(result, FirstStringByKeys(desc, new[] { "account_name", "user_guid" }));
                             continue;
                         }
                         if (getDeviceInfo == null)

--- a/DlcvDemo/Properties/AssemblyInfo.cs
+++ b/DlcvDemo/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.7.19.1")]
-[assembly: AssemblyFileVersion("2026.7.19.1")]
-[assembly: AssemblyInformationalVersion("2026.7.19.1a0")]
+[assembly: AssemblyVersion("2026.7.25.0")]
+[assembly: AssemblyFileVersion("2026.7.25.0")]
+[assembly: AssemblyInformationalVersion("2026.7.25.0a0")]
 [assembly: NeutralResourcesLanguage("zh-CN")]

--- a/dlcv_infer_cpp_dll/dlcv_sntl_admin.cpp
+++ b/dlcv_infer_cpp_dll/dlcv_sntl_admin.cpp
@@ -330,7 +330,7 @@ nlohmann::json sntl_admin::Virbox::GetDeviceList() {
             {
                 if (desc.value("type", std::string{}) == "slock")
                 {
-                    AddUnique(devices, FirstStringByKeys(desc, { "user_guid" }));
+                    AddUnique(devices, FirstStringByKeys(desc, { "account_name", "user_guid" }));
                     continue;
                 }
                 if (!api.get_device_info)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import shutil
 
 from setuptools import setup
 
-version = '2026.7.19.1a0'
+version = '2026.7.25.0a0'
 
 package_name = "dlcvpro_infer_csharp"  # 包名
 packages: list = [package_name]  # 需要打包的包


### PR DESCRIPTION
## 变更说明

- Virbox 软锁设备显示优先使用 `account_name`，当前授权码软锁显示为 `SC3050000000003`
- 当软锁没有 `account_name` 时回退到已确认的 `user_guid`，避免设备列表为空
- C# 与 C++ 实现保持一致
- 测试版版本更新为 `2026.7.25.0a0`

## 验证结果

- C# Debug/x64 构建成功
- C++ Debug/x64 构建成功
- `build_package.py --install` Release 构建、签名、wheel 打包及安装成功
- 安装后的 `DlcvCsharpApi.dll` 实测 Virbox devices 返回 `SC3050000000003`
- Virbox 许可列表实测为 `0、2、3、10120`

## 安装包

`dist/dlcvpro_infer_csharp-2026.7.25.0a0-cp311-none-win_amd64.whl`