### PR TITLE
发布: 正式版 2026.8.10.0

### DIFF
--- a/DlcvCsharpApi/Properties/AssemblyInfo.cs
+++ b/DlcvCsharpApi/Properties/AssemblyInfo.cs
@@ -29,6 +29,6 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.7.29.0")]
-[assembly: AssemblyFileVersion("2026.7.29.0")]
-[assembly: AssemblyInformationalVersion("2026.7.29.0a0")]
+[assembly: AssemblyVersion("2026.8.10.0")]
+[assembly: AssemblyFileVersion("2026.8.10.0")]
+[assembly: AssemblyInformationalVersion("2026.8.10.0")]

--- a/DlcvDemo/Properties/AssemblyInfo.cs
+++ b/DlcvDemo/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.7.29.0")]
-[assembly: AssemblyFileVersion("2026.7.29.0")]
-[assembly: AssemblyInformationalVersion("2026.7.29.0a0")]
+[assembly: AssemblyVersion("2026.8.10.0")]
+[assembly: AssemblyFileVersion("2026.8.10.0")]
+[assembly: AssemblyInformationalVersion("2026.8.10.0")]
 [assembly: NeutralResourcesLanguage("zh-CN")]

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import shutil
 
 from setuptools import setup
 
-version = '2026.7.29.0a0'
+version = '2026.8.10.0'
 
 package_name = "dlcvpro_infer_csharp"  # 包名
 packages: list = [package_name]  # 需要打包的包


### PR DESCRIPTION
## 变更
- 发布正式版 2026.8.10.0
- 版本号去掉预发布后缀并完成本机编译安装验证

## 说明
- wheel 已上传对应私有源
- 请 squash 合并
