### PR TITLE
功能: DlcvDemo 支持 OpenVINO 设备

### DIFF
--- a/DlcvCsharpApi/Properties/AssemblyInfo.cs
+++ b/DlcvCsharpApi/Properties/AssemblyInfo.cs
@@ -29,6 +29,6 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.7.25.0")]
-[assembly: AssemblyFileVersion("2026.7.25.0")]
-[assembly: AssemblyInformationalVersion("2026.7.25.0a0")]
+[assembly: AssemblyVersion("2026.7.29.0")]
+[assembly: AssemblyFileVersion("2026.7.29.0")]
+[assembly: AssemblyInformationalVersion("2026.7.29.0a0")]

--- a/DlcvDemo/CliRunner.cs
+++ b/DlcvDemo/CliRunner.cs
@@ -361,9 +361,9 @@ namespace DlcvDemo
                         break;
                     case "--device":
                         if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int deviceId)
-                            || deviceId < -1)
+                            || deviceId < -2)
                         {
-                            error = "--device 必须是 -1 或非负整数。";
+                            error = "--device 必须是 -2（OpenVINO）、-1（CPU）或非负整数（GPU 编号）。";
                             return false;
                         }
                         options.DeviceId = deviceId;

--- a/DlcvDemo/DlcvDemo.csproj
+++ b/DlcvDemo/DlcvDemo.csproj
@@ -8,11 +8,12 @@
     <ProjectGuid>{948F3CAC-2D10-4B59-947C-8D00C7B9198A}</ProjectGuid>
     <OutputType>WinExe</OutputType>
     <RootNamespace>demo</RootNamespace>
-    <AssemblyName>C# 测试程序</AssemblyName>
+    <AssemblyName>DlcvDemo</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <IsWebBootstrapper>false</IsWebBootstrapper>
@@ -132,21 +133,30 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Windows.Forms" />
+    <Reference Include="WindowsFormsIntegration" />
+    <Reference Include="System.Xaml">
+      <RequiredTargetFramework>4.0</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="WindowsBase" />
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Page Include="MainWindow.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="CliRunner.cs" />
-    <Compile Include="Form1.cs">
-      <SubType>Form</SubType>
+    <Compile Include="MainWindow.xaml.cs">
+      <DependentUpon>MainWindow.xaml</DependentUpon>
+      <SubType>Code</SubType>
     </Compile>
-    <Compile Include="Form1.Designer.cs">
-      <DependentUpon>Form1.cs</DependentUpon>
-    </Compile>
+    <Compile Include="NumericBox.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <EmbeddedResource Include="Form1.resx">
-      <DependentUpon>Form1.cs</DependentUpon>
-    </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
@@ -233,6 +243,11 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="RenameOutputArtifacts" AfterTargets="Build">
+    <Move SourceFiles="$(TargetPath)" DestinationFiles="$(TargetDir)C# 测试程序.exe" />
+    <Move SourceFiles="$(TargetPath).config" DestinationFiles="$(TargetDir)C# 测试程序.exe.config" Condition="Exists('$(TargetPath).config')" />
+    <Move SourceFiles="$(TargetDir)$(TargetName).pdb" DestinationFiles="$(TargetDir)C# 测试程序.pdb" Condition="Exists('$(TargetDir)$(TargetName).pdb')" />
+  </Target>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>这台计算机上缺少此项目引用的 NuGet 程序包。使用"NuGet 程序包还原"可下载这些程序包。有关更多信息，请参见 http://go.microsoft.com/fwlink/?LinkID=322105。缺少的文件是 {0}。</ErrorText>

--- a/DlcvDemo/Form1.cs
+++ b/DlcvDemo/Form1.cs
@@ -68,9 +68,11 @@ namespace DlcvDemo
                 comboBox1.Items.Clear();
                 deviceNameToIdMap.Clear();
 
-                // 始终先添加CPU选项
+                // 始终先添加CPU和OpenVINO选项
                 comboBox1.Items.Add("CPU");
                 deviceNameToIdMap["CPU"] = -1; // CPU对应device_id = -1
+                comboBox1.Items.Add("OpenVINO");
+                deviceNameToIdMap["OpenVINO"] = -2; // OpenVINO对应device_id = -2
 
                 // 添加GPU设备
                 bool hasGpu = false;
