### PR TITLE
日志: 精简推理模块逐对象调试输出

### DIFF
--- a/DlcvCsharpApi/flow/modules/Features.cs
+++ b/DlcvCsharpApi/flow/modules/Features.cs
@@ -350,11 +350,6 @@ namespace DlcvModules
                     }
 
                     if (cropped == null) continue;
-                    
-                    if (GlobalDebug.PrintDebug)
-                    {
-                        GlobalDebug.Log($"[ImageGeneration] 输入图像尺寸: {tup.Item2.Width}x{tup.Item2.Height}, 裁剪后的图像尺寸: {cropped.Width}x{cropped.Height}");
-                    }
 
                     // 派生状态
                     var parentWrap = tup.Item1;
@@ -514,7 +509,6 @@ namespace DlcvModules
             return token != null ? token.DeepClone() : JValue.CreateNull();
         }
 
-        
 
         private static int ClampToInt(double v)
         {
@@ -910,22 +904,6 @@ namespace DlcvModules
             var inImages = imageList ?? new List<ModuleImage>();
             var inResults = resultList ?? new JArray();
 
-            if (GlobalDebug.PrintDebug)
-            {
-                var cats = new List<string>();
-                foreach (var t in inResults)
-                {
-                    if (t is JObject r && r["sample_results"] is JArray srs)
-                    {
-                        foreach (var s in srs)
-                        {
-                            if (s is JObject so) cats.Add(so["category_name"]?.ToString() ?? "");
-                        }
-                    }
-                }
-                GlobalDebug.Log($"[ResultFilter] 筛选前 category_name 列表: {string.Join(", ", cats)}");
-            }
-
             var categories = ReadCategories();
             var keepSet = new HashSet<string>(categories, StringComparer.OrdinalIgnoreCase);
 
@@ -1036,22 +1014,6 @@ namespace DlcvModules
                 this.ScalarOutputsByName["has_positive"] = hasPositive;
             }
             catch { }
-
-            if (GlobalDebug.PrintDebug)
-            {
-                var cats = new List<string>();
-                foreach (var t in mainResults)
-                {
-                    if (t is JObject r && r["sample_results"] is JArray srs)
-                    {
-                        foreach (var s in srs)
-                        {
-                            if (s is JObject so) cats.Add(so["category_name"]?.ToString() ?? "");
-                        }
-                    }
-                }
-                GlobalDebug.Log($"[ResultFilter] 筛选后 category_name 列表: {string.Join(", ", cats)}");
-            }
 
             return new ModuleIO(mainImages, mainResults);
         }


### PR DESCRIPTION
## 修改内容

- 删除 ImageGeneration 每次裁剪的尺寸调试日志
- 删除 ResultFilter 筛选前后逐对象类别列表
- 保留上层每张图片的类别汇总和异常日志

## 验证

- PrintMatch build.bat：0 错误、0 警告
- SequenceGraph 测试：474 通过，0 失败，1 跳过