### PR TITLE
fix: 同路径模型缓存借用所有权与释放后清缓存

### DIFF
--- a/DlcvCsharpApi/Model.cs
+++ b/DlcvCsharpApi/Model.cs
@@ -69,6 +69,9 @@ namespace dlcv_infer_csharp
         private static readonly Dictionary<string, int> _modelCache = new Dictionary<string, int>();
         private static readonly HashSet<string> _loadingModels = new HashSet<string>();
         private static readonly object _cacheLock = new object();
+        // 当前实例对应的缓存键；仅用于 owner 释放时移除缓存条目。
+        private string _cacheKey;
+        private bool _cacheEnabled;
 
         // 缓存模型信息（加载后即读取一次）
         private JObject _cachedModelInfo = null;
@@ -112,6 +115,10 @@ namespace dlcv_infer_csharp
                         if (_modelCache.TryGetValue(cacheKey, out cachedIndex))
                         {
                             modelIndex = cachedIndex;
+                            _cacheKey = cacheKey;
+                            _cacheEnabled = true;
+                            // 缓存命中只借用已加载底层模型，不能再拥有释放权。
+                            OwnModelIndex = false;
                             _dllLoader = DllLoader.Instance;
                             TryCacheModelInfo();
                             return;
@@ -161,6 +168,10 @@ namespace dlcv_infer_csharp
                         _modelCache[cacheKey] = modelIndex;
                         _loadingModels.Remove(cacheKey);
                     }
+                    _cacheKey = cacheKey;
+                    _cacheEnabled = true;
+                    // 首个加载者拥有释放权；后续同键实例仅借用。
+                    OwnModelIndex = true;
                 }
             }
             catch
@@ -581,6 +592,9 @@ namespace dlcv_infer_csharp
                 modelIndex = -1;
                 return;
             }
+
+            // owner 释放前先摘掉缓存，避免后续同路径命中已释放的 model_index。
+            RemoveFromModelCache();
 
             if (_isDvpMode)
             {
@@ -2468,6 +2482,22 @@ namespace dlcv_infer_csharp
             {
                 _modelCache.Clear();
                 _loadingModels.Clear();
+            }
+        }
+
+        private void RemoveFromModelCache()
+        {
+            if (!_cacheEnabled || string.IsNullOrEmpty(_cacheKey))
+                return;
+            lock (_cacheLock)
+            {
+                int cachedIndex;
+                if (_modelCache.TryGetValue(_cacheKey, out cachedIndex) &&
+                    cachedIndex == modelIndex)
+                {
+                    _modelCache.Remove(_cacheKey);
+                }
+                _loadingModels.Remove(_cacheKey);
             }
         }
     }

--- a/DlcvCsharpApi/Utils.cs
+++ b/DlcvCsharpApi/Utils.cs
@@ -387,6 +387,9 @@ namespace dlcv_infer_csharp
         public static void FreeAllModels()
         {
             DllLoader.Instance.dlcv_free_all_models?.Invoke();
+            // 底层模型已全部释放，同步清空路径缓存，避免同路径再次命中失效 index。
+            Model.ClearModelCache();
+            DlcvModules.BaseModelModule.ClearModelCache();
         }
 
         public static JObject GetDeviceInfo()

--- a/DlcvCsharpApi/flow/modules/Models.cs
+++ b/DlcvCsharpApi/flow/modules/Models.cs
@@ -68,22 +68,44 @@ namespace DlcvModules
 					try { _modelPath = Context.Get<string>("model_path", null); } catch { }
 				}
 
-				string cacheKey = (_modelPath ?? "") + "|" + deviceId + "|" + rpcMode;
-				bool cacheHit = false;
+				string normalizedPath = NormalizeModelPath(_modelPath);
+				string cacheKey = (normalizedPath ?? "") + "|" + deviceId + "|" + rpcMode;
 				lock (_modelCacheLock)
 				{
-					cacheHit = _modelCache.TryGetValue(cacheKey, out _model);
-					if (!cacheHit)
+					if (!_modelCache.TryGetValue(cacheKey, out _model) || _model == null)
 					{
-						_model = new Model(_modelPath, deviceId, rpcMode, true);
+						_model = new Model(normalizedPath ?? _modelPath, deviceId, rpcMode, true);
 						_modelCache[cacheKey] = _model;
 					}
 				}
+				// 多个模块/面可共享同一路径模型实例；不在模块侧单独 Dispose。
 				SyncModelMeta();
 			}
 			else
 			{
 				SyncModelMeta();
+			}
+		}
+
+		public static void ClearModelCache()
+		{
+			lock (_modelCacheLock)
+			{
+				_modelCache.Clear();
+			}
+		}
+
+		private static string NormalizeModelPath(string modelPath)
+		{
+			if (string.IsNullOrWhiteSpace(modelPath))
+				return modelPath;
+			try
+			{
+				return Path.GetFullPath(modelPath.Trim());
+			}
+			catch
+			{
+				return modelPath.Trim();
 			}
 		}
 


### PR DESCRIPTION
## 问题描述

同一模型路径被多个模块或多个面共用时，缓存命中的实例仍会拥有释放权。任一侧 Dispose/FreeModel 会释放共享底层 model_index，后续同路径加载或推理会失败。FreeAllModels 之后路径缓存未清空，也会继续命中已失效的 index。

## 修复方案

- 缓存命中时设 OwnModelIndex=false，仅借用已加载底层模型，不再拥有释放权
- owner 释放前移除路径缓存条目，避免后续同路径命中已释放的 model_index
- FreeAllModels 后同步清空 Model 与 BaseModelModule 路径缓存
- BaseModelModule 规范化模型路径并共享同键实例

## 测试验证

- 借用方 Dispose 不再释放共享模型
- FreeAllModels 后同路径可重新加载
- DlcvCsharpApi Debug x64 编译通过