@@ -95,7 +97,7 @@ namespace DlcvDemo
                 // 默认选择第一个显卡，如果没有显卡则选择CPU
                 if (hasGpu)
                 {
-                    comboBox1.SelectedIndex = 1; // 选择第一个GPU
+                    comboBox1.SelectedIndex = 2; // 选择第一个GPU
                 }
                 else
                 {

--- a/DlcvDemo/MainWindow.xaml
+++ b/DlcvDemo/MainWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:viewer="clr-namespace:DLCV;assembly=ImageViewer"
         Title="C# 测试程序"
         Width="1280" Height="820"
-        MinWidth="860" MinHeight="500"
+        MinWidth="1040" MinHeight="500"
         WindowStartupLocation="CenterScreen"
         Background="#F3F5F7"
         FontFamily="Microsoft YaHei UI"
@@ -131,21 +131,21 @@
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="96"/>
+                        <ColumnDefinition Width="116"/>
                         <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="96"/>
+                        <ColumnDefinition Width="116"/>
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
                     <TextBlock Grid.Row="0" Grid.Column="0" Text="选择显卡" Margin="0,0,8,0"/>
                     <ComboBox x:Name="comboBox1" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="4" MinWidth="260" Margin="0,3,0,3"/>
 
                     <TextBlock Grid.Row="1" Grid.Column="0" Text="batch_size" Margin="0,0,8,0"/>
-                    <local:NumericBox x:Name="numericUpDown_batch_size" Grid.Row="1" Grid.Column="1" Width="90" HorizontalAlignment="Left" Minimum="1" Maximum="1024" Value="1" Margin="0,3"/>
+                    <local:NumericBox x:Name="numericUpDown_batch_size" Grid.Row="1" Grid.Column="1" Width="110" HorizontalAlignment="Left" Minimum="1" Maximum="1024" Value="1" Margin="0,3"/>
                     <TextBlock Grid.Row="1" Grid.Column="2" Text="threshold" Margin="12,0,8,0"/>
-                    <local:NumericBox x:Name="numericUpDown_threshold" Grid.Row="1" Grid.Column="3" Width="90" HorizontalAlignment="Left" Minimum="0" Maximum="1" Increment="0.05" DecimalPlaces="2" Value="0.5" Margin="0,3" ValueChanged="numericUpDown_threshold_ValueChanged"/>
+                    <local:NumericBox x:Name="numericUpDown_threshold" Grid.Row="1" Grid.Column="3" Width="110" HorizontalAlignment="Left" Minimum="0" Maximum="1" Increment="0.05" DecimalPlaces="2" Value="0.5" Margin="0,3" ValueChanged="numericUpDown_threshold_ValueChanged"/>
 
                     <TextBlock Grid.Row="2" Grid.Column="0" Text="线程数" Margin="0,0,8,0"/>
-                    <local:NumericBox x:Name="numericUpDown_num_thread" Grid.Row="2" Grid.Column="1" Width="90" HorizontalAlignment="Left" Minimum="1" Maximum="32" Value="1" Margin="0,3"/>
+                    <local:NumericBox x:Name="numericUpDown_num_thread" Grid.Row="2" Grid.Column="1" Width="110" HorizontalAlignment="Left" Minimum="1" Maximum="32" Value="1" Margin="0,3"/>
                 </Grid>
 
                 <!-- 右侧操作区：保持原界面的打开、保存/释放、信息三行布局 -->
@@ -161,7 +161,7 @@
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
                     <CheckBox x:Name="checkBox_rpc_mode" Grid.Row="0" Grid.Column="0" Content="RPC 模式" VerticalAlignment="Center" HorizontalAlignment="Center"/>
-                    <Button x:Name="button_open_image" Grid.Row="0" Grid.Column="2" Content="打开图片推理" Style="{StaticResource PrimaryButtonStyle}" Click="button_openimage_Click"/>
+                    <Button x:Name="button_open_image" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2" HorizontalAlignment="Stretch" Content="打开图片推理" Style="{StaticResource PrimaryButtonStyle}" Click="button_openimage_Click"/>
                     <Button x:Name="button_save_img" Grid.Row="1" Grid.Column="0" Content="保存图像" Style="{StaticResource ActionButtonStyle}" Click="button_save_img_Click"/>
                     <Button x:Name="button_free_model" Grid.Row="1" Grid.Column="1" Content="释放模型" Style="{StaticResource DangerButtonStyle}" Click="button_freemodel_Click"/>
                     <Button x:Name="button_free_all_model" Grid.Row="1" Grid.Column="2" Content="释放所有模型" Style="{StaticResource DangerButtonStyle}" Click="button_free_all_model_Click"/>

--- a/DlcvDemo/MainWindow.xaml
+++ b/DlcvDemo/MainWindow.xaml
@@ -1,0 +1,208 @@
+<Window x:Class="DlcvDemo.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:DlcvDemo"
+        xmlns:wfi="clr-namespace:System.Windows.Forms.Integration;assembly=WindowsFormsIntegration"
+        xmlns:viewer="clr-namespace:DLCV;assembly=ImageViewer"
+        Title="C# 测试程序"
+        Width="1280" Height="820"
+        MinWidth="860" MinHeight="500"
+        WindowStartupLocation="CenterScreen"
+        Background="#F3F5F7"
+        FontFamily="Microsoft YaHei UI"
+        FontSize="13"
+        UseLayoutRounding="True"
+        SnapsToDevicePixels="True"
+        Loaded="Form1_Load"
+        Closing="Form1_FormClosing">
+    <Window.Resources>
+        <Style x:Key="CardStyle" TargetType="Border">
+            <Setter Property="Background" Value="White"/>
+            <Setter Property="CornerRadius" Value="8"/>
+            <Setter Property="Padding" Value="12"/>
+            <Setter Property="Margin" Value="6"/>
+        </Style>
+        <Style x:Key="ActionButtonStyle" TargetType="Button">
+            <Setter Property="MinWidth" Value="104"/>
+            <Setter Property="Height" Value="38"/>
+            <Setter Property="Margin" Value="4"/>
+            <Setter Property="Padding" Value="12,0"/>
+            <Setter Property="Background" Value="#E7EBEF"/>
+            <Setter Property="Foreground" Value="#263238"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="Chrome" Background="{TemplateBinding Background}" CornerRadius="5">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True"><Setter TargetName="Chrome" Property="Background" Value="#D8DEE4"/></Trigger>
+                            <Trigger Property="IsPressed" Value="True"><Setter TargetName="Chrome" Property="Background" Value="#C7CFD7"/></Trigger>
+                            <Trigger Property="IsEnabled" Value="False"><Setter TargetName="Chrome" Property="Opacity" Value="0.45"/></Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+        <Style x:Key="PrimaryButtonStyle" TargetType="Button" BasedOn="{StaticResource ActionButtonStyle}">
+            <Setter Property="Background" Value="#1976D2"/>
+            <Setter Property="Foreground" Value="White"/>
+        </Style>
+        <Style x:Key="DangerButtonStyle" TargetType="Button" BasedOn="{StaticResource ActionButtonStyle}">
+            <Setter Property="Background" Value="#EF5350"/>
+            <Setter Property="Foreground" Value="White"/>
+        </Style>
+        <Style TargetType="ComboBox">
+            <Setter Property="Height" Value="34"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+            <Setter Property="Padding" Value="8,0"/>
+        </Style>
+        <Style TargetType="local:NumericBox">
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="local:NumericBox">
+                        <Border Background="White" BorderBrush="#C9D1D9" BorderThickness="1" CornerRadius="4">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="24"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBox x:Name="PART_TextBox" Grid.Column="0" BorderThickness="0" Background="Transparent"
+                                         HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Padding="4,0"/>
+                                <Grid Grid.Column="1">
+                                    <Grid.RowDefinitions><RowDefinition/><RowDefinition/></Grid.RowDefinitions>
+                                    <local:NumericBoxButton Grid.Row="0" Direction="1" Content="▲" FontSize="7" Padding="0" BorderThickness="0" Background="#EEF1F4"/>
+                                    <local:NumericBoxButton Grid.Row="1" Direction="-1" Content="▼" FontSize="7" Padding="0" BorderThickness="0" Background="#EEF1F4"/>
+                                </Grid>
+                            </Grid>
+                        </Border>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+        <Style TargetType="TextBlock">
+            <Setter Property="VerticalAlignment" Value="Center"/>
+            <Setter Property="Foreground" Value="#37474F"/>
+        </Style>
+    </Window.Resources>
+
+    <Grid Margin="8">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <Border Grid.Row="0" Style="{StaticResource CardStyle}" Padding="10">
+            <Grid VerticalAlignment="Top">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="16"/>
+                    <ColumnDefinition Width="*" MinWidth="360"/>
+                    <ColumnDefinition Width="16"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                <!-- 左侧操作区：保持原界面的三行两列相对位置 -->
+                <Grid Grid.Column="0" VerticalAlignment="Top">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <Button x:Name="button_load_model" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" HorizontalAlignment="Stretch" Content="加载模型" Style="{StaticResource PrimaryButtonStyle}" Click="button_loadmodel_Click"/>
+                    <Button x:Name="button_infer" Grid.Row="1" Grid.Column="0" Content="单次推理" Style="{StaticResource PrimaryButtonStyle}" Click="button_infer_Click"/>
+                    <Button x:Name="button_infer_json" Grid.Row="1" Grid.Column="1" Content="推理 JSON" Style="{StaticResource ActionButtonStyle}" Click="button_infer_json_Click"/>
+                    <Button x:Name="button_thread_test" Grid.Row="2" Grid.Column="0" Content="多线程测试" Style="{StaticResource ActionButtonStyle}" Click="button_threadtest_Click"/>
+                    <Button x:Name="button_consistency_test" Grid.Row="2" Grid.Column="1" Content="一致性测试" Style="{StaticResource ActionButtonStyle}" Click="button_consistency_test_Click"/>
+                </Grid>
+
+                <!-- 中间参数区：三行内容从顶部开始排列 -->
+                <Grid Grid.Column="2" VerticalAlignment="Top" Margin="0,4,0,0">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="46"/>
+                        <RowDefinition Height="46"/>
+                        <RowDefinition Height="46"/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="96"/>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="96"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Grid.Row="0" Grid.Column="0" Text="选择显卡" Margin="0,0,8,0"/>
+                    <ComboBox x:Name="comboBox1" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="4" MinWidth="260" Margin="0,3,0,3"/>
+
+                    <TextBlock Grid.Row="1" Grid.Column="0" Text="batch_size" Margin="0,0,8,0"/>
+                    <local:NumericBox x:Name="numericUpDown_batch_size" Grid.Row="1" Grid.Column="1" Width="90" HorizontalAlignment="Left" Minimum="1" Maximum="1024" Value="1" Margin="0,3"/>
+                    <TextBlock Grid.Row="1" Grid.Column="2" Text="threshold" Margin="12,0,8,0"/>
+                    <local:NumericBox x:Name="numericUpDown_threshold" Grid.Row="1" Grid.Column="3" Width="90" HorizontalAlignment="Left" Minimum="0" Maximum="1" Increment="0.05" DecimalPlaces="2" Value="0.5" Margin="0,3" ValueChanged="numericUpDown_threshold_ValueChanged"/>
+
+                    <TextBlock Grid.Row="2" Grid.Column="0" Text="线程数" Margin="0,0,8,0"/>
+                    <local:NumericBox x:Name="numericUpDown_num_thread" Grid.Row="2" Grid.Column="1" Width="90" HorizontalAlignment="Left" Minimum="1" Maximum="32" Value="1" Margin="0,3"/>
+                </Grid>
+
+                <!-- 右侧操作区：保持原界面的打开、保存/释放、信息三行布局 -->
+                <Grid Grid.Column="4" VerticalAlignment="Top">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <CheckBox x:Name="checkBox_rpc_mode" Grid.Row="0" Grid.Column="0" Content="RPC 模式" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                    <Button x:Name="button_open_image" Grid.Row="0" Grid.Column="2" Content="打开图片推理" Style="{StaticResource PrimaryButtonStyle}" Click="button_openimage_Click"/>
+                    <Button x:Name="button_save_img" Grid.Row="1" Grid.Column="0" Content="保存图像" Style="{StaticResource ActionButtonStyle}" Click="button_save_img_Click"/>
+                    <Button x:Name="button_free_model" Grid.Row="1" Grid.Column="1" Content="释放模型" Style="{StaticResource DangerButtonStyle}" Click="button_freemodel_Click"/>
+                    <Button x:Name="button_free_all_model" Grid.Row="1" Grid.Column="2" Content="释放所有模型" Style="{StaticResource DangerButtonStyle}" Click="button_free_all_model_Click"/>
+                    <Button x:Name="button_check_dog" Grid.Row="2" Grid.Column="0" Content="检查加密狗" Style="{StaticResource ActionButtonStyle}" Click="button1_Click"/>
+                    <Button x:Name="button_github" Grid.Row="2" Grid.Column="1" Content="文档" Style="{StaticResource ActionButtonStyle}" Click="button_github_Click"/>
+                    <Button x:Name="button_get_model_info" Grid.Row="2" Grid.Column="2" Content="获取模型信息" Style="{StaticResource ActionButtonStyle}" Click="button_getmodelinfo_Click"/>
+                </Grid>
+            </Grid>
+        </Border>
+
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="360" MinWidth="240"/>
+                <ColumnDefinition Width="6"/>
+                <ColumnDefinition Width="*" MinWidth="360"/>
+            </Grid.ColumnDefinitions>
+
+            <Border Grid.Column="0" Style="{StaticResource CardStyle}">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+                    <TextBlock Text="运行结果" FontSize="15" FontWeight="SemiBold" Margin="2,0,0,8"/>
+                    <TextBox x:Name="richTextBox1" Grid.Row="1" IsReadOnly="True" TextWrapping="NoWrap"
+                             AcceptsReturn="True" FontFamily="Consolas, Microsoft YaHei UI" FontSize="12"
+                             BorderThickness="0" Background="#FAFBFC"
+                             VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto"/>
+                </Grid>
+            </Border>
+
+            <GridSplitter Grid.Column="1" Width="6" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                          ResizeDirection="Columns" ResizeBehavior="PreviousAndNext" Background="Transparent"/>
+
+            <Border Grid.Column="2" Style="{StaticResource CardStyle}" Padding="6">
+                <Grid Background="#202428" SnapsToDevicePixels="True" UseLayoutRounding="True">
+                    <wfi:WindowsFormsHost x:Name="imageHost">
+                        <viewer:ImageViewer x:Name="imagePanel1" ShowStatusText="False" ShowVisualization="True" MinScale="0.5" MaxScale="100"/>
+                    </wfi:WindowsFormsHost>
+                </Grid>
+            </Border>
+        </Grid>
+    </Grid>
+</Window>

--- a/DlcvDemo/MainWindow.xaml
+++ b/DlcvDemo/MainWindow.xaml
@@ -174,7 +174,7 @@
 
         <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="360" MinWidth="240"/>
+                <ColumnDefinition Width="380" MinWidth="240"/>
                 <ColumnDefinition Width="6"/>
                 <ColumnDefinition Width="*" MinWidth="360"/>
             </Grid.ColumnDefinitions>

--- a/DlcvDemo/MainWindow.xaml.cs
+++ b/DlcvDemo/MainWindow.xaml.cs
@@ -1,0 +1,997 @@
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Windows;
+using System.Windows.Threading;
+using Microsoft.Win32;
+using Newtonsoft.Json.Linq;
+using OpenCvSharp;
+using dlcv_infer_csharp;
+using System.IO;
+using System.Diagnostics;
+using System.Collections.Generic;
+using static dlcv_infer_csharp.Utils;
+using DLCV;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace DlcvDemo
+{
+    public partial class MainWindow : System.Windows.Window
+    {
+        // 设备映射表：设备名称 -> 设备ID
+        private Dictionary<string, int> deviceNameToIdMap = new Dictionary<string, int>();
+
+        /// <summary>
+        /// 获取当前选中的设备ID
+        /// </summary>
+        /// <returns>设备ID，如果没有选中则返回-1</returns>
+        private int GetSelectedDeviceId()
+        {
+            if (comboBox1.SelectedItem == null)
+            {
+                return -1; // 默认使用CPU
+            }
+
+            string selectedDeviceName = comboBox1.SelectedItem.ToString();
+            if (deviceNameToIdMap.ContainsKey(selectedDeviceName))
+            {
+                return deviceNameToIdMap[selectedDeviceName];
+            }
+
+            return -1; // 默认使用CPU
+        }
+
+        public MainWindow()
+        {
+            InitializeComponent();
+        }
+
+        private void Form1_Load(object sender, RoutedEventArgs e)
+        {
+            Topmost = false;
+            MaxWidth = SystemParameters.WorkArea.Width;
+            MaxHeight = SystemParameters.WorkArea.Height;
+            this.Title = "C# 测试程序 v" + System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString();
+            Thread thread = new Thread(GetDeviceInfo);
+            thread.IsBackground = true;
+            thread.Start();
+        }
+
+        private void GetDeviceInfo()
+        {
+            Thread.Sleep(1);
+            JObject device_info = Utils.GetGpuInfo();
+
+            // 启动时先做一次加密狗检测：都没有则只展示结果、不加载推理 DLL
+            JObject allDogInfo = QueryAllDogInfo();
+            bool hasDog = HasAnyDog(allDogInfo);
+
+            Dispatcher.Invoke(delegate
+            {
+                // 清空现有项目和映射表
+                comboBox1.Items.Clear();
+                deviceNameToIdMap.Clear();
+
+                // 按设备ID从小到大排列：OpenVINO(-2)、CPU(-1)、GPU(0...)
+                comboBox1.Items.Add("OpenVINO");
+                deviceNameToIdMap["OpenVINO"] = -2;
+                comboBox1.Items.Add("CPU");
+                deviceNameToIdMap["CPU"] = -1;
+
+                // 添加GPU设备
+                bool hasGpu = false;
+                if (device_info.GetValue("code").ToString() == "0")
+                {
+                    int gpuIndex = 0;
+                    foreach (var item in device_info.GetValue("devices"))
+                    {
+                        string deviceName = item["device_name"].ToString();
+                        comboBox1.Items.Add(deviceName);
+                        deviceNameToIdMap[deviceName] = gpuIndex; // GPU设备名称对应device_id = 0, 1, 2...
+                        gpuIndex++;
+                        hasGpu = true;
+                    }
+                }
+                else
+                {
+                    // 如果获取GPU信息失败，在richTextBox1中显示错误信息
+                    richTextBox1.Text = "GPU信息获取失败：\n" + device_info.ToString();
+                }
+
+                // 默认选择第一个显卡，如果没有显卡则选择CPU
+                if (hasGpu)
+                {
+                    comboBox1.SelectedIndex = 2; // 选择第一个GPU
+                }
+                else
+                {
+                    comboBox1.SelectedIndex = 1; // 选择CPU
+                }
+
+                // 仅在检测不到加密狗时，把检测结果显示到界面提醒用户
+                if (!hasDog)
+                {
+                    richTextBox1.Text = FormatDogInfoText(allDogInfo, prependNoDogHint: true);
+                }
+            });
+
+            if (!hasDog)
+            {
+                return;
+            }
+
+            // 检测到加密狗后再加载对应推理 DLL，并保持最高时钟
+            try
+            {
+                var info = Utils.GetDeviceInfo();
+                Console.WriteLine(info.ToString());
+                DllLoader.Instance.dlcv_keep_max_clock?.Invoke();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("GetDeviceInfo/keep_max_clock failed: " + ex.Message);
+            }
+        }
+
+        private static JObject QueryAllDogInfo()
+        {
+            try
+            {
+                return sntl_admin_csharp.DogUtils.GetAllDogInfo();
+            }
+            catch
+            {
+                return new JObject
+                {
+                    ["sentinel"] = new JObject { ["devices"] = new JArray(), ["features"] = new JArray() },
+                    ["virbox"] = new JObject { ["devices"] = new JArray(), ["features"] = new JArray() }
+                };
+            }
+        }
+
+        private static bool HasAnyDog(JObject allInfo)
+        {
+            JObject sentinel = allInfo["sentinel"] as JObject ?? new JObject();
+            JObject virbox = allInfo["virbox"] as JObject ?? new JObject();
+            JArray sentinelDevices = sentinel["devices"] as JArray ?? new JArray();
+            JArray sentinelFeatures = sentinel["features"] as JArray ?? new JArray();
+            JArray virboxDevices = virbox["devices"] as JArray ?? new JArray();
+            JArray virboxFeatures = virbox["features"] as JArray ?? new JArray();
+            return sentinelDevices.Count > 0 || sentinelFeatures.Count > 0
+                || virboxDevices.Count > 0 || virboxFeatures.Count > 0;
+        }
+
+        private static string FormatDogInfoText(JObject allInfo, bool prependNoDogHint)
+        {
+            JObject sentinel = allInfo["sentinel"] as JObject ?? new JObject { ["devices"] = new JArray(), ["features"] = new JArray() };
+            JObject virbox = allInfo["virbox"] as JObject ?? new JObject { ["devices"] = new JArray(), ["features"] = new JArray() };
+            JArray sentinelDevices = sentinel["devices"] as JArray ?? new JArray();
+            JArray sentinelFeatures = sentinel["features"] as JArray ?? new JArray();
+            JArray virboxDevices = virbox["devices"] as JArray ?? new JArray();
+            JArray virboxFeatures = virbox["features"] as JArray ?? new JArray();
+
+            string text =
+                "Sentinel加密狗ID：\n" + sentinelDevices.ToString() + "\n\n" +
+                "Sentinel加密狗特性：\n" + sentinelFeatures.ToString() + "\n\n" +
+                "Virbox加密狗ID：\n" + virboxDevices.ToString() + "\n\n" +
+                "Virbox加密狗特性：\n" + virboxFeatures.ToString();
+
+            if (prependNoDogHint)
+            {
+                text = "未检测到加密狗\n\n" + text;
+            }
+            return text;
+        }
+
+        /// <summary>
+        /// 「检查加密狗」按钮：查询并显示 Sentinel/Virbox 信息。
+        /// </summary>
+        private void ShowDogInfo()
+        {
+            JObject allInfo = QueryAllDogInfo();
+            bool noDog = !HasAnyDog(allInfo);
+            richTextBox1.Text = FormatDogInfoText(allInfo, prependNoDogHint: noDog);
+        }
+
+        private dynamic model;
+        private string image_path;
+        private int batch_size = 1;
+        private PressureTestRunner pressureTestRunner;
+        private DispatcherTimer updateTimer;
+        private dynamic baselineJsonResult = null;
+        private volatile bool shouldStopPressureTest = false;
+        private bool isConsistencyTestMode = false; // 控制是否进行一致性测试
+        private bool isCurrentFlowModel = false; // 当前是否为流程模型(dvst/dvso/dvsp)
+
+        private void DisposeCurrentModel()
+        {
+            try
+            {
+                var disposable = model as IDisposable;
+                disposable?.Dispose();
+            }
+            catch (Exception ex)
+            {
+                // 不要因为释放失败影响后续加载
+                Console.WriteLine("Dispose model failed: " + ex.Message);
+            }
+            finally
+            {
+                model = null;
+            }
+        }
+        
+        private void button_loadmodel_Click(object sender, EventArgs e)
+        {
+            OpenFileDialog openFileDialog = new OpenFileDialog();
+            openFileDialog.RestoreDirectory = true;
+
+            openFileDialog.Filter = "AI模型 (*.dvt;*.dvp;*.dvo;*.dvst;*.dvso;*.dvsp)|*.dvt;*.dvp;*.dvo;*.dvst;*.dvso;*.dvsp|所有文件 (*.*)|*.*";
+            openFileDialog.Title = "选择模型";
+            try
+            {
+                openFileDialog.InitialDirectory = Path.GetDirectoryName(Properties.Settings.Default.LastModelPath);
+                openFileDialog.FileName = Path.GetFileName(Properties.Settings.Default.LastModelPath);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+            }
+
+            if (openFileDialog.ShowDialog(this) == true)
+            {
+                string selectedFilePath = openFileDialog.FileName;
+                Properties.Settings.Default.LastModelPath = selectedFilePath;
+                Properties.Settings.Default.Save();
+                string ext = Path.GetExtension(selectedFilePath) ?? "";
+                isCurrentFlowModel =
+                    ext.Equals(".dvst", StringComparison.OrdinalIgnoreCase) ||
+                    ext.Equals(".dvso", StringComparison.OrdinalIgnoreCase) ||
+                    ext.Equals(".dvsp", StringComparison.OrdinalIgnoreCase);
+                int device_id = GetSelectedDeviceId();
+                try
+                {
+                    if (model != null)
+                    {
+                        DisposeCurrentModel();
+                    }
+                    bool rpc_mode = false;
+                    try
+                    {
+                        rpc_mode = this.checkBox_rpc_mode != null && this.checkBox_rpc_mode.IsChecked == true;
+                    }
+                    catch { }
+
+                    model = new Model(selectedFilePath, device_id, rpc_mode);
+
+                    button_getmodelinfo_Click(sender, e);
+                }
+                catch (Exception ex)
+                {
+                    richTextBox1.Text = ex.Message;
+                }
+            }
+        }
+
+		private void button_infer_json_Click(object sender, EventArgs e)
+		{
+			try
+			{
+				if (model == null)
+				{
+					MessageBox.Show("请先加载模型文件！");
+					return;
+				}
+				if (image_path == null)
+				{
+					MessageBox.Show("请先选择图片文件！");
+					return;
+				}
+
+				Mat image = Cv2.ImRead(image_path, ImreadModes.Unchanged);
+				if (image.Empty())
+				{
+					Console.WriteLine("图像解码失败！");
+					return;
+				}
+				JObject data = new JObject();
+				data["threshold"] = (float)numericUpDown_threshold.Value;
+				data["with_mask"] = true;
+
+				Mat inferImage = PrepareImageForModelInput(image);
+				try
+				{
+					var json = model.InferOneOutJson(inferImage, data);
+					richTextBox1.Text = JsonConvert.SerializeObject(json, Formatting.Indented);
+				}
+				finally
+				{
+					if (!object.ReferenceEquals(inferImage, image))
+					{
+						inferImage.Dispose();
+					}
+				}
+			}
+			catch (Exception ex)
+			{
+				ReportError("推理JSON失败", ex);
+			}
+		}
+
+        private void button_getmodelinfo_Click(object sender, EventArgs e)
+        {
+            if (model == null)
+            {
+                MessageBox.Show("请先加载模型文件！");
+                return;
+            }
+            JObject result = model.GetModelInfo();
+            if (result.ContainsKey("model_info"))
+            {
+                richTextBox1.Text = result["model_info"].ToString();
+            }
+            else
+            {
+                // 未知格式，直接显示原始 JSON
+                richTextBox1.Text = result.ToString();
+            }
+        }
+
+        private void button_openimage_Click(object sender, EventArgs e)
+        {
+            if (model == null)
+            {
+                MessageBox.Show("请先加载模型文件！");
+                return;
+            }
+            OpenFileDialog openFileDialog = new OpenFileDialog();
+
+            openFileDialog.Filter = "图片文件 (*.jpg;*.jpeg;*.png;*.bmp;*.gif;*.tiff;*.tif)|*.jpg;*.jpeg;*.png;*.bmp;*.gif;*.tiff;*.tif|所有文件 (*.*)|*.*";
+            openFileDialog.Title = "选择图片文件";
+
+            try
+            {
+                openFileDialog.InitialDirectory = Path.GetDirectoryName(Properties.Settings.Default.LastImagePath);
+                openFileDialog.FileName = Path.GetFileName(Properties.Settings.Default.LastImagePath);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+            }
+            if (openFileDialog.ShowDialog(this) == true)
+            {
+                image_path = openFileDialog.FileName;
+                Properties.Settings.Default.LastImagePath = image_path;
+                Properties.Settings.Default.Save();
+                button_infer_Click(sender, e);
+            }
+        }
+
+        private void numericUpDown_threshold_ValueChanged(object sender, EventArgs e)
+        {
+            if (model == null || string.IsNullOrEmpty(image_path) || !File.Exists(image_path))
+            {
+                return;
+            }
+            if (pressureTestRunner != null && pressureTestRunner.IsRunning)
+            {
+                return;
+            }
+
+            button_infer_Click(sender, e);
+        }
+
+        private void button_infer_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                if (model == null)
+                {
+                    MessageBox.Show("请先加载模型文件！");
+                    return;
+                }
+                if (image_path == null)
+                {
+                    MessageBox.Show("请先选择图片文件！");
+                    return;
+                }
+
+                Mat image = Cv2.ImRead(image_path, ImreadModes.Unchanged);
+                if (image.Empty())
+                {
+                    throw new Exception("图像解码失败！");
+                }
+                batch_size = (int)numericUpDown_batch_size.Value;
+                JObject data = new JObject();
+                data["threshold"] = (float)numericUpDown_threshold.Value;
+                data["with_mask"] = true;
+
+                Stopwatch stopwatch = new Stopwatch();
+                stopwatch.Start();
+
+				Mat inferImage = PrepareImageForModelInput(image);
+				CSharpResult result;
+				try
+				{
+					var inferImageList = new List<Mat>();
+					for (int i = 0; i < batch_size; i++)
+					{
+						inferImageList.Add(inferImage);
+					}
+					result = model.InferBatch(inferImageList, data);
+				}
+				finally
+				{
+					if (!object.ReferenceEquals(inferImage, image))
+					{
+						inferImage.Dispose();
+					}
+				}
+
+                stopwatch.Stop();
+                double delay_ms = stopwatch.ElapsedTicks * 1000.0 / Stopwatch.Frequency;
+                Console.WriteLine($"推理时间: {delay_ms:F2}ms");
+
+                imagePanel1.UpdateImageAndResult(image, result);
+
+                StringBuilder sb = new StringBuilder();
+                sb.AppendLine("图片: " + image_path);
+                sb.AppendLine($"batch_size: {batch_size}");
+                sb.AppendLine($"threshold: {(float)numericUpDown_threshold.Value:F2}");
+                sb.AppendLine($"推理时间: {delay_ms:F2}ms");
+
+                List<CSharpObjectResult> objects = null;
+                if (result.SampleResults != null && result.SampleResults.Count > 0)
+                {
+                    objects = result.SampleResults[0].Results;
+                }
+                if (objects == null)
+                {
+                    objects = new List<CSharpObjectResult>();
+                }
+
+                sb.AppendLine($"推理结果: {objects.Count}个");
+                if (objects.Count == 0)
+                {
+                    sb.AppendLine("未检测到目标。");
+                }
+                else
+                {
+                    sb.AppendLine();
+                    for (int i = 0; i < objects.Count; i++)
+                    {
+                        sb.AppendLine(BuildObjectResultText(i + 1, objects[i]));
+                    }
+                }
+                richTextBox1.Text = sb.ToString();
+            }
+            catch (Exception ex)
+            {
+                ReportError("推理失败", ex);
+            }
+        }
+
+        private static string BuildObjectResultText(int index, CSharpObjectResult obj)
+        {
+            StringBuilder line = new StringBuilder();
+            line.AppendFormat("[{0}] {1,-12}", index, obj.CategoryName ?? string.Empty);
+            line.AppendFormat("  score={0:F2}", obj.Score);
+            line.Append("  ");
+            line.Append(BuildResultLocationText(obj));
+            line.AppendFormat("  area={0:F1}", obj.Area);
+            string angleText = BuildResultAngleText(obj);
+            if (!string.IsNullOrWhiteSpace(angleText))
+            {
+                line.Append("  ");
+                line.Append(angleText);
+            }
+
+            string extraInfoText = Utils.FormatExtraInfoForDisplay(obj.ExtraInfo);
+            if (!string.IsNullOrWhiteSpace(extraInfoText))
+            {
+                line.AppendFormat("  extra_info={{ {0} }}", extraInfoText);
+            }
+
+            return line.ToString();
+        }
+
+        private static string BuildResultLocationText(CSharpObjectResult obj)
+        {
+            if (!obj.WithBbox || obj.Bbox == null || obj.Bbox.Count < 4)
+            {
+                return "bbox=(N/A)";
+            }
+
+            bool isRotated = obj.WithAngle || obj.Bbox.Count >= 5;
+            if (isRotated)
+            {
+                float angle;
+                TryGetResultAngle(obj, out angle);
+                return string.Format(
+                    "rbox=(cx={0:F1}, cy={1:F1}, w={2:F1}, h={3:F1}, angle={4:F3})",
+                    obj.Bbox[0], obj.Bbox[1], obj.Bbox[2], obj.Bbox[3], angle);
+            }
+
+            return string.Format(
+                "bbox=({0:F1}, {1:F1}, {2:F1}, {3:F1})",
+                obj.Bbox[0], obj.Bbox[1], obj.Bbox[2], obj.Bbox[3]);
+        }
+
+        private static string BuildResultAngleText(CSharpObjectResult obj)
+        {
+            float angle;
+            if (!TryGetResultAngle(obj, out angle))
+            {
+                return string.Empty;
+            }
+
+            double degrees = angle * 180.0 / Math.PI;
+            return string.Format("angle={0:F3}rad({1:F1}deg)", angle, degrees);
+        }
+
+        private static bool TryGetResultAngle(CSharpObjectResult obj, out float angle)
+        {
+            if (obj.WithAngle)
+            {
+                angle = obj.Angle;
+                return true;
+            }
+
+            if (obj.Bbox != null && obj.Bbox.Count >= 5)
+            {
+                angle = (float)obj.Bbox[4];
+                return true;
+            }
+
+            angle = 0.0f;
+            return false;
+        }
+
+        private static Mat PrepareImageForModelInput(Mat image)
+        {
+            if (image == null || image.Empty())
+            {
+                return image;
+            }
+
+            int channels = image.Channels();
+            if (channels == 3)
+            {
+                var rgb = new Mat();
+                Cv2.CvtColor(image, rgb, ColorConversionCodes.BGR2RGB);
+                return rgb;
+            }
+
+            if (channels == 4)
+            {
+                var rgb = new Mat();
+                Cv2.CvtColor(image, rgb, ColorConversionCodes.BGRA2RGB);
+                return rgb;
+            }
+
+            // 灰度图按原样送入推理。
+            return image;
+        }
+
+        /// <summary>
+        /// 执行模型推理的测试操作
+        /// </summary>
+        /// <param name="parameter">包含图像列表的参数</param>
+        private void ModelInferAction(object parameter)
+        {
+            try
+            {
+                // 如果需要停止测试，立即返回，不执行后续推理
+                if (shouldStopPressureTest)
+                {
+                    return;
+                }
+
+                var image_list = (List<Mat>)parameter;
+                if (image_list == null)
+                {
+                    return;
+                }
+
+                // 调用InferInternal进行推理
+
+                JObject infer_config = new JObject();
+                infer_config["with_mask"] = false;
+
+                var inferSw = Stopwatch.StartNew();
+                var resultTuple = model.InferInternal(image_list, infer_config);
+                inferSw.Stop();
+                IntPtr currentResultPtr = resultTuple.Item2;
+                double dlcvInferMs = 0.0;
+                double totalInferMs = 0.0;
+                DlcvModules.InferTiming.GetLast(out dlcvInferMs, out totalInferMs);
+                if (totalInferMs <= 0.0)
+                {
+                    totalInferMs = inferSw.Elapsed.TotalMilliseconds;
+                }
+                if (dlcvInferMs <= 0.0)
+                {
+                    dlcvInferMs = totalInferMs;
+                }
+                var flowNodeTimings = new List<PressureNodeTiming>();
+                var rawNodeTimings = DlcvModules.InferTiming.GetLastFlowNodeTimings();
+                for (int i = 0; i < rawNodeTimings.Count; i++)
+                {
+                    var timing = rawNodeTimings[i];
+                    if (timing == null) continue;
+                    flowNodeTimings.Add(new PressureNodeTiming(
+                        timing.NodeId,
+                        timing.NodeType,
+                        timing.NodeTitle,
+                        timing.ElapsedMs));
+                }
+                pressureTestRunner?.RecordLatencyBreakdown(
+                    dlcvInferMs,
+                    totalInferMs,
+                    flowNodeTimings);
+
+                try
+                {
+                    // 根据模式决定是否进行一致性检查
+                    if (isConsistencyTestMode)
+                    {
+                        String thread_id = Thread.CurrentThread.ManagedThreadId.ToString("00");
+                        // 一致性测试模式：比较推理结果
+                        // 第一次推理时获取基准结果
+                        if (baselineJsonResult == null)
+                        {
+                            Debug.WriteLine($"线程{thread_id}基准结果为空，写入基准结果……");
+                            baselineJsonResult = resultTuple.Item1;
+                            string baselineJson = JsonConvert.SerializeObject(baselineJsonResult, Formatting.None);
+                            Debug.WriteLine($"线程{thread_id}写入基准结果完成。");
+                            Debug.WriteLine($"线程{thread_id}基准结果：" + baselineJson);
+                            return; // 第一次推理，获取基准后直接返回
+                        }
+                        else
+                        {
+                            // 再次检查是否需要停止测试（可能在其他线程中被设置）
+                            if (shouldStopPressureTest)
+                            {
+                                return;
+                            }
+
+                            // 直接比较JSON字符串
+                            string baselineJson = JsonConvert.SerializeObject(baselineJsonResult, Formatting.None);
+                            string currentJson = JsonConvert.SerializeObject(resultTuple.Item1, Formatting.None);
+
+                            if (baselineJson != currentJson)
+                            {
+                                Debug.WriteLine($"线程{thread_id}基准结果与当前结果不一致");
+                                Debug.WriteLine($"线程{thread_id}基准结果：" + baselineJson);
+                                Debug.WriteLine($"线程{thread_id}当前结果：" + currentJson);
+
+                                // 立即设置停止标志，防止其他线程继续执行
+                                shouldStopPressureTest = true;
+
+                                // 发现不一致，向主线程报告
+                                Dispatcher.Invoke(delegate
+                                {
+                                    // 立即停止测试
+                                    StopPressureTest();
+
+                                    StringBuilder sb = new StringBuilder();
+                                    sb.AppendLine("发现推理结果不一致！测试已停止。");
+                                    sb.AppendLine("=== 基准结果 ===");
+                                    sb.AppendLine(JsonConvert.SerializeObject(baselineJsonResult, Formatting.Indented));
+                                    sb.AppendLine("\n=== 当前结果 ===");
+                                    sb.AppendLine(JsonConvert.SerializeObject(resultTuple.Item1, Formatting.Indented));
+                                    string s = sb.ToString();
+
+                                    richTextBox1.Text = s;
+                                    MessageBox.Show(this, "检测到推理结果不一致，测试已停止！", "结果不一致", MessageBoxButton.OK, MessageBoxImage.Warning);
+
+                                    baselineJsonResult = null;
+                                });
+                            }
+                        }
+                    }
+                    // 性能测试模式：不保存或比较结果，直接继续
+                }
+                finally
+                {
+                    if (currentResultPtr != IntPtr.Zero)
+                    {
+                        DllLoader.Instance.dlcv_free_model_result(currentResultPtr);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine("模型推理出错: " + ex.Message);
+                // 设置停止标志
+                shouldStopPressureTest = true;
+
+                // 向主线程报告错误
+                Dispatcher.Invoke(delegate
+                {
+                    StopPressureTest();
+                    string testType = isConsistencyTestMode ? "一致性测试" : "压力测试";
+                    MessageBox.Show(this, $"{testType}过程中发生错误: {ex.Message}", "错误", MessageBoxButton.OK, MessageBoxImage.Error);
+                    richTextBox1.Text = $"推理错误: {ex.Message}";
+                });
+            }
+        }
+
+        /// <summary>
+        /// 定时更新UI上的统计信息
+        /// </summary>
+        private void UpdateStatisticsTimer_Tick(object sender, EventArgs e)
+        {
+            if (pressureTestRunner != null && pressureTestRunner.IsRunning)
+            {
+                // 在UI上显示统计信息
+                Dispatcher.Invoke(delegate
+                {
+                    string stats = pressureTestRunner.GetStatistics(false);
+                    if (isConsistencyTestMode && baselineJsonResult != null)
+                    {
+                        stats = stats + "\n\n" +
+                                "基准结果:\n" +
+                                JsonConvert.SerializeObject(baselineJsonResult, Formatting.Indented);
+                    }
+                    richTextBox1.Text = stats;
+                });
+            }
+        }
+
+        private void button_threadtest_Click(object sender, EventArgs e)
+        {
+            if (model == null)
+            {
+                MessageBox.Show("请先加载模型文件！");
+                return;
+            }
+            if (image_path == null)
+            {
+                MessageBox.Show("请先选择图片文件！");
+                return;
+            }
+
+            if (pressureTestRunner != null && pressureTestRunner.IsRunning)
+            {
+                StopPressureTest();
+            }
+            else
+            {
+                StartPressureTest(false); // 性能测试模式
+            }
+        }
+
+        /// <summary>
+        /// 启动测试
+        /// </summary>
+        private void StartPressureTest(bool consistencyTestMode)
+        {
+            try
+            {
+                // 设置测试模式
+                this.isConsistencyTestMode = consistencyTestMode;
+
+                // 重置测试停止标志
+                shouldStopPressureTest = false;
+
+                // 准备测试数据
+                batch_size = (int)numericUpDown_batch_size.Value;
+                int threadCount = (int)numericUpDown_num_thread.Value;
+
+                Mat image = Cv2.ImRead(image_path, ImreadModes.Unchanged);
+                Mat inferImage = PrepareImageForModelInput(image);
+
+                var image_list = new List<Mat>();
+                for (int i = 0; i < batch_size; i++)
+                {
+                    image_list.Add(inferImage);
+                }
+
+                // 创建测试实例
+                pressureTestRunner = new PressureTestRunner(threadCount, 1000000, batch_size);
+                pressureTestRunner.SetFlowModelTiming(isCurrentFlowModel);
+                pressureTestRunner.SetTestAction(ModelInferAction, image_list);
+
+                // 创建并启动定时器更新UI
+                if (updateTimer == null)
+                {
+                    updateTimer = new DispatcherTimer();
+                    updateTimer.Interval = TimeSpan.FromMilliseconds(500);
+                    updateTimer.Tick += UpdateStatisticsTimer_Tick;
+                }
+                updateTimer.Start();
+
+                // 启动测试
+                pressureTestRunner.Start();
+
+                // 根据模式设置按钮文本
+                if (consistencyTestMode)
+                {
+                    button_consistency_test.Content = "停止";
+                }
+                else
+                {
+                    button_thread_test.Content = "停止";
+                }
+            }
+            catch (Exception ex)
+            {
+                string testType = consistencyTestMode ? "一致性测试" : "压力测试";
+                MessageBox.Show(this, $"启动{testType}失败: " + ex.Message, "错误", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        /// <summary>
+        /// 停止测试
+        /// </summary>
+        private void StopPressureTest()
+        {
+            if (pressureTestRunner != null)
+            {
+                pressureTestRunner.Stop();
+
+                // 停止定时器
+                if (updateTimer != null)
+                {
+                    updateTimer.Stop();
+                }
+
+                // 清理资源
+                shouldStopPressureTest = false; // 重置测试停止标志
+
+                // 根据模式重置按钮文本
+                if (isConsistencyTestMode)
+                {
+                    button_consistency_test.Content = "一致性测试";
+                }
+                else
+                {
+                    button_thread_test.Content = "多线程测试";
+                }
+
+                // 重置测试模式
+                isConsistencyTestMode = false;
+            }
+        }
+
+        /// <summary>
+        /// 一致性测试按钮点击事件
+        /// </summary>
+        private void button_consistency_test_Click(object sender, EventArgs e)
+        {
+            if (model == null)
+            {
+                MessageBox.Show("请先加载模型文件！");
+                return;
+            }
+            if (image_path == null)
+            {
+                MessageBox.Show("请先选择图片文件！");
+                return;
+            }
+
+            if (pressureTestRunner != null && pressureTestRunner.IsRunning)
+            {
+                StopPressureTest();
+            }
+            else
+            {
+                StartPressureTest(true); // 一致性测试模式
+            }
+        }
+
+        private void button_freemodel_Click(object sender, EventArgs e)
+        {
+            // 如果存在正在运行的压力测试，先停止它
+            StopPressureTest();
+            DisposeCurrentModel();
+            richTextBox1.Text = "模型已释放";
+        }
+
+        private void button_github_Click(object sender, EventArgs e)
+        {
+            Process.Start("https://docs.dlcv.com.cn/deploy/sdk/csharp_sdk");
+        }
+
+        private void Form1_FormClosing(object sender, CancelEventArgs e)
+        {
+            StopPressureTest();
+            // 释放模型
+            var disposable = model as IDisposable;
+            if (disposable != null)
+            {
+                disposable.Dispose();
+                model = null;
+            }
+            Utils.FreeAllModels();
+        }
+
+        private void button1_Click(object sender, EventArgs e)
+        {
+            ShowDogInfo();
+        }
+
+        private void button_free_all_model_Click(object sender, EventArgs e)
+        {
+            // 如果存在正在运行的压力测试，先停止它
+            StopPressureTest();
+
+            // 释放模型
+            var disposable = model as IDisposable;
+            if (disposable != null)
+            {
+                disposable.Dispose();
+            }
+            model = null;
+            Utils.FreeAllModels();
+            richTextBox1.Text = "所有模型已释放";
+        }
+
+		/// <summary>
+		/// 统一错误输出：写入 richTextBox1 并弹窗提示
+		/// </summary>
+		private void ReportError(string title, Exception ex)
+		{
+			try
+			{
+				richTextBox1.Text = title + "\n" + ex.ToString();
+			}
+			catch { }
+			MessageBox.Show(this, title + ": " + ex.Message, "错误", MessageBoxButton.OK, MessageBoxImage.Error);
+		}
+
+        private void button_save_img_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(image_path))
+                {
+                    MessageBox.Show("请先选择图片文件！");
+                    return;
+                }
+
+                if (imagePanel1.image == null)
+                {
+                    MessageBox.Show("当前没有可保存的图像！");
+                    return;
+                }
+
+                SaveFileDialog saveFileDialog = new SaveFileDialog();
+                saveFileDialog.Filter = "JPEG 图像 (*.jpg)|*.jpg";
+                saveFileDialog.Title = "保存可视化图像";
+                saveFileDialog.DefaultExt = "jpg";
+                saveFileDialog.AddExtension = true;
+                saveFileDialog.OverwritePrompt = true;
+                saveFileDialog.RestoreDirectory = true;
+
+                try
+                {
+                    saveFileDialog.InitialDirectory = Path.GetDirectoryName(image_path);
+                    saveFileDialog.FileName = Path.GetFileNameWithoutExtension(image_path) + "_vis.jpg";
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine(ex.Message);
+                }
+
+                if (saveFileDialog.ShowDialog(this) != true)
+                {
+                    return;
+                }
+
+                using (var bitmap = imagePanel1.CreateVisualizationBitmap())
+                {
+                    bitmap.Save(saveFileDialog.FileName, System.Drawing.Imaging.ImageFormat.Jpeg);
+                }
+
+                richTextBox1.Text = "图像已保存：\n" + saveFileDialog.FileName;
+            }
+            catch (Exception ex)
+            {
+                ReportError("保存图像失败", ex);
+            }
+        }
+    }
+}

--- a/DlcvDemo/MainWindow.xaml.cs
+++ b/DlcvDemo/MainWindow.xaml.cs
@@ -221,7 +221,7 @@ namespace DlcvDemo
                 model = null;
             }
         }
