### PR TITLE
流程模型节点支持附加旋转推理参数

### DIFF
--- a/C# API文档.md
+++ b/C# API文档.md
@@ -199,6 +199,7 @@ public dynamic InferOneOutJson(Mat image, JObject paramsJson = null);
 - `Infer` 内部调用 `InferBatch(new List<Mat> { image })`。
 - `InferOneOutJson` 内部调用 `InferInternalCore(..., emitPoly: true)` 以保留 `poly` 字段。
 - 流程中的 `model/*` 节点始终使用流程文件自身的 `properties.threshold`；入口 `paramsJson.threshold` 不会改写节点属性。
+- `model/det` 与 `model/instance_seg` 节点会把 `rotate_inference`、`rotate_angle`、`dual_fill_value` 传给底层模型推理接口。
 - 入口 `threshold` 仅在流程执行完成后过滤最终对外结果，保留 `score >= threshold` 的对象；未传入有限数值时不做额外过滤，无有限数值 `score` 的非标准条目保留。
 
 ### 4.3 内部推理方法

--- a/DlcvCsharpApi/flow/modules/Models.cs
+++ b/DlcvCsharpApi/flow/modules/Models.cs
@@ -205,6 +205,9 @@ namespace DlcvModules
 			TryAddParam(p, "return_polygon");
 			TryAddParam(p, "epsilon");
 			TryAddParam(p, "batch_size");
+			TryAddParam(p, "rotate_inference");
+			TryAddParam(p, "rotate_angle");
+			TryAddParam(p, "dual_fill_value");
 			// 注意：with_mask 仅控制最终返回格式，不在这里传给子模型。
 			// 流程内部需要始终保留 mask_rle，否则 mask_to_rbox 等后处理节点会丢失结果。
 			// output/return_json 会根据 infer_params.with_mask 决定是否把 mask 暴露给前端/JSON。
@@ -423,6 +426,10 @@ namespace DlcvModules
 					{
 						p[key] = (int)v;
 					}
+					else if (v is long)
+					{
+						p[key] = (long)v;
+					}
 					else if (v is float)
 					{
 						p[key] = (float)v;
@@ -430,6 +437,10 @@ namespace DlcvModules
 					else if (v is double)
 					{
 						p[key] = (double)v;
+					}
+					else if (v is decimal)
+					{
+						p[key] = (decimal)v;
 					}
 					else if (v is string)
 					{

--- a/模块、流程与模型推理标准文档.md
+++ b/模块、流程与模型推理标准文档.md
@@ -325,7 +325,7 @@ Flow 中的所有模块都围绕同一套运行时对象工作。这样做的直
 | 链路路由 | 预先建立 `linkId -> (srcNodeId, srcOutIdx)` 映射 |
 | 主通道与额外通道 | 每两个输入端口形成一组通道；第 0 组为主通道，其余进入 `ExtraInputsIn` |
 | 标量注入 | 把上游标量结果写入 `ScalarInputsByIndex` 和 `ScalarInputsByName` |
-| 入口参数 | C# 节点使用流程配置属性；C++ 保留其他基础类型入口参数覆盖同名属性的既有行为。两端均不使用 `with_mask` 和 `threshold` 覆盖节点：`with_mask` 只控制最终返回内容，`threshold` 只在流程聚合完成后筛选最终对外结果 |
+| 入口参数 | C# 节点使用流程配置属性；目标检测和实例分割节点把 `rotate_inference`、`rotate_angle`、`dual_fill_value` 传给底层模型。C++ 保留其他基础类型入口参数覆盖同名属性的既有行为。两端均不使用 `with_mask` 和 `threshold` 覆盖节点：`with_mask` 只控制最终返回内容，`threshold` 只在流程聚合完成后筛选最终对外结果 |
 | 模型预加载 | `LoadModels()` 只对 `model/*` 节点调用 `LoadModel()` |
 | 输出发布 | 每个节点执行后，把主输出写入公共输出表，把额外输出写入 `ExtraOutputs` |
 | 时间记录 | 记录图搭建、节点执行、输出发布等耗时 |


### PR DESCRIPTION
## 变更说明

- `model/det` 与 `model/instance_seg` 从模型节点属性读取 `rotate_inference`、`rotate_angle`、`dual_fill_value`。
- 旋转参数与 `threshold`、`iou_threshold` 同级保存，并传给底层模型推理接口。
- 补充 `Int64` 与 `Decimal` 参数类型处理，避免整数角度和填充值被转成字符串。
- 更新 C# API 与流程模型文档。

## 验证结果

- Debug x64 构建通过，0 个警告、0 个错误。
- 使用含两个 `.dvo` 模型的 `.dvst` 执行 C# 命令行推理，退出码为 0。
- 实例分割节点阈值为 0.8；关闭旋转时仅返回“螺丝”，开启 45 度附加推理时返回“螺丝”和“开裂”。
- C# 命令行未传旋转参数，验证配置来自模型节点属性。
- 结构化结果与 JSON 结果一致。
