### PR TITLE
修复dvs流程在c#以及python上对分类模型处理的差异

### DIFF
--- a/DlcvCsharpApi/Model.cs
+++ b/DlcvCsharpApi/Model.cs
@@ -93,15 +93,15 @@ namespace dlcv_infer_csharp
         {
             _modelPath = modelPath;
 
-            // 根据模型文件后缀判断是否使用 DVP 模式
+            // 根据模型文件后缀判断是否使用 HTTP 模式
             if (string.IsNullOrEmpty(modelPath))
             {
                 throw new ArgumentException("模型路径不能为空", nameof(modelPath));
             }
 
             string extension = Path.GetExtension(modelPath).ToLower();
-            _isDvpMode = extension == ".dvp";
-            _isDvsMode = extension == ".dvst" || extension == ".dvso" || extension == ".dvsp";
+            _isDvpMode = extension == ".dvp" || extension == ".dvsp";
+            _isDvsMode = extension == ".dvst" || extension == ".dvso";
             _isRpcMode = rpc_mode;
             string cacheKey = BuildModelCacheKey(modelPath, device_id, _isDvpMode, _isDvsMode, _isRpcMode);
 

--- a/DlcvCsharpApi/Properties/AssemblyInfo.cs
+++ b/DlcvCsharpApi/Properties/AssemblyInfo.cs
@@ -29,6 +29,6 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.8.10.0")]
-[assembly: AssemblyFileVersion("2026.8.10.0")]
-[assembly: AssemblyInformationalVersion("2026.8.10.0")]
+[assembly: AssemblyVersion("2026.8.19.0")]
+[assembly: AssemblyFileVersion("2026.8.19.0")]
+[assembly: AssemblyInformationalVersion("2026.8.19.0")]

--- a/DlcvCsharpApi/flow/modules/Models.cs
+++ b/DlcvCsharpApi/flow/modules/Models.cs
@@ -496,6 +496,7 @@ namespace DlcvModules
 			var imagesOut = baseIo != null ? (baseIo.ImageList ?? new List<ModuleImage>()) : new List<ModuleImage>();
 			var resultsOut = baseIo != null ? (baseIo.ResultList ?? new JArray()) : new JArray();
 			int topK = Math.Max(0, ReadInt("top_k", 1));
+			var categoryByIndex = new Dictionary<int, string>();
 
 			int n = Math.Min(resultsOut.Count, imagesOut.Count);
 			for (int i = 0; i < n; i++)
@@ -509,11 +510,20 @@ namespace DlcvModules
 				var imgMat = imagesOut[i] != null ? imagesOut[i].ImageObject : null;
 				int iw = imgMat != null ? Math.Max(1, imgMat.Width) : 1;
 				int ih = imgMat != null ? Math.Max(1, imgMat.Height) : 1;
+				JObject top1 = null;
+				double top1Score = double.MinValue;
 
 				foreach (var s in samples)
 				{
 					var so = s as JObject;
 					if (so == null) continue;
+					double score = so.Value<double?>("score") ?? 0.0;
+					if (top1 == null || score > top1Score)
+					{
+						top1 = so;
+						top1Score = score;
+					}
+
 					var bboxArr = so["bbox"] as JArray;
 					bool withBbox = so.Value<bool?>("with_bbox") ?? false;
 					bool validDims = false;
@@ -535,6 +545,37 @@ namespace DlcvModules
 						so["angle"] = -100.0;
 					}
 				}
+
+				int index = entry.Value<int?>("index") ?? i;
+				string categoryName = top1 != null ? top1.Value<string>("category_name") : null;
+				if (categoryName != null) categoryByIndex[index] = categoryName;
+			}
+
+			if (resultList != null && resultList.Count > 0)
+			{
+				var overlaidResults = new JArray();
+				foreach (var token in resultList)
+				{
+					var sourceEntry = token as JObject;
+					var overlaidEntry = sourceEntry != null ? (JObject)sourceEntry.DeepClone() : null;
+					int index = sourceEntry != null ? (sourceEntry.Value<int?>("index") ?? -1) : -1;
+					if (overlaidEntry != null
+						&& string.Equals(sourceEntry.Value<string>("type"), "local", StringComparison.Ordinal)
+						&& categoryByIndex.TryGetValue(index, out string categoryName))
+					{
+						var samples = overlaidEntry["sample_results"] as JArray;
+						if (samples != null)
+						{
+							foreach (var sample in samples)
+							{
+								var sampleObject = sample as JObject;
+								if (sampleObject != null) sampleObject["category_name"] = categoryName;
+							}
+						}
+					}
+					overlaidResults.Add(overlaidEntry != null ? (JToken)overlaidEntry : token.DeepClone());
+				}
+				return new ModuleIO(imagesOut, overlaidResults);
 			}
 
 			return new ModuleIO(imagesOut, resultsOut);

--- a/DlcvDemo/Properties/AssemblyInfo.cs
+++ b/DlcvDemo/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.8.10.0")]
-[assembly: AssemblyFileVersion("2026.8.10.0")]
-[assembly: AssemblyInformationalVersion("2026.8.10.0")]
+[assembly: AssemblyVersion("2026.8.19.0")]
+[assembly: AssemblyFileVersion("2026.8.19.0")]
+[assembly: AssemblyInformationalVersion("2026.8.19.0")]
 [assembly: NeutralResourcesLanguage("zh-CN")]

--- a/Test/DlcvCSharpTest/Program.cs
+++ b/Test/DlcvCSharpTest/Program.cs
@@ -68,6 +68,11 @@ namespace DlcvCSharpTest
                     return RunDvsRgbSelfTest(args);
                 }
 