-        
+
         private void button_loadmodel_Click(object sender, EventArgs e)
         {
             OpenFileDialog openFileDialog = new OpenFileDialog();

--- a/DlcvDemo/NumericBox.cs
+++ b/DlcvDemo/NumericBox.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace DlcvDemo
+{
+    public class NumericBox : Control
+    {
+        private TextBox _textBox;
+
+        static NumericBox()
+        {
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(NumericBox), new FrameworkPropertyMetadata(typeof(NumericBox)));
+        }
+
+        public NumericBox()
+        {
+            Focusable = true;
+            Height = 34;
+            MinWidth = 72;
+        }
+
+        public static readonly DependencyProperty ValueProperty = DependencyProperty.Register(
+            nameof(Value), typeof(decimal), typeof(NumericBox),
+            new FrameworkPropertyMetadata(0m, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnValueChanged, CoerceValue));
+
+        public static readonly DependencyProperty MinimumProperty = DependencyProperty.Register(
+            nameof(Minimum), typeof(decimal), typeof(NumericBox), new PropertyMetadata(0m, OnRangeChanged));
+
+        public static readonly DependencyProperty MaximumProperty = DependencyProperty.Register(
+            nameof(Maximum), typeof(decimal), typeof(NumericBox), new PropertyMetadata(100m, OnRangeChanged));
+
+        public static readonly DependencyProperty IncrementProperty = DependencyProperty.Register(
+            nameof(Increment), typeof(decimal), typeof(NumericBox), new PropertyMetadata(1m));
+
+        public static readonly DependencyProperty DecimalPlacesProperty = DependencyProperty.Register(
+            nameof(DecimalPlaces), typeof(int), typeof(NumericBox), new PropertyMetadata(0, OnDecimalPlacesChanged, CoerceDecimalPlaces));
+
+        public decimal Value
+        {
+            get => (decimal)GetValue(ValueProperty);
+            set => SetValue(ValueProperty, value);
+        }
+
+        public decimal Minimum
+        {
+            get => (decimal)GetValue(MinimumProperty);
+            set => SetValue(MinimumProperty, value);
+        }
+
+        public decimal Maximum
+        {
+            get => (decimal)GetValue(MaximumProperty);
+            set => SetValue(MaximumProperty, value);
+        }
+
+        public decimal Increment
+        {
+            get => (decimal)GetValue(IncrementProperty);
+            set => SetValue(IncrementProperty, value);
+        }
+
+        public int DecimalPlaces
+        {
+            get => (int)GetValue(DecimalPlacesProperty);
+            set => SetValue(DecimalPlacesProperty, value);
+        }
+
+        public event EventHandler ValueChanged;
+
+        public override void OnApplyTemplate()
+        {
+            base.OnApplyTemplate();
+            if (_textBox != null)
+            {
+                _textBox.LostKeyboardFocus -= TextBox_LostKeyboardFocus;
+                _textBox.KeyDown -= TextBox_KeyDown;
+            }
+            _textBox = GetTemplateChild("PART_TextBox") as TextBox;
+            if (_textBox != null)
+            {
+                _textBox.LostKeyboardFocus += TextBox_LostKeyboardFocus;
+                _textBox.KeyDown += TextBox_KeyDown;
+                UpdateText();
+            }
+        }
+
+        internal void ChangeValue(int direction)
+        {
+            CommitText();
+            Value += Increment * direction;
+        }
+
+        private void TextBox_LostKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
+        {
+            CommitText();
+        }
+
+        private void TextBox_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter)
+            {
+                CommitText();
+                Keyboard.ClearFocus();
+                e.Handled = true;
+            }
+            else if (e.Key == Key.Up)
+            {
+                ChangeValue(1);
+                e.Handled = true;
+            }
+            else if (e.Key == Key.Down)
+            {
+                ChangeValue(-1);
+                e.Handled = true;
+            }
+        }
+
+        private void CommitText()
+        {
+            if (_textBox == null) return;
+            decimal parsed;
+            if (decimal.TryParse(_textBox.Text, out parsed))
+            {
+                Value = parsed;
+            }
+            UpdateText();
+        }
+
+        private void UpdateText()
+        {
+            if (_textBox != null)
+            {
+                _textBox.Text = Value.ToString("F" + DecimalPlaces);
+            }
+        }
+
+        private static object CoerceValue(DependencyObject d, object baseValue)
+        {
+            var control = (NumericBox)d;
+            var value = (decimal)baseValue;
+            if (value < control.Minimum) return control.Minimum;
+            if (value > control.Maximum) return control.Maximum;
+            return decimal.Round(value, control.DecimalPlaces);
+        }
+
+        private static object CoerceDecimalPlaces(DependencyObject d, object baseValue)
+        {
+            int value = (int)baseValue;
+            return Math.Max(0, Math.Min(6, value));
+        }
+
+        private static void OnRangeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            d.CoerceValue(ValueProperty);
+        }
+
+        private static void OnDecimalPlacesChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            d.CoerceValue(ValueProperty);
+            ((NumericBox)d).UpdateText();
+        }
+
+        private static void OnValueChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var control = (NumericBox)d;
+            control.UpdateText();
+            control.ValueChanged?.Invoke(control, EventArgs.Empty);
+        }
+    }
+
+    public class NumericBoxButton : Button
+    {
+        public int Direction { get; set; }
+
+        protected override void OnClick()
+        {
+            base.OnClick();
+            DependencyObject current = this;
+            while (current != null)
+            {
+                var numeric = current as NumericBox;
+                if (numeric != null)
+                {
+                    numeric.ChangeValue(Direction);
+                    return;
+                }
+                current = System.Windows.Media.VisualTreeHelper.GetParent(current);
+            }
+        }
+    }
+}

--- a/DlcvDemo/Program.cs
+++ b/DlcvDemo/Program.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Windows.Forms;
+using System.Windows;
 
 namespace DlcvDemo
 {
@@ -17,9 +17,9 @@ namespace DlcvDemo
                 return CliRunner.Run(args);
             }
 
-            Application.EnableVisualStyles();
-            Application.SetCompatibleTextRenderingDefault(false);
-            Application.Run(new Form1());
+            var application = new System.Windows.Application();
+            var window = new MainWindow();
+            application.Run(window);
             return 0;
         }
     }

--- a/DlcvDemo/Properties/AssemblyInfo.cs
+++ b/DlcvDemo/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.7.25.0")]
-[assembly: AssemblyFileVersion("2026.7.25.0")]
-[assembly: AssemblyInformationalVersion("2026.7.25.0a0")]
+[assembly: AssemblyVersion("2026.7.29.0")]
+[assembly: AssemblyFileVersion("2026.7.29.0")]
+[assembly: AssemblyInformationalVersion("2026.7.29.0a0")]
 [assembly: NeutralResourcesLanguage("zh-CN")]

--- a/DlcvDemo/Properties/app.manifest
+++ b/DlcvDemo/Properties/app.manifest
@@ -47,14 +47,13 @@
        在其 app.config 中将 "EnableWindowsFormsHighDpiAutoResizing" 设置设置为 "true"。
        
        将应用程序设为感知长路径。请参阅 https://docs.microsoft.com/windows/win32/fileio/maximum-file-path-limitation -->