+                if (args != null && args.Length >= 1 && string.Equals(args[0], "dvsp-parity-selftest", StringComparison.OrdinalIgnoreCase))
+                {
+                    return RunDvspParitySelfTest(args);
+                }
+
                 if (args != null && args.Length >= 1 && string.Equals(args[0], "maskrbox-selftest", StringComparison.OrdinalIgnoreCase))
                 {
                     return RunMaskToRBoxSelfTest();
@@ -1853,6 +1858,99 @@ namespace DlcvCSharpTest
                         try { disposables[i]?.Dispose(); } catch { }
                     }
                 }
+            }
+        }
+
+        private static int RunDvspParitySelfTest(string[] args)
+        {
+            if (args == null || args.Length < 4)
+            {
+                Console.WriteLine("用法: DlcvCSharpTest dvsp-parity-selftest <modelPath> <imagePath> <expectedJson>");
+                return 2;
+            }
+
+            string modelPath = args[1];
+            string imagePath = args[2];
+            string expectedPath = args[3];
+            if (!File.Exists(modelPath) || !File.Exists(imagePath) || !File.Exists(expectedPath))
+            {
+                Console.WriteLine("模型、图片或基线 JSON 不存在");
+                return 2;
+            }
+
+            Model model = null;
+            Mat bgr = null;
+            Mat rgb = null;
+            Utils.CSharpResult result = default(Utils.CSharpResult);
+            try
+            {
+                var expectedRoot = JObject.Parse(File.ReadAllText(expectedPath, Encoding.UTF8));
+                var expected = expectedRoot["results"] as JArray ?? new JArray();
+
+                model = new Model(modelPath, GpuDeviceId, false, false);
+                bgr = Cv2.ImRead(imagePath, ImreadModes.Color);
+                if (bgr == null || bgr.Empty()) throw new Exception("图像解码失败");
+                rgb = new Mat();
+                Cv2.CvtColor(bgr, rgb, ColorConversionCodes.BGR2RGB);
+
+                var inferParams = new JObject
+                {
+                    ["threshold"] = 0.0,
+                    ["with_mask"] = false,
+                    ["batch_size"] = 1
+                };
+                result = model.InferBatch(new List<Mat> { rgb }, inferParams);
+                var actual = result.SampleResults != null && result.SampleResults.Count > 0
+                    ? result.SampleResults[0].Results ?? new List<Utils.CSharpObjectResult>()
+                    : new List<Utils.CSharpObjectResult>();
+
+                Console.WriteLine("expected_count=" + expected.Count + ", actual_count=" + actual.Count);
+                bool ok = expected.Count == actual.Count;
+                int count = Math.Min(expected.Count, actual.Count);
+                for (int i = 0; i < count; i++)
+                {
+                    var exp = expected[i] as JObject ?? new JObject();
+                    var expBox = exp["bbox"] as JArray ?? new JArray();
+                    var act = actual[i];
+                    var actBox = act.Bbox ?? new List<double>();
+                    double ax1 = actBox.Count > 0 ? actBox[0] : double.NaN;
+                    double ay1 = actBox.Count > 1 ? actBox[1] : double.NaN;
+                    double ax2 = actBox.Count > 2 ? ax1 + actBox[2] : double.NaN;
+                    double ay2 = actBox.Count > 3 ? ay1 + actBox[3] : double.NaN;
+                    double ex1 = expBox.Count > 0 ? expBox[0].Value<double>() : double.NaN;
+                    double ey1 = expBox.Count > 1 ? expBox[1].Value<double>() : double.NaN;
+                    double ex2 = expBox.Count > 2 ? expBox[2].Value<double>() : double.NaN;
+                    double ey2 = expBox.Count > 3 ? expBox[3].Value<double>() : double.NaN;
+                    double expectedScore = exp.Value<double?>("score") ?? double.NaN;
+                    string expectedCategory = exp.Value<string>("category_name") ?? "";
+
+                    bool itemOk = string.Equals(expectedCategory, act.CategoryName ?? "", StringComparison.Ordinal)
+                        && Math.Abs(expectedScore - act.Score) <= 1e-6
+                        && Math.Abs(ex1 - ax1) <= 1e-6
+                        && Math.Abs(ey1 - ay1) <= 1e-6
+                        && Math.Abs(ex2 - ax2) <= 1e-6
+                        && Math.Abs(ey2 - ay2) <= 1e-6;
+                    ok &= itemOk;
+                    Console.WriteLine(string.Format(CultureInfo.InvariantCulture,
+                        "[{0}] {1} score expected={2:R} actual={3:R}; bbox expected=[{4:R},{5:R},{6:R},{7:R}] actual=[{8:R},{9:R},{10:R},{11:R}] {12}",
+                        i, act.CategoryName, expectedScore, (double)act.Score, ex1, ey1, ex2, ey2, ax1, ay1, ax2, ay2, itemOk ? "OK" : "MISMATCH"));
+                }
+
+                Console.WriteLine(ok ? "SELFTEST PASSED" : "SELFTEST FAILED");
+                return ok ? 0 : 1;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("SELFTEST ERROR: " + ex.Message);
+                return 1;
+            }
+            finally
+            {
+                DisposeResultMasks(result);
+                if (rgb != null) rgb.Dispose();
+                if (bgr != null) bgr.Dispose();
+                try { if (model != null) model.Dispose(); } catch { }
+                ForceGc();
             }
         }
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import shutil
 
 from setuptools import setup
 
-version = '2026.8.10.0'
+version = '2026.8.19.0'
 
 package_name = "dlcvpro_infer_csharp"  # 包名
 packages: list = [package_name]  # 需要打包的包


### PR DESCRIPTION
1 修复C#分类模型流程与python的差异
2 dvsp走与dvp一样的线路