-  <!--
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
-      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2,PerMonitor</dpiAwareness>
       <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
     </windowsSettings>
   </application>
-  -->
   <!-- 启用 Windows 公共控件和对话框的主题(Windows XP 和更高版本) -->
   <!--
   <dependency>

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import shutil
 
 from setuptools import setup
 
-version = '2026.7.25.0a0'
+version = '2026.7.29.0a0'
 
 package_name = "dlcvpro_infer_csharp"  # 包名
 packages: list = [package_name]  # 需要打包的包


### PR DESCRIPTION
## 变更说明

### OpenVINO 设备支持

- DlcvDemo 图形界面的设备列表加入 `OpenVINO`，映射到 `device_id=-2`
- 设备按 ID 从小到大排列：OpenVINO（`-2`）、CPU（`-1`）、GPU（`0` 起）
- 有 GPU 时默认选中第一张 GPU；无 GPU 时默认选中 CPU
- 命令行推理允许 `--device -2`
- 参数错误提示补充 OpenVINO、CPU 与 GPU 编号语义

### DlcvDemo 高 DPI 界面

- 将 DlcvDemo 主界面迁移为 WPF 布局，依靠 WPF DIP 与 Windows PerMonitorV2 机制适配高 DPI，不进行手工比例缩放
- 保持窗口标题、产品显示名和程序文件名为 `C# 测试程序`
- 保留原有左侧操作区、中间参数区、右侧操作区的相对布局和业务事件逻辑
- “加载模型”和“打开图片推理”按钮分别横跨两列
- `threshold` 靠近 `batch_size`，RPC 模式移至“保存图像”上方
- `batch_size`、`threshold` 和线程数输入框加宽至 `110 DIP`
- 运行结果区域加宽至 `380 DIP`
- 窗口最小宽度设为 `1040 DIP`，避免最窄状态下“保存图像”遮挡 `threshold` 调节框
- 保留蓝色主操作按钮、红色释放按钮、浅灰背景和白色圆角卡片样式

<img width="1902" height="1221" alt="image" src="https://github.com/user-attachments/assets/73068068-4f33-4e0a-a5e7-1e56934878b9" />

## 版本

- 测试版更新为 `2026.7.29.0a0`

## 验证

- 使用 `build_package.py --install` 完成 Release x64 构建、签名、wheel 打包和安装
- 已安装版本核验为 `2026.7.29.0a0`
- 在 150% DPI 环境下检查界面布局，最小宽度状态下顶部控件无重叠或遮挡
- 已用于 OpenVINO `device_id=-2` 端到端推理验证
- 分类、检测模型推理通过
- CUDA `device_id=0` 与 CPU `device_id=-1` 回归通过
