### PR TITLE
同步类型数量校验及 OK/NG 状态到 C# 和 C++

### DIFF
--- a/C# API文档.md
+++ b/C# API文档.md
@@ -77,11 +77,18 @@ public partial class Utils
     public struct CSharpSampleResult
     {
         public List<CSharpObjectResult> Results { get; set; }
+        public bool? Ok { get; set; }
+        public string Reason { get; set; }
 
         public CSharpSampleResult(List<CSharpObjectResult> results);
+        public CSharpSampleResult(List<CSharpObjectResult> results, bool? ok, string reason);
     }
 }
 ```
+
+- `Ok` 为流程对当前图片的显式判定状态；流程未产生判定状态时为 `null`。
+- `Reason` 为失败原因文本；没有原因时为 `null`。
+- 普通模型和未使用判定模块的旧流程保持 `Ok=null`、`Reason=null`。
 
 ### 2.3 CSharpResult
 
@@ -151,7 +158,8 @@ public CSharpResult InferBatch(List<Mat> imageList, JObject paramsJson = null);
 ```csharp
 public dynamic InferOneOutJson(Mat image, JObject paramsJson = null);
 ```
-- 返回 `JArray`，每个元素为单个检测结果对象。
+- 普通模型和未产生判定状态的流程返回 `JArray`，每个元素为单个检测结果对象。
+- 流程产生 `ok/reason` 时返回 `JObject`：`{"result_list": [...], "ok": true|false, "reason": null|[...]}`。
 - 字段包含：`category_id`、`category_name`、`score`、`bbox`（`[x,y,w,h]`）、`with_bbox`、`with_angle`、`angle`、`poly`（多边形点数组）、`mask_rle`（RLE 编码 mask）、`area`。
 
 ### 3.6 测速
@@ -209,6 +217,7 @@ public dynamic InferOneOutJson(Mat image, JObject paramsJson = null);
 - 调用形式与 `Model` 一致，流程模型的阈值职责边界如下。
 - `Infer` 内部调用 `InferBatch(new List<Mat> { image })`。
 - `InferOneOutJson` 内部调用 `InferInternalCore(..., emitPoly: true)` 以保留 `poly` 字段。
+- `output/return_json` 产生按图 `ok/reason` 时，`Infer` / `InferBatch` 将其写入对应 `CSharpSampleResult.Ok/Reason`，`InferOneOutJson` 将其写入单图包装对象。
 - 流程中的 `model/*` 节点始终使用流程文件自身的 `properties.threshold`；入口 `paramsJson.threshold` 不会改写节点属性。
 - 流程中的 `model/*` 节点默认从自身 `properties.calc_mean` 读取均值计算开关；入口 `paramsJson.calc_mean` 显式传入时仅覆盖本次推理，省略时继续使用节点属性。
 - 入口 `threshold` 仅在流程执行完成后过滤最终对外结果，保留 `score >= threshold` 的对象；未传入有限数值时不做额外过滤，无有限数值 `score` 的非标准条目保留。
@@ -225,7 +234,7 @@ private Tuple<JObject, IntPtr> InferInternalCore(List<Mat> images, JObject param
   3. 从 `frontend_json` / `frontend_json_by_node` 收集各节点输出。
   4. 按 `origin_index` 或位置索引映射回原始图像结果。
   5. 若入口含有限数值 `threshold`，按该值过滤每张图的最终结果。
-  6. 返回 `{"result_list": [...]}` 格式 JSON。
+  6. 返回 `{"result_list": [...]}` 格式 JSON；每张图存在流程判定时，对应项同时包含 `ok/reason`。
 
 ### 4.4 模型信息
 

--- a/C#模型测试工程开发文档.md
+++ b/C#模型测试工程开发文档.md
@@ -88,7 +88,9 @@
   - `demo2-rgb-selftest <extractModelPath> <componentModelPath> <icModelPath> <imagePath>`
   - `flow-batch-selftest <modelPath> <imagePath> [batch]`
   - `calc-mean-selftest`
+  - `category-count-check-selftest`
 - `dlcv_infer_cpp_test.exe` 支持 `count-results-selftest`，验证新配置闭区间、非法范围与旧配置兼容逻辑。
+- `DlcvCSharpTest.exe category-count-check-selftest` 与 `dlcv_infer_cpp_test.exe category-count-check-selftest` 验证类型数量规则、同一原图局部结果聚合、粘性 `ok=false`、字符串或数组 `reason`、Flow 输出包装及旧流程兼容行为。
 - `dlcv_infer_cpp_test.exe` 支持三模型加载计时子命令：
   - `load-three-models <extractModelPath> <componentModelPath> <icModelPath>`
   - 三个模型按参数顺序串行加载，实时输出各模型加载耗时，完成后输出三次耗时之和。

--- a/C#测试程序开发文档.md
+++ b/C#测试程序开发文档.md
@@ -95,6 +95,7 @@
 - `--calc-mean=true` 时，结构化与 JSON 摘要包含 `with_mean`、`foreground_mean`、`background_mean`，并通过 `mean_check_passed` 检查带掩码结果是否包含均值及两种结果的一致性；普通检测结果不参与均值检查，两条结果均为空时该检查通过。
 - 中文图片路径通过 `File.ReadAllBytes` 与 `Cv2.ImDecode` 解码；三通道和四通道图像分别转换为 RGB。
 - 同一次命令分别调用 `Infer` 与 `InferOneOutJson`，摘要包含 `structured`、`json`、`consistent` 和 `threshold_check_passed`。
+- `InferOneOutJson` 返回带 `result_list` 的流程判定包装对象时，命令行模式从包装对象中读取结果数组后继续执行双路径一致性检查。
 - `structured` 与 `json` 均包含 `count`、`scores`、`categories` 和 `below_threshold`。
 - `--output` 写入无 BOM 的 UTF-8 JSON；该路径不得覆盖模型或图片，父目录必须存在。
 - 原生推理运行库仍可能向标准输出写入本地编码日志；机器解析使用 `--output` 文件，不把 stdout 当作单一 JSON 文档。
@@ -208,6 +209,8 @@
     - 无框结果（`with_bbox = false`，如分类、OCR）：标签绘制在图像内部左上角，多个结果时自上而下堆叠，与 C++ 测试程序行为一致。
   - **颜色**：根据类别（OK/NG）区分颜色（如绿/红）。
   - **无结果状态**：当 `SampleResults.Count==0` 时，自动显示左上角状态文本 `No Result`（控件会将 `ShowStatusText` 置为 `true`）。
+  - **流程判定状态**：`CSharpSampleResult.Ok` 有值时优先在图像左上角显示带阴影的灰色半透明方块，方块内为绿色 `OK` 或红色 `NG`，不再根据类别名推测状态；`Ok` 无值时保留原有 `ShowStatusText` 行为。
+  - **失败原因**：`CSharpSampleResult.Reason` 非空时，显示在左侧预测结果文本下方。
 
 ### 6. 主流程与状态（必须一致）
 

--- a/C++ API文档.md
+++ b/C++ API文档.md
@@ -607,7 +607,7 @@ auto nodes = dlcv_infer::Model::GetLastFlowNodeTimings();
 
 ### 20.1 公开面
 
-`Model` 暴露字段 `modelIndex`、`OwnModelIndex`；公开构造为默认构造、`Model(const std::string&, int)`、`Model(const std::wstring&, int)`；禁用拷贝、支持移动；公开成员函数为 `FreeModel()`、`GetModelInfo()`、`Infer()`、`InferBatch()`、`InferOneOutJson()`、`GetLastInferTiming()`、`GetLastFlowNodeTimings()`。
+`Model` 暴露字段 `modelIndex`、`OwnModelIndex`；公开构造为默认构造、`Model(const std::string&, int)`、`Model(const std::wstring&, int)`；禁用拷贝、支持移动；公开成员函数为 `FreeModel()`、`GetModelInfo()`、`Infer()`、`InferBatch()`、`InferOneOutJson()`、`GetLastInferTiming()`、`GetLastFlowNodeTimings()`、`GetLastInspectionStatus()`。
 
 ### 20.2 加载、释放与信息查询
 
@@ -619,7 +619,7 @@ auto nodes = dlcv_infer::Model::GetLastFlowNodeTimings();
 
 ### 20.4 推理、结果与计时
 
-普通模型请求固定组装 `model_index + image_list` 后调用底层推理，`code!=0` 时抛异常。结构化包装阶段会自动补推断 `with_bbox`、`with_angle`，读取 `with_mean`、`foreground_mean`、`background_mean`，并对 `mask` 做 `clone()`、必要时缩放或反推框。`InferOneOutJson()` 只返回首张图结果；最近一次计时保存在线程局部变量中，FlowGraph 模式优先使用流程返回的 `timing`。
+普通模型请求固定组装 `model_index + image_list` 后调用底层推理，`code!=0` 时抛异常。结构化包装阶段会自动补推断 `with_bbox`、`with_angle`，读取 `with_mean`、`foreground_mean`、`background_mean`，并对 `mask` 做 `clone()`、必要时缩放或反推框。`InferOneOutJson()` 只返回首张图结果；未产生流程判定时返回原结果数组，产生判定时返回 `{"result_list":[...],"ok":true|false,"reason":null|[...]}`。最近一次计时和流程判定状态保存在当前线程；`GetLastInspectionStatus(bool&, std::vector<std::string>&, size_t)` 按图片索引读取最近一次 `Infer`、`InferBatch` 或 `InferOneOutJson` 的状态，未产生状态时返回 `false`。FlowGraph 模式的计时优先使用流程返回的 `timing`。
 
 ---
 
@@ -643,7 +643,7 @@ auto nodes = dlcv_infer::Model::GetLastFlowNodeTimings();
 
 ### 23.2 `FlowGraphModel`
 
-`FlowGraphModel` 公开接口为 `IsLoaded()`、`Load()`、`GetModelInfo()`、`InferOneOutJson()`、`InferInternal()`、`Benchmark()`，禁用拷贝、支持移动。`Load()` 从 UTF-8 流程 JSON 读取 `nodes` 并只预加载 `model/*` 节点；`InferInternal()` 在上下文中写入前端图像、设备和参数后返回 `result_list` 与 `timing`；清理阶段只清 `ModelPool`，不调用 `Utils::FreeAllModels()`。
+`FlowGraphModel` 公开接口为 `IsLoaded()`、`Load()`、`GetModelInfo()`、`InferOneOutJson()`、`InferInternal()`、`Benchmark()`，禁用拷贝、支持移动。`Load()` 从 UTF-8 流程 JSON 读取 `nodes` 并只预加载 `model/*` 节点；`InferInternal()` 在上下文中写入前端图像、设备和参数后返回 `result_list` 与 `timing`，并保留按图 `ok/reason`；清理阶段只清 `ModelPool`，不调用 `Utils::FreeAllModels()`。
 
 ### 23.3 `ExecutionContext`
 
@@ -655,7 +655,7 @@ auto nodes = dlcv_infer::Model::GetLastFlowNodeTimings();
 
 ### 23.5 Flow 结果聚合
 
-聚合读取优先级为 `frontend_payloads_by_node -> frontend_json.by_node -> frontend_json_by_node -> frontend_json.last -> frontend_payload_last`。单图时 `result_list` 直接是结果数组，多图时为 `[{ "result_list": [...] }, ...]`。
+聚合读取优先级为 `frontend_payloads_by_node -> frontend_json.by_node -> frontend_json_by_node -> frontend_json.last -> frontend_payload_last`。单图时 `result_list` 直接是结果数组，存在流程判定时根对象同时包含 `ok/reason`；多图时为 `[{ "result_list": [...], "ok": ..., "reason": ... }, ...]`，未产生判定状态的图片不增加这些字段。
 
 ### 23.6 已注册 Flow 节点
 

--- a/C++测试程序开发文档.md
+++ b/C++测试程序开发文档.md
@@ -68,6 +68,7 @@ dlcv_infer_cpp_qt_demo.exe --help
 - 普通模型使用 `--threshold` 作为推理阈值；流程模型保留各模型节点自身的阈值，`--threshold` 只对最终对外结果进行筛选。
 - 图片由 `QFile` 读取字节并通过 `cv::imdecode` 解码；BGR/BGRA 转为 RGB。
 - 同一次命令分别调用 `Infer` 与 `InferOneOutJson`，输出字段与 C# 测试程序一致；开启均值计算时同时检查两种结果的均值字段。
+- 输出中的 `inspection` 包含最近一次流程判定的 `present`、`ok`、`reason`，`inspection_consistent` 检查结构化与 JSON 两条路径的判定一致性。
 - C++ 结构化结果的本地 GBK 类别名在 CLI 边界转换为 UTF-8，再写入 JSON。
 - `--output` 使用 `QSaveFile` 原子写入 UTF-8 JSON；该路径不得覆盖模型或图片，父目录必须存在。
 - 退出码：`0` 为验证通过，`1` 为运行异常，`2` 为参数错误，`3` 为双路径不一致、存在低于阈值的结果或均值检查失败。
@@ -121,8 +122,8 @@ dlcv_infer_cpp_qt_demo.exe --help
 1. 点击 **打开图片推理**，选择图片（`jpg/jpeg/png/bmp/gif/tiff/tif`）。
 2. 图像经过 `prepareImageForInference` 转换为 RGB。
 3. 调用 `model->InferBatch()` 执行推理。
-4. 结果在文本区显示（数量、每个目标的类别、score、bbox、area、angle，以及可用的前景与背景均值）。
-5. 图像区显示可视化结果（bbox 框 + mask 叠加）。
+4. 结果在文本区显示（数量、每个目标的类别、score、bbox、area、angle，以及可用的前景与背景均值）；流程失败原因存在时显示在预测结果下方。
+5. 图像区显示可视化结果（bbox 框 + mask 叠加）；流程判定存在时左上角显示带阴影方块的绿色 `OK` 或红色 `NG`。
 
 **代码路径**：`MainWindow::onInfer()`
 - `prepareImageForInference`：将 OpenCV 读到的 BGR/BGRA 转换为 RGB。
@@ -132,7 +133,7 @@ dlcv_infer_cpp_qt_demo.exe --help
 ### 4.3 JSON 输出测试
 
 1. 点击 **推理JSON**。
-2. 调用 `model->InferOneOutJson()` 获取 JSON 数组结果。
+2. 调用 `model->InferOneOutJson()` 获取 JSON；未产生流程判定时为结果数组，产生判定时为包含 `result_list/ok/reason` 的包装对象。
 3. 文本区显示格式化的 JSON（缩进 4）。
 
 **代码路径**：`MainWindow::onInferJson()`

--- a/DlcvCsharpApi/DataTypes.cs
+++ b/DlcvCsharpApi/DataTypes.cs
@@ -166,9 +166,28 @@ namespace dlcv_infer_csharp
             /// </summary>
             public List<CSharpObjectResult> Results { get; set; }
 
+            /// <summary>
+            /// 流程判定状态；未配置判定模块时为 null。
+            /// </summary>
+            public bool? Ok { get; set; }
+
+            /// <summary>
+            /// 流程判定原因；没有原因时为 null。
+            /// </summary>
+            public string Reason { get; set; }
+
             public CSharpSampleResult(List<CSharpObjectResult> results)
             {
                 Results = results;
+                Ok = null;
+                Reason = null;
+            }
+
+            public CSharpSampleResult(List<CSharpObjectResult> results, bool? ok, string reason)
+            {
+                Results = results;
+                Ok = ok;
+                Reason = reason;
             }
 
             public override String ToString()

--- a/DlcvCsharpApi/DlcvCsharpApi.csproj
+++ b/DlcvCsharpApi/DlcvCsharpApi.csproj
@@ -91,6 +91,7 @@
     <Compile Include="flow\modules\Visualize.cs" />
     <Compile Include="flow\modules\MaskRleUtils.cs" />
     <Compile Include="flow\modules\ComponentSizeMeasure.cs" />
+    <Compile Include="flow\modules\CategoryCountCheck.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="sntl_admin_csharp.cs" />
     <Compile Include="sequence\Schemas.cs" />

--- a/DlcvCsharpApi/Model.cs
+++ b/DlcvCsharpApi/Model.cs
@@ -2220,7 +2220,11 @@ namespace dlcv_infer_csharp
                     // DVS 流程的 JSON 输出需要 poly，必须走 InferOneOutJson（emitPoly=true）。
                     // InferInternal 默认 emitPoly=false，会导致 return_json 只输出 mask_rle，
                     // 而 StandardizeJsonOutput 无法识别 mask_rle，从而 with_mask 被置为 false。
-                    rawResults = _dvsModel.InferOneOutJson(normalized[0], params_json) as JArray ?? new JArray();
+                    JToken dvsJson = _dvsModel.InferOneOutJson(normalized[0], params_json) as JToken;
+                    var dvsContainer = dvsJson as JObject;
+                    rawResults = dvsJson as JArray
+                        ?? (dvsContainer != null ? dvsContainer["result_list"] as JArray : null)
+                        ?? new JArray();
 
                     // DVS 模式下不需要释放非托管资源，直接处理
                     var finalResults = new JArray();
@@ -2231,6 +2235,29 @@ namespace dlcv_infer_csharp
                             finalResults.Add(StandardizeJsonOutput(obj, false));
                         }
                     }
+
+                    if (dvsContainer != null &&
+                        (dvsContainer.ContainsKey("ok") || dvsContainer.ContainsKey("reason")))
+                    {
+                        var payload = new JObject
+                        {
+                            ["result_list"] = finalResults
+                        };
+                        if (dvsContainer.ContainsKey("ok"))
+                        {
+                            payload["ok"] = dvsContainer["ok"] != null
+                                ? dvsContainer["ok"].DeepClone()
+                                : JValue.CreateNull();
+                        }
+                        if (dvsContainer.ContainsKey("reason"))
+                        {
+                            payload["reason"] = dvsContainer["reason"] != null
+                                ? dvsContainer["reason"].DeepClone()
+                                : JValue.CreateNull();
+                        }
+                        return payload;
+                    }
+
                     return finalResults;
                 }
                 finally

--- a/DlcvCsharpApi/Properties/AssemblyInfo.cs
+++ b/DlcvCsharpApi/Properties/AssemblyInfo.cs
@@ -29,6 +29,6 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.8.20.0")]
-[assembly: AssemblyFileVersion("2026.8.20.0")]
-[assembly: AssemblyInformationalVersion("2026.8.20.0")]
+[assembly: AssemblyVersion("2026.8.20.1")]
+[assembly: AssemblyFileVersion("2026.8.20.1")]
+[assembly: AssemblyInformationalVersion("2026.8.20.1")]

--- a/DlcvCsharpApi/flow/FlowGraphModel.cs
+++ b/DlcvCsharpApi/flow/FlowGraphModel.cs
@@ -252,12 +252,14 @@ namespace DlcvModules
 
                 // 从 output/return_json 读取每张图结果
                 var perImageResults = new List<JArray>();
+                var perImageStatus = new List<JObject>();
                 for (int i = 0; i < images.Count; i++)
                 {
                     perImageResults.Add(new JArray());
+                    perImageStatus.Add(new JObject());
                 }
 
-                AggregateFrontendResults(ctx, perImageResults);
+                AggregateFrontendResults(ctx, perImageResults, perImageStatus);
                 // 入口阈值只作用于 return_json 汇总后的最终对外结果。
                 ApplyFinalThresholdFilter(perImageResults, paramsJson);
 
@@ -265,16 +267,19 @@ namespace DlcvModules
                 if (images.Count == 1)
                 {
                     root["result_list"] = perImageResults.Count > 0 ? perImageResults[0] : new JArray();
+                    if (perImageStatus.Count > 0) CopyStatusFields(root, perImageStatus[0]);
                 }
                 else
                 {
                     var batchContainer = new JArray();
                     for (int i = 0; i < perImageResults.Count; i++)
                     {
-                        batchContainer.Add(new JObject
+                        var container = new JObject
                         {
                             ["result_list"] = perImageResults[i] ?? new JArray()
-                        });
+                        };
+                        if (i < perImageStatus.Count) CopyStatusFields(container, perImageStatus[i]);
+                        batchContainer.Add(container);
                     }
                     root["result_list"] = batchContainer;
                 }
@@ -318,7 +323,7 @@ namespace DlcvModules
             {
                 var resultToken = tuple.Item1["result_list"];
                 var resultList = resultToken as JArray ?? new JArray();
-                return ConvertFlowResultsToCSharp(resultList, includeMask);
+                return ConvertFlowResultsToCSharp(resultList, includeMask, tuple.Item1);
             }
             finally
             {
@@ -382,6 +387,16 @@ namespace DlcvModules
                 else
                 {
                     resultArray = new JArray();
+                }
+
+                if (resultTuple.Item1.ContainsKey("ok") || resultTuple.Item1.ContainsKey("reason"))
+                {
+                    var payload = new JObject
+                    {
+                        ["result_list"] = resultArray
+                    };
+                    CopyStatusFields(payload, resultTuple.Item1);
+                    return payload;
                 }
 
                 return resultArray;
@@ -455,7 +470,10 @@ namespace DlcvModules
             public Dictionary<string, object> Payload { get; set; }
         }
 
-        private static void AggregateFrontendResults(ExecutionContext ctx, List<JArray> perImageResults)
+        private static void AggregateFrontendResults(
+            ExecutionContext ctx,
+            List<JArray> perImageResults,
+            List<JObject> perImageStatus)
         {
             if (ctx == null || perImageResults == null || perImageResults.Count == 0)
             {
@@ -491,6 +509,10 @@ namespace DlcvModules
                     }
 
                     AppendResultsArray(perImageResults[targetIndex], ExtractResultsArray(item));
+                    if (perImageStatus != null && targetIndex < perImageStatus.Count)
+                    {
+                        MergeStatusFields(perImageStatus[targetIndex], item);
+                    }
                 }
             }
         }
@@ -606,6 +628,90 @@ namespace DlcvModules
 
             // 没有合法 origin_index 时，回退到 by_image 的位置索引并折回。
             return position >= 0 ? (position % imageCount) : -1;
+        }
+
+        private static void CopyStatusFields(JObject target, JObject source)
+        {
+            if (target == null || source == null) return;
+            if (source.ContainsKey("ok"))
+            {
+                target["ok"] = source["ok"] != null ? source["ok"].DeepClone() : JValue.CreateNull();
+            }
+            if (source.ContainsKey("reason"))
+            {
+                target["reason"] = source["reason"] != null ? source["reason"].DeepClone() : JValue.CreateNull();
+            }
+        }
+
+        private static void MergeStatusFields(JObject target, Dictionary<string, object> source)
+        {
+            if (target == null || source == null) return;
+
+            if (source.TryGetValue("ok", out object okValue))
+            {
+                bool? incomingOk = ReadStatusOk(ToStatusToken(okValue));
+                bool? existingOk = ReadStatusOk(target["ok"]);
+                if (incomingOk.HasValue)
+                {
+                    target["ok"] = existingOk.HasValue
+                        ? existingOk.Value && incomingOk.Value
+                        : incomingOk.Value;
+                }
+            }
+
+            if (source.TryGetValue("reason", out object reasonValue))
+            {
+                var reasons = ReadStatusReasons(target["reason"]);
+                var incomingReasons = ReadStatusReasons(ToStatusToken(reasonValue));
+                for (int i = 0; i < incomingReasons.Count; i++)
+                {
+                    if (!reasons.Contains(incomingReasons[i])) reasons.Add(incomingReasons[i]);
+                }
+                target["reason"] = reasons.Count > 0
+                    ? (JToken)new JArray(reasons)
+                    : JValue.CreateNull();
+            }
+        }
+
+        private static JToken ToStatusToken(object value)
+        {
+            if (value == null) return JValue.CreateNull();
+            if (value is JToken token) return token;
+            try { return JToken.FromObject(value); } catch { return new JValue(value.ToString()); }
+        }
+
+        private static bool? ReadStatusOk(JToken token)
+        {
+            if (token == null || token.Type == JTokenType.Null) return null;
+            try { return token.Value<bool>(); } catch { return null; }
+        }
+
+        private static List<string> ReadStatusReasons(JToken token)
+        {
+            var reasons = new List<string>();
+            if (token == null || token.Type == JTokenType.Null) return reasons;
+
+            var array = token as JArray;
+            if (array == null)
+            {
+                string value = token.ToString();
+                if (!string.IsNullOrWhiteSpace(value)) reasons.Add(value);
+                return reasons;
+            }
+
+            for (int i = 0; i < array.Count; i++)
+            {
+                if (array[i] == null || array[i].Type == JTokenType.Null) continue;
+                string value = array[i].ToString();
+                if (!string.IsNullOrWhiteSpace(value) && !reasons.Contains(value)) reasons.Add(value);
+            }
+            return reasons;
+        }
+
+        private static string ReadStatusReason(JToken token)
+        {
+            var reasons = ReadStatusReasons(token);
+            return reasons.Count > 0 ? string.Join("; ", reasons) : null;
         }
 
         private static JArray ExtractResultsArray(Dictionary<string, object> item)
@@ -746,14 +852,18 @@ namespace DlcvModules
             return !double.IsNaN(score) && !double.IsInfinity(score);
         }
 
-        private Utils.CSharpResult ConvertFlowResultsToCSharp(JArray resultList, bool includeMask = true)
+        private Utils.CSharpResult ConvertFlowResultsToCSharp(
+            JArray resultList,
+            bool includeMask = true,
+            JObject rootStatus = null)
         {
             var samples = new List<Utils.CSharpSampleResult>();
             if (resultList == null || resultList.Count == 0)
             {
-                var sample_result = new Utils.CSharpSampleResult();
-                sample_result.Results = new List<Utils.CSharpObjectResult>();
-                samples.Add(sample_result);
+                samples.Add(new Utils.CSharpSampleResult(
+                    new List<Utils.CSharpObjectResult>(),
+                    ReadStatusOk(rootStatus != null ? rootStatus["ok"] : null),
+                    ReadStatusReason(rootStatus != null ? rootStatus["reason"] : null)));
                 return new Utils.CSharpResult(samples);
             }
 
@@ -771,22 +881,31 @@ namespace DlcvModules
                 {
                     var container = token as JObject;
                     var list = container != null ? (container["result_list"] as JArray) : null;
-                    samples.Add(ParseSingleImageResults(list, includeMask));
+                    samples.Add(ParseSingleImageResults(list, includeMask, container));
                 }
             }
             else
             {
                 // Batch=1，resultList 本身就是结果列表
-                samples.Add(ParseSingleImageResults(resultList, includeMask));
+                samples.Add(ParseSingleImageResults(resultList, includeMask, rootStatus));
             }
 
             return new Utils.CSharpResult(samples);
         }
 
-        private Utils.CSharpSampleResult ParseSingleImageResults(JArray list, bool includeMask = true)
+        private Utils.CSharpSampleResult ParseSingleImageResults(
+            JArray list,
+            bool includeMask = true,
+            JObject status = null)
         {
             var objects = new List<Utils.CSharpObjectResult>();
-            if (list == null) return new Utils.CSharpSampleResult(objects);
+            if (list == null)
+            {
+                return new Utils.CSharpSampleResult(
+                    objects,
+                    ReadStatusOk(status != null ? status["ok"] : null),
+                    ReadStatusReason(status != null ? status["reason"] : null));
+            }
 
             foreach (var token in list)
             {
@@ -804,7 +923,10 @@ namespace DlcvModules
                     ParseNewFormatEntry(entry, objects, includeMask);
                 }
             }
-            return new Utils.CSharpSampleResult(objects);
+            return new Utils.CSharpSampleResult(
+                objects,
+                ReadStatusOk(status != null ? status["ok"] : null),
+                ReadStatusReason(status != null ? status["reason"] : null));
         }
         private void ParseNewFormatEntry(JObject entry, List<Utils.CSharpObjectResult> objects, bool includeMask = true)
         {

--- a/DlcvCsharpApi/flow/modules/CategoryCountCheck.cs
+++ b/DlcvCsharpApi/flow/modules/CategoryCountCheck.cs
@@ -1,0 +1,279 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using Newtonsoft.Json.Linq;
+
+namespace DlcvModules
+{
+    /// <summary>
+    /// post_process/category_count_check：按原图汇总 local 结果后按类别校验数量。
+    /// </summary>
+    public class CategoryCountCheck : BaseModule
+    {
+        static CategoryCountCheck()
+        {
+            ModuleRegistry.Register("post_process/category_count_check", typeof(CategoryCountCheck));
+        }
+
+        public CategoryCountCheck(
+            int nodeId,
+            string title = null,
+            Dictionary<string, object> properties = null,
+            ExecutionContext context = null)
+            : base(nodeId, title, properties, context)
+        {
+        }
+
+        public override ModuleIO Process(List<ModuleImage> imageList = null, JArray resultList = null)
+        {
+            var images = imageList ?? new List<ModuleImage>();
+            var results = resultList ?? new JArray();
+            var rules = ParseRules();
+            bool allOk = true;
+            var allReasons = new List<string>();
+
+            var groups = new Dictionary<int, List<JObject>>();
+            var groupOrder = new List<int>();
+            foreach (JToken token in results)
+            {
+                var entry = token as JObject;
+                if (entry == null || !string.Equals(entry["type"]?.ToString(), "local", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                int key = ResolveGroupKey(entry);
+                if (!groups.TryGetValue(key, out List<JObject> entries))
+                {
+                    entries = new List<JObject>();
+                    groups[key] = entries;
+                    groupOrder.Add(key);
+                }
+                entries.Add(entry);
+            }
+
+            for (int groupIndex = 0; groupIndex < groupOrder.Count; groupIndex++)
+            {
+                List<JObject> entries = groups[groupOrder[groupIndex]];
+                var detections = new JArray();
+                for (int i = 0; i < entries.Count; i++)
+                {
+                    var entryDetections = entries[i]["sample_results"] as JArray;
+                    if (entryDetections == null) continue;
+                    foreach (JToken detection in entryDetections)
+                    {
+                        detections.Add(detection);
+                    }
+                }
+
+                bool moduleOk = true;
+                var groupReasons = new List<string>();
+                for (int i = 0; i < rules.Count; i++)
+                {
+                    Rule rule = rules[i];
+                    int count = CountMatching(detections, rule.Category);
+                    if (!Evaluate(count, rule.Operator, rule.Expect))
+                    {
+                        moduleOk = false;
+                        groupReasons.Add(FormatReason(rule.Category, rule.Operator, rule.Expect, count));
+                    }
+                }
+
+                for (int i = 0; i < entries.Count; i++)
+                {
+                    JObject entry = entries[i];
+                    bool? existingOk = ReadNullableBool(entry["ok"]);
+                    var entryReasons = ReadExistingReasons(entry["reason"]);
+                    bool entryOk = existingOk.HasValue
+                        ? (moduleOk ? existingOk.Value : false)
+                        : moduleOk;
+
+                    if (!moduleOk)
+                    {
+                        for (int reasonIndex = 0; reasonIndex < groupReasons.Count; reasonIndex++)
+                        {
+                            AddUnique(entryReasons, groupReasons[reasonIndex]);
+                        }
+                    }
+
+                    entry["ok"] = entryOk;
+                    entry["reason"] = entryReasons.Count > 0
+                        ? (JToken)new JArray(entryReasons)
+                        : JValue.CreateNull();
+
+                    if (!entryOk)
+                    {
+                        allOk = false;
+                        for (int reasonIndex = 0; reasonIndex < entryReasons.Count; reasonIndex++)
+                        {
+                            AddUnique(allReasons, entryReasons[reasonIndex]);
+                        }
+                    }
+                }
+            }
+
+            ScalarOutputsByName["ok"] = allOk;
+            ScalarOutputsByName["reason"] = allReasons.Count > 0
+                ? string.Join("; ", allReasons)
+                : string.Empty;
+
+            return new ModuleIO(images, results);
+        }
+
+        private List<Rule> ParseRules()
+        {
+            if (Properties == null || !Properties.TryGetValue("rules", out object raw) || raw == null)
+            {
+                return new List<Rule>();
+            }
+
+            JArray array = null;
+            if (raw is string text)
+            {
+                try { array = JArray.Parse(text); } catch { return new List<Rule>(); }
+            }
+            else if (raw is JArray jArray)
+            {
+                array = jArray;
+            }
+            else if (raw is IEnumerable && !(raw is string))
+            {
+                try { array = JArray.FromObject(raw); } catch { return new List<Rule>(); }
+            }
+
+            var rules = new List<Rule>();
+            if (array == null) return rules;
+
+            foreach (JToken token in array)
+            {
+                var item = token as JObject;
+                if (item == null) continue;
+
+                string category = item["category"] == null || item["category"].Type == JTokenType.Null
+                    ? string.Empty
+                    : item["category"].ToString();
+                string op = item["operator"] == null || item["operator"].Type == JTokenType.Null
+                    ? "equal"
+                    : item["operator"].ToString();
+                if (op != "equal" && op != "gt" && op != "lt")
+                {
+                    op = "equal";
+                }
+
+                int expect;
+                try
+                {
+                    JToken expectToken = item["expect"];
+                    double rawExpect = expectToken == null || expectToken.Type == JTokenType.Null
+                        ? 0.0
+                        : Convert.ToDouble(expectToken.ToString(), CultureInfo.InvariantCulture);
+                    expect = Math.Max(0, (int)rawExpect);
+                }
+                catch
+                {
+                    expect = 1;
+                }
+
+                rules.Add(new Rule(category, op, expect));
+            }
+            return rules;
+        }
+
+        private static int ResolveGroupKey(JObject entry)
+        {
+            int originIndex = ReadNonNegativeInt(entry["origin_index"]);
+            if (originIndex >= 0) return originIndex;
+            int index = ReadNonNegativeInt(entry["index"]);
+            return index >= 0 ? index : -1;
+        }
+
+        private static int ReadNonNegativeInt(JToken token)
+        {
+            try
+            {
+                int value = token != null ? token.Value<int>() : -1;
+                return value >= 0 ? value : -1;
+            }
+            catch
+            {
+                return -1;
+            }
+        }
+
+        private static int CountMatching(JArray detections, string category)
+        {
+            int count = 0;
+            foreach (JToken token in detections)
+            {
+                var detection = token as JObject;
+                if (detection == null) continue;
+                if (string.IsNullOrEmpty(category) ||
+                    string.Equals(detection["category_name"]?.ToString(), category, StringComparison.Ordinal))
+                {
+                    count++;
+                }
+            }
+            return count;
+        }
+
+        private static bool Evaluate(int count, string op, int expect)
+        {
+            if (op == "gt") return count > expect;
+            if (op == "lt") return count < expect;
+            return count == expect;
+        }
+
+        private static string FormatReason(string category, string op, int expect, int actual)
+        {
+            string displayCategory = string.IsNullOrEmpty(category) ? "全部类别" : category;
+            string opLabel = op == "gt" ? ">" : op == "lt" ? "<" : "=";
+            return "类别" + displayCategory + "期望" + opLabel + expect + ",实际" + actual;
+        }
+
+        private static List<string> ReadExistingReasons(JToken token)
+        {
+            var reasons = new List<string>();
+            if (token == null || token.Type == JTokenType.Null) return reasons;
+            var array = token as JArray;
+            if (array == null)
+            {
+                reasons.Add(token.ToString());
+                return reasons;
+            }
+            foreach (JToken item in array)
+            {
+                if (item != null && item.Type != JTokenType.Null)
+                {
+                    reasons.Add(item.ToString());
+                }
+            }
+            return reasons;
+        }
+
+        private static bool? ReadNullableBool(JToken token)
+        {
+            if (token == null || token.Type == JTokenType.Null) return null;
+            try { return token.Value<bool>(); } catch { return null; }
+        }
+
+        private static void AddUnique(List<string> values, string value)
+        {
+            if (!values.Contains(value)) values.Add(value);
+        }
+
+        private sealed class Rule
+        {
+            public string Category { get; private set; }
+            public string Operator { get; private set; }
+            public int Expect { get; private set; }
+
+            public Rule(string category, string op, int expect)
+            {
+                Category = category;
+                Operator = op;
+                Expect = expect;
+            }
+        }
+    }
+}

--- a/DlcvCsharpApi/flow/modules/Outputs.cs
+++ b/DlcvCsharpApi/flow/modules/Outputs.cs
@@ -140,6 +140,18 @@ namespace DlcvModules
                 : BuildByImageMapped(images, results, emitPoly);
 
             var payload = new Dictionary<string, object> { { "by_image", byImage } };
+            var okValues = new List<bool>();
+            for (int i = 0; i < byImage.Count; i++)
+            {
+                if (byImage[i] != null && byImage[i].TryGetValue("ok", out object okValue) && okValue != null)
+                {
+                    try { okValues.Add(Convert.ToBoolean(okValue)); } catch { }
+                }
+            }
+            if (okValues.Count > 0)
+            {
+                payload["okng"] = okValues.TrueForAll(x => x) ? "OK" : "NG";
+            }
 
             // 写入 Context
             if (Context != null)
@@ -235,7 +247,7 @@ namespace DlcvModules
                 var entry = results[i] as JObject;
                 var dets = entry != null ? entry["sample_results"] as JArray : null;
                 var outResults = BuildOutResults(wrap, dets, emitPoly);
-                byImage.Add(BuildImageEntry(wrap, outResults));
+                byImage.Add(BuildImageEntry(wrap, outResults, entry));
             }
             return byImage;
         }
@@ -252,18 +264,23 @@ namespace DlcvModules
             var transToDets = new Dictionary<string, List<JObject>>(Math.Max(1, results.Count));
             var indexToDets = new Dictionary<int, List<JObject>>(Math.Max(1, results.Count));
             var originToDets = new Dictionary<int, List<JObject>>(Math.Max(1, results.Count));
+            var indexToMeta = new Dictionary<int, JObject>(Math.Max(1, results.Count));
+            var originToMeta = new Dictionary<int, JObject>(Math.Max(1, results.Count));
+            var transToMeta = new Dictionary<string, JObject>(Math.Max(1, results.Count));
 
             foreach (var entryToken in results)
             {
                 var entry = entryToken as JObject;
                 if (entry == null || !string.Equals(entry["type"]?.ToString(), "local", StringComparison.OrdinalIgnoreCase)) continue;
 
-                var dets = entry["sample_results"] as JArray;
-                if (dets == null || dets.Count == 0) continue;
-
+                var dets = entry["sample_results"] as JArray ?? new JArray();
                 int idx = entry["index"]?.Value<int?>() ?? -1;
                 int oidx = entry["origin_index"]?.Value<int?>() ?? -1;
                 string tSig = SerializeTransformKey(entry["transform"] as JObject);
+                if (idx >= 0) indexToMeta[idx] = entry;
+                if (oidx >= 0) originToMeta[oidx] = entry;
+                if (!string.IsNullOrEmpty(tSig)) MergeTransformMetadata(transToMeta, tSig, entry);
+                if (dets.Count == 0) continue;
 
                 List<JObject> idxBucket = idx >= 0 ? GetOrCreateDetBucket(indexToDets, idx) : null;
                 List<JObject> orgBucket = oidx >= 0 ? GetOrCreateDetBucket(originToDets, oidx) : null;
@@ -285,6 +302,7 @@ namespace DlcvModules
                 if (wrap == null) continue;
 
                 List<JObject> dets = null;
+                JObject metadata = null;
                 if (!indexToDets.TryGetValue(i, out dets))
                 {
                     if (!originToDets.TryGetValue(wrap.OriginalIndex, out dets))
@@ -293,9 +311,17 @@ namespace DlcvModules
                         if (sig != null) transToDets.TryGetValue(sig, out dets);
                     }
                 }
+                if (!indexToMeta.TryGetValue(i, out metadata))
+                {
+                    if (!originToMeta.TryGetValue(wrap.OriginalIndex, out metadata))
+                    {
+                        string sig = SerializeTransformKey(wrap.TransformState);
+                        if (sig != null) transToMeta.TryGetValue(sig, out metadata);
+                    }
+                }
 
                 var outResults = BuildOutResults(wrap, dets, emitPoly);
-                byImage.Add(BuildImageEntry(wrap, outResults));
+                byImage.Add(BuildImageEntry(wrap, outResults, metadata));
             }
 
             return byImage;
@@ -311,17 +337,82 @@ namespace DlcvModules
             return list;
         }
 
-        private static Dictionary<string, object> BuildImageEntry(ModuleImage wrap, List<Dictionary<string, object>> outResults)
+        private static void MergeTransformMetadata(Dictionary<string, JObject> map, string key, JObject source)
+        {
+            if (map == null || string.IsNullOrEmpty(key) || source == null ||
+                (!source.ContainsKey("ok") && !source.ContainsKey("reason")))
+            {
+                return;
+            }
+
+            if (!map.TryGetValue(key, out JObject target))
+            {
+                target = new JObject();
+                map[key] = target;
+            }
+
+            if (source.ContainsKey("ok") && bool.TryParse(source["ok"]?.ToString(), out bool incomingOk))
+            {
+                target["ok"] = bool.TryParse(target["ok"]?.ToString(), out bool existingOk)
+                    ? existingOk && incomingOk
+                    : incomingOk;
+            }
+
+            if (source.ContainsKey("reason"))
+            {
+                var reasons = new JArray();
+                AppendUniqueReasons(reasons, target["reason"]);
+                AppendUniqueReasons(reasons, source["reason"]);
+                target["reason"] = reasons.Count > 0 ? (JToken)reasons : JValue.CreateNull();
+            }
+        }
+
+        private static void AppendUniqueReasons(JArray target, JToken value)
+        {
+            if (target == null || value == null || value.Type == JTokenType.Null) return;
+            var values = value as JArray ?? new JArray(value);
+            foreach (var item in values)
+            {
+                string reason = item?.ToString();
+                if (string.IsNullOrWhiteSpace(reason)) continue;
+                bool exists = false;
+                foreach (var existing in target)
+                {
+                    if (string.Equals(existing?.ToString(), reason, StringComparison.Ordinal))
+                    {
+                        exists = true;
+                        break;
+                    }
+                }
+                if (!exists) target.Add(reason);
+            }
+        }
+
+        private static Dictionary<string, object> BuildImageEntry(
+            ModuleImage wrap,
+            List<Dictionary<string, object>> outResults,
+            JObject metadata)
         {
             var ori = wrap.OriginalImage ?? wrap.ImageObject;
             int w0 = ori != null ? ori.Width : 0;
             int h0 = ori != null ? ori.Height : 0;
-            return new Dictionary<string, object>
+            var item = new Dictionary<string, object>
             {
                 ["origin_index"] = wrap.OriginalIndex,
                 ["original_size"] = new int[] { w0, h0 },
                 ["results"] = outResults ?? new List<Dictionary<string, object>>()
             };
+            if (metadata != null && metadata.ContainsKey("ok"))
+            {
+                item["ok"] = metadata["ok"] != null ? metadata["ok"].ToObject<object>() : null;
+            }
+            if (metadata != null && metadata.ContainsKey("reason"))
+            {
+                item["reason"] = metadata["reason"] != null
+                    ? metadata["reason"].DeepClone()
+                    : JValue.CreateNull();
+            }
+            return item;
         }
 
         private static List<Dictionary<string, object>> BuildOutResults(ModuleImage wrap, JArray dets, bool emitPoly)

--- a/DlcvDemo/CliRunner.cs
+++ b/DlcvDemo/CliRunner.cs
@@ -176,10 +176,12 @@ namespace DlcvDemo
                 }
 
                 object rawJsonResult = model.InferOneOutJson(inferImage, (JObject)inferParams.DeepClone());
-                var jsonResults = rawJsonResult as JArray;
+                var jsonContainer = rawJsonResult as JObject;
+                var jsonResults = rawJsonResult as JArray
+                    ?? (jsonContainer != null ? jsonContainer["result_list"] as JArray : null);
                 if (jsonResults == null)
                 {
-                    throw new InvalidOperationException("InferOneOutJson 未返回 JSON 数组。");
+                    throw new InvalidOperationException("InferOneOutJson 未返回有效的结果数组。");
                 }
 
                 PathSummary jsonSummary = BuildJsonSummary(jsonResults, options.Threshold);

--- a/DlcvDemo/Form1.cs
+++ b/DlcvDemo/Form1.cs
@@ -531,9 +531,11 @@ namespace DlcvDemo
                 sb.AppendLine($"推理时间: {delay_ms:F2}ms");
 
                 List<CSharpObjectResult> objects = null;
+                string reason = null;
                 if (result.SampleResults != null && result.SampleResults.Count > 0)
                 {
                     objects = result.SampleResults[0].Results;
+                    reason = result.SampleResults[0].Reason;
                 }
                 if (objects == null)
                 {
@@ -541,6 +543,10 @@ namespace DlcvDemo
                 }
 
                 sb.AppendLine($"推理结果: {objects.Count}个");
+                if (!string.IsNullOrWhiteSpace(reason))
+                {
+                    sb.AppendLine("原因: " + reason);
+                }
                 if (objects.Count == 0)
                 {
                     sb.AppendLine("未检测到目标。");

--- a/DlcvDemo/MainWindow.xaml.cs
+++ b/DlcvDemo/MainWindow.xaml.cs
@@ -626,9 +626,11 @@ namespace DlcvDemo
                 sb.AppendLine($"推理时间: {delay_ms:F2}ms");
 
                 List<CSharpObjectResult> objects = null;
+                string reason = null;
                 if (result.SampleResults != null && result.SampleResults.Count > 0)
                 {
                     objects = result.SampleResults[0].Results;
+                    reason = result.SampleResults[0].Reason;
                 }
                 if (objects == null)
                 {
@@ -636,6 +638,10 @@ namespace DlcvDemo
                 }
 
                 sb.AppendLine($"推理结果: {objects.Count}个");
+                if (!string.IsNullOrWhiteSpace(reason))
+                {
+                    sb.AppendLine("原因: " + reason);
+                }
                 if (objects.Count == 0)
                 {
                     sb.AppendLine("未检测到目标。");

--- a/DlcvDemo/Properties/AssemblyInfo.cs
+++ b/DlcvDemo/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.8.20.0")]
-[assembly: AssemblyFileVersion("2026.8.20.0")]
-[assembly: AssemblyInformationalVersion("2026.8.20.0")]
+[assembly: AssemblyVersion("2026.8.20.1")]
+[assembly: AssemblyFileVersion("2026.8.20.1")]
+[assembly: AssemblyInformationalVersion("2026.8.20.1")]
 [assembly: NeutralResourcesLanguage("zh-CN")]

--- a/ImageViewer/ImageViewer.cs
+++ b/ImageViewer/ImageViewer.cs
@@ -426,7 +426,25 @@ namespace DLCV
 
         public void DrawResults(PaintEventArgs e)
         {
-            if (currentResults == null || !ShowVisualization) return;
+            if (currentResults == null) return;
+
+            var sampleResults = currentResults.Value.SampleResults;
+            bool? statusOk = sampleResults != null && sampleResults.Count > 0
+                ? sampleResults[0].Ok
+                : null;
+            string legacyStatusText = "OK";
+            bool drawLegacyStatus = ShowStatusText;
+            if (!statusOk.HasValue && (sampleResults == null || sampleResults.Count == 0))
+            {
+                legacyStatusText = "No Result";
+                drawLegacyStatus = true;
+            }
+
+            if (!ShowVisualization)
+            {
+                if (statusOk.HasValue) DrawStatusBadge(e.Graphics, statusOk.Value);
+                return;
+            }
 
             float borderWidth = Math.Max(1, 2 / _scale); // 更细的边框
 
@@ -435,17 +453,11 @@ namespace DLCV
             float baseFontPx = VisualizationBaseFontSize;
             float screenFontPx = Math.Min(Math.Max(baseFontPx * _scale, baseFontPx), MaxFontPx) * _labelFontScale;
             float fontSize = Math.Max(VisualizationMinFontSize, screenFontPx / _scale);
-            string _statusText = "OK";
 
             // 遍历结构体的嵌套结构
-            if (currentResults.Value.SampleResults.Count == 0)
+            if (sampleResults != null && sampleResults.Count > 0)
             {
-                _statusText = "No Result";
-                ShowStatusText = true;
-            }
-            else
-            {
-                var sampleResult = currentResults.Value.SampleResults[0];
+                var sampleResult = sampleResults[0];
                 int topLeftLabelIndex = 0;
                 float safeScale = Math.Max(_scale, 1e-6f);
                 float topLeftPadding = Math.Max(2f, 10f / safeScale);
@@ -473,9 +485,10 @@ namespace DLCV
                     }
                     // 其他情况保持默认红色
 
-                    // 判断是否显示NG状态
-                    if (!categoryNameLower.Contains("ok"))
-                        _statusText = "NG";
+                    if (!statusOk.HasValue && !categoryNameLower.Contains("ok"))
+                    {
+                        legacyStatusText = "NG";
+                    }
 
                     if (!hasBbox)
                     {
@@ -649,17 +662,64 @@ namespace DLCV
 
             }
 
-            // 绘制状态文本
-            if (ShowStatusText)
+            if (statusOk.HasValue)
             {
-                var originalTransform = e.Graphics.Transform;
-                e.Graphics.ResetTransform();
-                using (Font font = new Font("微软雅黑", 24))
-                using (SolidBrush brush = new SolidBrush(_statusText == "OK" ? Color.Green : Color.Red))
+                DrawStatusBadge(e.Graphics, statusOk.Value);
+            }
+            else if (drawLegacyStatus)
+            {
+                DrawLegacyStatusText(e.Graphics, legacyStatusText);
+            }
+        }
+
+        private static void DrawLegacyStatusText(Graphics graphics, string statusText)
+        {
+            var state = graphics.Save();
+            try
+            {
+                graphics.ResetTransform();
+                using (var font = new Font("微软雅黑", 24))
+                using (var brush = new SolidBrush(statusText == "OK" ? Color.Green : Color.Red))
                 {
-                    e.Graphics.DrawString(_statusText, font, brush, 10, 10);
+                    graphics.DrawString(statusText, font, brush, 10, 10);
                 }
-                e.Graphics.Transform = originalTransform;
+            }
+            finally
+            {
+                graphics.Restore(state);
+            }
+        }
+
+        private static void DrawStatusBadge(Graphics graphics, bool ok)
+        {
+            var state = graphics.Save();
+            try
+            {
+                graphics.ResetTransform();
+                graphics.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.AntiAlias;
+
+                const float left = 10f;
+                const float top = 10f;
+                const float width = 128f;
+                const float height = 80f;
+                var badgeRect = new RectangleF(left, top, width, height);
+
+                using (var backgroundBrush = new SolidBrush(Color.FromArgb(230, 72, 72, 72)))
+                using (var font = new Font("Microsoft YaHei", 32f, FontStyle.Bold, GraphicsUnit.Pixel))
+                using (var textBrush = new SolidBrush(ok ? Color.Green : Color.Red))
+                using (var format = new StringFormat
+                {
+                    Alignment = StringAlignment.Center,
+                    LineAlignment = StringAlignment.Center
+                })
+                {
+                    graphics.FillRectangle(backgroundBrush, badgeRect);
+                    graphics.DrawString(ok ? "OK" : "NG", font, textBrush, badgeRect, format);
+                }
+            }
+            finally
+            {
+                graphics.Restore(state);
             }
         }
 

--- a/Test/DlcvCSharpTest/Program.cs
+++ b/Test/DlcvCSharpTest/Program.cs
@@ -88,6 +88,11 @@ namespace DlcvCSharpTest
                     return RunCountResultsSelfTest();
                 }
 
+                if (args != null && args.Length >= 1 && string.Equals(args[0], "category-count-check-selftest", StringComparison.OrdinalIgnoreCase))
+                {
+                    return RunCategoryCountCheckSelfTest();
+                }
+
                 if (args != null && args.Length >= 1 && string.Equals(args[0], "template-count-priority-selftest", StringComparison.OrdinalIgnoreCase))
                 {
                     return RunTemplateCountPrioritySelfTest();
@@ -2180,6 +2185,368 @@ namespace DlcvCSharpTest
 
             Console.WriteLine("BBOX IoU 去重自测通过");
             return 0;
+        }
+
+        private static int RunCategoryCountCheckSelfTest()
+        {
+            Console.WriteLine("==== 类型数量校验自测 ====");
+
+            _ = new GraphExecutor(new List<Dictionary<string, object>>());
+            Type moduleType = ModuleRegistry.Get("post_process/category_count_check");
+            if (moduleType == null)
+            {
+                Console.WriteLine("post_process/category_count_check 未注册");
+                return 1;
+            }
+
+            using (var image = new Mat(100, 120, MatType.CV_8UC3, Scalar.Black))
+            {
+                var images = new List<ModuleImage>
+                {
+                    new ModuleImage(image, image, new TransformationState(120, 100), 0)
+                };
+
+                if (!VerifyCategoryCountCase(
+                    moduleType,
+                    new JArray
+                    {
+                        new JObject
+                        {
+                            ["category"] = "黑块",
+                            ["operator"] = "equal",
+                            ["expect"] = 2
+                        }
+                    },
+                    BuildCategoryCountResults("local", "黑块", "黑块", "其他"),
+                    true,
+                    null))
+                {
+                    return 1;
+                }
+
+                if (!VerifyCategoryCountCase(
+                    moduleType,
+                    "[{\"category\":\"黑块\",\"operator\":\"equal\",\"expect\":2}]",
+                    BuildCategoryCountResults("local", "黑块"),
+                    false,
+                    "类别黑块期望=2,实际1"))
+                {
+                    return 1;
+                }
+
+                if (!VerifyCategoryCountCase(
+                    moduleType,
+                    new JArray
+                    {
+                        new JObject
+                        {
+                            ["category"] = "",
+                            ["operator"] = "gt",
+                            ["expect"] = 2
+                        },
+                        new JObject
+                        {
+                            ["category"] = "黑块",
+                            ["operator"] = "lt",
+                            ["expect"] = 3
+                        }
+                    },
+                    BuildCategoryCountResults("local", "黑块", "黑块", "其他"),
+                    true,
+                    null))
+                {
+                    return 1;
+                }
+
+                var groupedResults = new JArray
+                {
+                    BuildCategoryCountEntry(0, 0, "黑块", "黑块", "黑块", "黑块"),
+                    BuildCategoryCountEntry(1, 0, "黑块", "黑块", "黑块", "黑块")
+                };
+                var groupedModule = (BaseModule)Activator.CreateInstance(
+                    moduleType,
+                    new object[]
+                    {
+                        209,
+                        null,
+                        new Dictionary<string, object>
+                        {
+                            ["rules"] = new JArray
+                            {
+                                new JObject
+                                {
+                                    ["category"] = "黑块",
+                                    ["operator"] = "equal",
+                                    ["expect"] = 8
+                                }
+                            }
+                        },
+                        null
+                    });
+                ModuleIO groupedOutput = groupedModule.Process(images, groupedResults);
+                if (!Convert.ToBoolean(groupedModule.ScalarOutputsByName["ok"]) ||
+                    groupedOutput.ResultList.Any(x => x["ok"] == null || !x["ok"].Value<bool>()))
+                {
+                    Console.WriteLine("同一 origin_index 的多个 local entry 未先汇总计数");
+                    return 1;
+                }
+
+                var stickyResults = BuildCategoryCountResults("local", "黑块");
+                var stickyEntry = (JObject)stickyResults[0];
+                stickyEntry["ok"] = false;
+                stickyEntry["reason"] = new JArray("上游失败");
+                if (!VerifyCategoryCountCase(
+                    moduleType,
+                    new JArray
+                    {
+                        new JObject
+                        {
+                            ["category"] = "黑块",
+                            ["operator"] = "equal",
+                            ["expect"] = 1
+                        }
+                    },
+                    stickyResults,
+                    false,
+                    "上游失败"))
+                {
+                    return 1;
+                }
+
+                var nonLocalResults = BuildCategoryCountResults("global", "黑块");
+                var nonLocalModule = (BaseModule)Activator.CreateInstance(
+                    moduleType,
+                    new object[]
+                    {
+                        205,
+                        null,
+                        new Dictionary<string, object>
+                        {
+                            ["rules"] = new JArray
+                            {
+                                new JObject
+                                {
+                                    ["category"] = "黑块",
+                                    ["operator"] = "equal",
+                                    ["expect"] = 1
+                                }
+                            }
+                        },
+                        null
+                    });
+                ModuleIO nonLocalOutput = nonLocalModule.Process(images, nonLocalResults);
+                var nonLocalEntry = nonLocalOutput.ResultList[0] as JObject;
+                if (nonLocalEntry == null || nonLocalEntry.ContainsKey("ok") || nonLocalEntry.ContainsKey("reason"))
+                {
+                    Console.WriteLine("非 local 结果不应注入 ok/reason");
+                    return 1;
+                }
+
+                var context = new DlcvModules.ExecutionContext();
+                var ngModule = (BaseModule)Activator.CreateInstance(
+                    moduleType,
+                    new object[]
+                    {
+                        206,
+                        null,
+                        new Dictionary<string, object>
+                        {
+                            ["rules"] = new JArray
+                            {
+                                new JObject
+                                {
+                                    ["category"] = "黑块",
+                                    ["operator"] = "equal",
+                                    ["expect"] = 2
+                                }
+                            }
+                        },
+                        context
+                    });
+                ModuleIO checkedOutput = ngModule.Process(images, BuildCategoryCountResults("local", "黑块"));
+                var returnJson = new ReturnJson(207, properties: new Dictionary<string, object>(), context: context);
+                returnJson.Process(images, checkedOutput.ResultList);
+
+                var frontendJson = context.Get<Dictionary<string, object>>("frontend_json", null);
+                var last = frontendJson != null && frontendJson.ContainsKey("last")
+                    ? frontendJson["last"] as Dictionary<string, object>
+                    : null;
+                var byImage = last != null && last.ContainsKey("by_image")
+                    ? last["by_image"] as List<Dictionary<string, object>>
+                    : null;
+                if (byImage == null || byImage.Count != 1 ||
+                    !byImage[0].ContainsKey("ok") || Convert.ToBoolean(byImage[0]["ok"]) ||
+                    !byImage[0].ContainsKey("reason"))
+                {
+                    Console.WriteLine("ReturnJson 未透传 ok/reason");
+                    return 1;
+                }
+
+                var legacyContext = new DlcvModules.ExecutionContext();
+                var legacyReturnJson = new ReturnJson(208, properties: new Dictionary<string, object>(), context: legacyContext);
+                legacyReturnJson.Process(images, BuildCategoryCountResults("local", "黑块"));
+                var legacyFrontendJson = legacyContext.Get<Dictionary<string, object>>("frontend_json", null);
+                var legacyLast = legacyFrontendJson != null && legacyFrontendJson.ContainsKey("last")
+                    ? legacyFrontendJson["last"] as Dictionary<string, object>
+                    : null;
+                var legacyByImage = legacyLast != null && legacyLast.ContainsKey("by_image")
+                    ? legacyLast["by_image"] as List<Dictionary<string, object>>
+                    : null;
+                if (legacyByImage == null || legacyByImage.Count != 1 ||
+                    legacyByImage[0].ContainsKey("ok") || legacyByImage[0].ContainsKey("reason"))
+                {
+                    Console.WriteLine("旧结果不应凭空增加 ok/reason");
+                    return 1;
+                }
+
+                var transformOnlyContext = new DlcvModules.ExecutionContext();
+                var transformOnlyReturnJson = new ReturnJson(210, properties: new Dictionary<string, object>(), context: transformOnlyContext);
+                var transformState = new TransformationState(
+                    120,
+                    100,
+                    null,
+                    new double[] { 1, 0, 0, 0, 1, 0 },
+                    new int[] { 120, 100 });
+                var transformOnlyImages = new List<ModuleImage>
+                {
+                    new ModuleImage(image, image, transformState, 0)
+                };
+                var transform = JObject.FromObject(transformState.ToDict());
+                var transformOnlyResults = new JArray
+                {
+                    new JObject
+                    {
+                        ["type"] = "local",
+                        ["index"] = -1,
+                        ["origin_index"] = -1,
+                        ["transform"] = transform.DeepClone(),
+                        ["sample_results"] = BuildCategoryCountEntry(0, 0, "黑块")["sample_results"].DeepClone(),
+                        ["ok"] = false,
+                        ["reason"] = new JArray("旧流程失败")
+                    },
+                    new JObject
+                    {
+                        ["type"] = "local",
+                        ["index"] = -1,
+                        ["origin_index"] = -1,
+                        ["transform"] = transform.DeepClone(),
+                        ["sample_results"] = new JArray(),
+                        ["ok"] = true
+                    }
+                };
+                transformOnlyReturnJson.Process(transformOnlyImages, transformOnlyResults);
+                var transformOnlyFrontendJson = transformOnlyContext.Get<Dictionary<string, object>>("frontend_json", null);
+                var transformOnlyLast = transformOnlyFrontendJson != null && transformOnlyFrontendJson.ContainsKey("last")
+                    ? transformOnlyFrontendJson["last"] as Dictionary<string, object>
+                    : null;
+                var transformOnlyByImage = transformOnlyLast != null && transformOnlyLast.ContainsKey("by_image")
+                    ? transformOnlyLast["by_image"] as List<Dictionary<string, object>>
+                    : null;
+                var transformOnlyReasons = transformOnlyByImage != null && transformOnlyByImage.Count == 1 &&
+                    transformOnlyByImage[0].ContainsKey("reason")
+                    ? transformOnlyByImage[0]["reason"] as JArray
+                    : null;
+                if (transformOnlyByImage == null || transformOnlyByImage.Count != 1 ||
+                    !transformOnlyByImage[0].ContainsKey("ok") || Convert.ToBoolean(transformOnlyByImage[0]["ok"]) ||
+                    transformOnlyReasons == null || !transformOnlyReasons.Any(x => x.ToString() == "旧流程失败"))
+                {
+                    Console.WriteLine("旧流程通过 transform 对齐时丢失或覆盖 ok/reason");
+                    return 1;
+                }
+            }
+
+            Console.WriteLine("类型数量校验自测通过");
+            return 0;
+        }
+
+        private static bool VerifyCategoryCountCase(
+            Type moduleType,
+            object rules,
+            JArray results,
+            bool expectedOk,
+            string expectedReason)
+        {
+            var module = (BaseModule)Activator.CreateInstance(
+                moduleType,
+                new object[]
+                {
+                    204,
+                    null,
+                    new Dictionary<string, object> { ["rules"] = rules },
+                    null
+                });
+            ModuleIO output = module.Process(new List<ModuleImage>(), results);
+            var entry = output.ResultList.Count > 0 ? output.ResultList[0] as JObject : null;
+            bool scalarOk = module.ScalarOutputsByName.ContainsKey("ok") &&
+                Convert.ToBoolean(module.ScalarOutputsByName["ok"]);
+            string scalarReason = module.ScalarOutputsByName.ContainsKey("reason")
+                ? Convert.ToString(module.ScalarOutputsByName["reason"])
+                : null;
+            bool entryOk = entry != null && entry["ok"] != null && entry["ok"].Value<bool>();
+            var reasons = entry != null ? entry["reason"] as JArray : null;
+
+            bool reasonMatches = expectedReason == null
+                ? reasons == null && string.IsNullOrEmpty(scalarReason)
+                : reasons != null && reasons.Any(x => string.Equals(x.ToString(), expectedReason, StringComparison.Ordinal)) &&
+                  scalarReason != null && scalarReason.Contains(expectedReason);
+
+            if (entry == null || entryOk != expectedOk || scalarOk != expectedOk || !reasonMatches)
+            {
+                Console.WriteLine(
+                    "类型数量校验结果不一致: entry_ok=" + entryOk +
+                    ", scalar_ok=" + scalarOk +
+                    ", reason=" + scalarReason);
+                return false;
+            }
+            return true;
+        }
+
+        private static JObject BuildCategoryCountEntry(int index, int originIndex, params string[] categories)
+        {
+            var detections = new JArray();
+            for (int i = 0; i < categories.Length; i++)
+            {
+                detections.Add(new JObject
+                {
+                    ["category_id"] = i,
+                    ["category_name"] = categories[i],
+                    ["score"] = 0.9,
+                    ["bbox"] = new JArray(10 + i, 10, 20 + i, 20)
+                });
+            }
+            return new JObject
+            {
+                ["type"] = "local",
+                ["index"] = index,
+                ["origin_index"] = originIndex,
+                ["sample_results"] = detections
+            };
+        }
+
+        private static JArray BuildCategoryCountResults(string type, params string[] categories)
+        {
+            var detections = new JArray();
+            for (int i = 0; i < categories.Length; i++)
+            {
+                detections.Add(new JObject
+                {
+                    ["category_id"] = i,
+                    ["category_name"] = categories[i],
+                    ["score"] = 0.9,
+                    ["bbox"] = new JArray(10 + i, 10, 20 + i, 20)
+                });
+            }
+
+            return new JArray
+            {
+                new JObject
+                {
+                    ["type"] = type,
+                    ["index"] = 0,
+                    ["origin_index"] = 0,
+                    ["sample_results"] = detections
+                }
+            };
         }
 
         private static int RunCountResultsSelfTest()

--- a/Test/dlcv_infer_cpp_test/main.cpp
+++ b/Test/dlcv_infer_cpp_test/main.cpp
@@ -842,6 +842,282 @@ int RunCountResultsSelfTest() {
     return 0;
 }
 
+
+json BuildCategoryCountCheckFlow(const json& rules, int total) {
+    json nodes = json::array({
+        json::object({
+            {"id", 1},
+            {"order", 1},
+            {"type", "input/frontend_image"},
+            {"outputs", json::array({
+                json::object({{"type", "image_chan"}, {"links", json::array()}}),
+                json::object({{"type", "result_chan"}, {"links", json::array()}})
+            })}
+        })
+    });
+
+    json mergeInputs = json::array();
+    for (int i = 0; i < total; ++i) {
+        const int imageInputLink = 100 + i * 2;
+        const int resultInputLink = imageInputLink + 1;
+        const int imageOutputLink = 200 + i * 2;
+        const int resultOutputLink = imageOutputLink + 1;
+        nodes[0]["outputs"][0]["links"].push_back(imageInputLink);
+        nodes[0]["outputs"][1]["links"].push_back(resultInputLink);
+        nodes.push_back(json::object({
+            {"id", 2 + i},
+            {"order", 2 + i},
+            {"type", "input/build_results"},
+            {"properties", json::object({
+                {"category_id", 1},
+                {"category_name", "黑块"},
+                {"score", 0.99},
+                {"bbox_x", 10.0 + i * 30.0},
+                {"bbox_y", 10.0},
+                {"bbox_w", 20.0},
+                {"bbox_h", 20.0}
+            })},
+            {"inputs", json::array({
+                json::object({{"type", "image_chan"}, {"link", imageInputLink}}),
+                json::object({{"type", "result_chan"}, {"link", resultInputLink}})
+            })},
+            {"outputs", json::array({
+                json::object({{"type", "image_chan"}, {"links", json::array({imageOutputLink})}}),
+                json::object({{"type", "result_chan"}, {"links", json::array({resultOutputLink})}})
+            })}
+        }));
+        mergeInputs.push_back(json::object({{"type", "image_chan"}, {"link", imageOutputLink}}));
+        mergeInputs.push_back(json::object({{"type", "result_chan"}, {"link", resultOutputLink}}));
+    }
+
+    nodes.push_back(json::object({
+        {"id", 100},
+        {"order", 100},
+        {"type", "post_process/merge_results"},
+        {"inputs", std::move(mergeInputs)},
+        {"outputs", json::array({
+            json::object({{"type", "image_chan"}, {"links", json::array({901})}}),
+            json::object({{"type", "result_chan"}, {"links", json::array({902})}})
+        })}
+    }));
+    nodes.push_back(json::object({
+        {"id", 101},
+        {"order", 101},
+        {"type", "post_process/category_count_check"},
+        {"properties", json::object({{"rules", rules}})},
+        {"inputs", json::array({
+            json::object({{"type", "image_chan"}, {"link", 901}}),
+            json::object({{"type", "result_chan"}, {"link", 902}})
+        })},
+        {"outputs", json::array({
+            json::object({{"type", "image_chan"}, {"links", json::array({301})}}),
+            json::object({{"type", "result_chan"}, {"links", json::array({302})}}),
+            json::object({{"name", "ok"}, {"type", "bool"}, {"links", json::array()}}),
+            json::object({{"name", "reason"}, {"type", "string"}, {"links", json::array()}})
+        })}
+    }));
+    nodes.push_back(json::object({
+        {"id", 102},
+        {"order", 102},
+        {"type", "output/return_json"},
+        {"inputs", json::array({
+            json::object({{"type", "image_chan"}, {"link", 301}}),
+            json::object({{"type", "result_chan"}, {"link", 302}})
+        })},
+        {"outputs", json::array()}
+    }));
+    return json::object({{"nodes", std::move(nodes)}});
+}
+
+bool ReadCategoryCheckStatus(
+    const json& root,
+    size_t sampleIndex,
+    bool& ok,
+    std::vector<std::string>& reasons) {
+    const json* statusToken = &root;
+    try {
+        if (!(root.contains("ok") && root.at("ok").is_boolean())) {
+            if (!root.contains("result_list") || !root.at("result_list").is_array() ||
+                sampleIndex >= root.at("result_list").size()) return false;
+            statusToken = &root.at("result_list").at(sampleIndex);
+        }
+        if (!statusToken->is_object() || !statusToken->contains("ok") ||
+            !statusToken->at("ok").is_boolean()) return false;
+        ok = statusToken->at("ok").get<bool>();
+        reasons.clear();
+        if (statusToken->contains("reason") && statusToken->at("reason").is_array()) {
+            for (const auto& reason : statusToken->at("reason")) {
+                if (reason.is_string()) reasons.push_back(reason.get<std::string>());
+            }
+        }
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+bool RunCategoryCountCheckFlowCase(
+    const json& rules,
+    int total,
+    int imageCount,
+    bool expectedOk,
+    const std::string& expectedReason,
+    std::string& error) {
+    const std::string tempDir = BuildTempRectCorrectionDir();
+    const std::string flowPath = JoinPathA(tempDir, "category_count_check.json");
+    {
+        std::ofstream ofs(flowPath, std::ios::binary);
+        if (!ofs) {
+            error = "cannot write temp flow file";
+            return false;
+        }
+        ofs << BuildCategoryCountCheckFlow(rules, total).dump(2);
+    }
+
+    try {
+        dlcv_infer::flow::FlowGraphModel model;
+        const json loadReport = model.Load(flowPath, 0);
+        if (!loadReport.is_object() || loadReport.value("code", 1) != 0) {
+            error = std::string("flow load failed: ") + loadReport.dump();
+            DeleteFileA(flowPath.c_str());
+            return false;
+        }
+
+        const cv::Mat image(64, 320, CV_8UC3, cv::Scalar(0, 255, 0));
+        std::vector<cv::Mat> images(static_cast<size_t>(imageCount), image);
+        const json root = model.InferInternal(images, json::object());
+        if (!root.is_object() || root.value("code", 1) != 0) {
+            error = std::string("flow infer failed: ") + root.dump();
+            DeleteFileA(flowPath.c_str());
+            return false;
+        }
+
+        for (int i = 0; i < imageCount; ++i) {
+            bool ok = false;
+            std::vector<std::string> reasons;
+            if (!ReadCategoryCheckStatus(root, static_cast<size_t>(i), ok, reasons)) {
+                error = "missing inspection status: " + root.dump();
+                DeleteFileA(flowPath.c_str());
+                return false;
+            }
+            if (ok != expectedOk) {
+                error = "inspection ok mismatch: " + root.dump();
+                DeleteFileA(flowPath.c_str());
+                return false;
+            }
+            if (expectedReason.empty()) {
+                if (!reasons.empty()) {
+                    error = "unexpected inspection reason: " + root.dump();
+                    DeleteFileA(flowPath.c_str());
+                    return false;
+                }
+            } else if (reasons.size() != 1 || reasons.front() != expectedReason) {
+                error = "inspection reason mismatch: " + root.dump();
+                DeleteFileA(flowPath.c_str());
+                return false;
+            }
+        }
+
+        if (imageCount == 1) {
+            const json oneOut = model.InferOneOutJson(image, json::object());
+            if (!oneOut.is_object() || oneOut.value("ok", !expectedOk) != expectedOk ||
+                !oneOut.contains("result_list") || !oneOut.at("result_list").is_array()) {
+                error = "InferOneOutJson wrapper mismatch: " + oneOut.dump();
+                DeleteFileA(flowPath.c_str());
+                return false;
+            }
+        }
+    } catch (const std::exception& ex) {
+        error = std::string("exception: ") + ex.what();
+        DeleteFileA(flowPath.c_str());
+        return false;
+    }
+
+    DeleteFileA(flowPath.c_str());
+    return true;
+}
+
+bool RunCategoryCountCheckLegacyCompatibilityCase(std::string& error) {
+    const std::string tempDir = BuildTempRectCorrectionDir();
+    const std::string flowPath = JoinPathA(tempDir, "category_count_check_legacy.json");
+    {
+        std::ofstream ofs(flowPath, std::ios::binary);
+        if (!ofs) {
+            error = "cannot write legacy temp flow file";
+            return false;
+        }
+        ofs << BuildCountResultsFlow(json::object(), 1, true).dump(2);
+    }
+
+    try {
+        dlcv_infer::flow::FlowGraphModel model;
+        const json loadReport = model.Load(flowPath, 0);
+        if (!loadReport.is_object() || loadReport.value("code", 1) != 0) {
+            error = std::string("legacy flow load failed: ") + loadReport.dump();
+            DeleteFileA(flowPath.c_str());
+            return false;
+        }
+        const cv::Mat image(64, 64, CV_8UC3, cv::Scalar(0, 255, 0));
+        const json root = model.InferInternal(std::vector<cv::Mat>{image}, json::object());
+        if (root.contains("ok") || root.contains("reason")) {
+            error = "legacy root unexpectedly contains inspection status: " + root.dump();
+            DeleteFileA(flowPath.c_str());
+            return false;
+        }
+        const json oneOut = model.InferOneOutJson(image, json::object());
+        if (!oneOut.is_array()) {
+            error = "legacy InferOneOutJson is not array: " + oneOut.dump();
+            DeleteFileA(flowPath.c_str());
+            return false;
+        }
+    } catch (const std::exception& ex) {
+        error = std::string("legacy exception: ") + ex.what();
+        DeleteFileA(flowPath.c_str());
+        return false;
+    }
+
+    DeleteFileA(flowPath.c_str());
+    return true;
+}
+
+int RunCategoryCountCheckSelfTest() {
+    auto fail = [](const std::string& message) -> int {
+        std::cout << "category_count_check selftest failed: " << message << "\n";
+        return 1;
+    };
+
+    const json equalOne = json::array({
+        json::object({{"category", "黑块"}, {"operator", "equal"}, {"expect", 1}})
+    });
+    const json equalEight = json::array({
+        json::object({{"category", "黑块"}, {"operator", "equal"}, {"expect", 8}})
+    });
+    const std::string countOneReason = "类别黑块期望=8,实际1";
+    std::string error;
+    if (!RunCategoryCountCheckFlowCase(equalOne, 1, 1, true, std::string(), error)) return fail(error);
+    if (!RunCategoryCountCheckFlowCase(equalEight, 7, 1, false, countOneReason, error)) return fail(error);
+    if (!RunCategoryCountCheckFlowCase(
+            json::array({json::object({{"category", "黑块"}, {"operator", "gt"}, {"expect", 0}})}),
+            2, 1, true, std::string(), error)) return fail(error);
+    if (!RunCategoryCountCheckFlowCase(
+            json::array({json::object({{"category", "黑块"}, {"operator", "lt"}, {"expect", 2}})}),
+            1, 1, true, std::string(), error)) return fail(error);
+    if (!RunCategoryCountCheckFlowCase(
+            json::array({json::object({{"category", ""}, {"operator", "equal"}, {"expect", 1}})}),
+            2, 1, true, std::string(), error)) return fail(error);
+    if (!RunCategoryCountCheckFlowCase(equalOne.dump(), 1, 1, true, std::string(), error)) return fail(error);
+    if (!RunCategoryCountCheckFlowCase(
+            json::array({json::object({{"category", "黑块"}, {"operator", "invalid"}, {"expect", 1}})}),
+            1, 1, true, std::string(), error)) return fail(error);
+    if (!RunCategoryCountCheckFlowCase(
+            json::array({json::object({{"category", "黑块"}, {"operator", "equal"}, {"expect", "bad"}})}),
+            1, 1, true, std::string(), error)) return fail(error);
+    if (!RunCategoryCountCheckLegacyCompatibilityCase(error)) return fail(error);
+
+    std::cout << "category_count_check selftest passed\n";
+    return 0;
+}
+
 json BuildImageGenerationExpandFlow(const std::string& saveDir,
                                     const std::string& suffix,
                                     const json& cropProperties,
@@ -1417,8 +1693,14 @@ int wmain(int argc, wchar_t* argv[]) {
         return RunBBoxIoUDedupSelfTest();
     }
 
+
     if (argc >= 2 && std::wstring(argv[1]) == L"count-results-selftest") {
         return RunCountResultsSelfTest();
+    }
+
+
+    if (argc >= 2 && std::wstring(argv[1]) == L"category-count-check-selftest") {
+        return RunCategoryCountCheckSelfTest();
     }
 
     if (argc >= 2 && std::wstring(argv[1]) == L"image-generation-expand-selftest") {
@@ -1443,6 +1725,7 @@ int wmain(int argc, wchar_t* argv[]) {
     std::cout << "  rect-image-correction-selftest\n";
     std::cout << "  bbox-iou-dedup-selftest\n";
     std::cout << "  count-results-selftest\n";
+    std::cout << "  category-count-check-selftest\n";
     std::cout << "  image-generation-expand-selftest\n";
     std::cout << "  cross-model-label-merge-selftest\n";
     std::cout << "  load-three-models <extractModelPath> <componentModelPath> <icModelPath>\n";

--- a/dlcv_infer_cpp_dll/dlcv_infer.cpp
+++ b/dlcv_infer_cpp_dll/dlcv_infer.cpp
@@ -40,10 +40,87 @@ thread_local double g_lastDlcvInferMs = 0.0;
 thread_local double g_lastTotalInferMs = 0.0;
 thread_local std::vector<dlcv_infer::FlowNodeTiming> g_lastFlowNodeTimings;
 
+struct InspectionStatusSnapshot final {
+    bool HasOk = false;
+    bool Ok = false;
+    std::vector<std::string> Reasons;
+};
+
+thread_local std::vector<InspectionStatusSnapshot> g_lastInspectionStatuses;
+
 void SetLastInferTiming(double dlcvInferMs, double totalInferMs, std::vector<dlcv_infer::FlowNodeTiming> nodeTimings = {}) {
     g_lastDlcvInferMs = std::max(0.0, dlcvInferMs);
     g_lastTotalInferMs = std::max(0.0, totalInferMs);
     g_lastFlowNodeTimings = std::move(nodeTimings);
+}
+
+InspectionStatusSnapshot ParseInspectionStatus(const Json& token) {
+    InspectionStatusSnapshot status;
+    try {
+        if (!token.is_object() || !token.contains("ok") || !token.at("ok").is_boolean()) {
+            return status;
+        }
+        status.HasOk = true;
+        status.Ok = token.at("ok").get<bool>();
+        if (!token.contains("reason") || token.at("reason").is_null()) return status;
+
+        const Json& reason = token.at("reason");
+        if (reason.is_array()) {
+            for (const auto& item : reason) {
+                if (item.is_string()) status.Reasons.push_back(item.get<std::string>());
+            }
+        } else if (reason.is_string()) {
+            status.Reasons.push_back(reason.get<std::string>());
+        }
+    } catch (...) {
+        return InspectionStatusSnapshot();
+    }
+    return status;
+}
+
+void ClearLastInspectionStatuses() {
+    g_lastInspectionStatuses.clear();
+}
+
+void SetLastInspectionStatusesFromFlowRoot(const Json& flowRoot, size_t expectedImageCount) {
+    g_lastInspectionStatuses.clear();
+    if (expectedImageCount > 0) g_lastInspectionStatuses.resize(expectedImageCount);
+
+    try {
+        const InspectionStatusSnapshot rootStatus = ParseInspectionStatus(flowRoot);
+        if (rootStatus.HasOk) {
+            if (g_lastInspectionStatuses.empty()) g_lastInspectionStatuses.resize(1);
+            g_lastInspectionStatuses[0] = rootStatus;
+            return;
+        }
+
+        if (!flowRoot.is_object() || !flowRoot.contains("result_list") ||
+            !flowRoot.at("result_list").is_array()) return;
+
+        const Json& resultList = flowRoot.at("result_list");
+        for (size_t i = 0; i < resultList.size(); ++i) {
+            const InspectionStatusSnapshot status = ParseInspectionStatus(resultList.at(i));
+            if (!status.HasOk) continue;
+            if (i >= g_lastInspectionStatuses.size()) g_lastInspectionStatuses.resize(i + 1);
+            g_lastInspectionStatuses[i] = status;
+        }
+    } catch (...) {
+        g_lastInspectionStatuses.clear();
+    }
+}
+
+Json WrapNormalizedFlowJsonWithInspectionStatus(
+    Json normalized,
+    const InspectionStatusSnapshot& status) {
+    if (!status.HasOk) return normalized;
+
+    Json reason = Json();
+    if (!status.Reasons.empty()) reason = status.Reasons;
+    return Json::object({
+        {"result_list", std::move(normalized)},
+        {"ok", status.Ok},
+        {"reason", std::move(reason)}
+    });
 }
 
 #ifndef _WIN32
@@ -1988,6 +2065,7 @@ namespace dlcv_infer {
     }
 
     Result Model::Infer(const cv::Mat& image, const json& params_json) {
+        ClearLastInspectionStatuses();
         if (_isFlowGraphMode) {
             if (!_flowModel) throw std::runtime_error("dvs model not loaded");
             if (image.empty()) throw std::invalid_argument("image is empty");
@@ -1999,6 +2077,7 @@ namespace dlcv_infer {
 
             const auto begin = std::chrono::steady_clock::now();
             json flowRoot = _flowModel->InferInternal(prepared, params_json);
+            SetLastInspectionStatusesFromFlowRoot(flowRoot, prepared.size());
             const auto end = std::chrono::steady_clock::now();
 
             double dlcvInferMs = 0.0;
@@ -2047,6 +2126,7 @@ namespace dlcv_infer {
     }
 
     Result Model::InferBatch(const std::vector<cv::Mat>& image_list, const json& params_json) {
+        ClearLastInspectionStatuses();
         if (_isFlowGraphMode) {
             if (!_flowModel) throw std::runtime_error("dvs model not loaded");
             if (image_list.empty()) {
@@ -2066,6 +2146,7 @@ namespace dlcv_infer {
 
             const auto begin = std::chrono::steady_clock::now();
             json flowRoot = _flowModel->InferInternal(prepared, params_json);
+            SetLastInspectionStatusesFromFlowRoot(flowRoot, prepared.size());
             const auto end = std::chrono::steady_clock::now();
 
             double dlcvInferMs = 0.0;
@@ -2119,6 +2200,7 @@ namespace dlcv_infer {
     }
 
     json Model::InferOneOutJson(const cv::Mat& image, const json& params_json) {
+        ClearLastInspectionStatuses();
         if (_isFlowGraphMode) {
             if (!_flowModel) throw std::runtime_error("dvs model not loaded");
             if (image.empty()) throw std::invalid_argument("image is empty");
@@ -2130,6 +2212,7 @@ namespace dlcv_infer {
 
             const auto begin = std::chrono::steady_clock::now();
             json flowRoot = _flowModel->InferInternal(prepared, params_json);
+            SetLastInspectionStatusesFromFlowRoot(flowRoot, prepared.size());
             const auto end = std::chrono::steady_clock::now();
 
             double dlcvInferMs = 0.0;
@@ -2161,7 +2244,10 @@ namespace dlcv_infer {
             } catch (...) {
                 flowResults = json::array();
             }
-            return NormalizeFlowOneOutJson(flowResults, emitMaskOutput);
+            Json normalized = NormalizeFlowOneOutJson(flowResults, emitMaskOutput);
+            const InspectionStatusSnapshot status = g_lastInspectionStatuses.empty()
+                ? InspectionStatusSnapshot() : g_lastInspectionStatuses.front();
+            return WrapNormalizedFlowJsonWithInspectionStatus(std::move(normalized), status);
         }
 
         const std::vector<cv::Mat> prepared = prepareInferInputBatch({ image });
@@ -2237,6 +2323,21 @@ namespace dlcv_infer {
 
     std::vector<FlowNodeTiming> Model::GetLastFlowNodeTimings() {
         return g_lastFlowNodeTimings;
+    }
+
+    bool Model::GetLastInspectionStatus(
+        bool& ok,
+        std::vector<std::string>& reasons,
+        size_t sampleIndex) {
+        ok = false;
+        reasons.clear();
+        if (sampleIndex >= g_lastInspectionStatuses.size()) return false;
+
+        const InspectionStatusSnapshot& status = g_lastInspectionStatuses[sampleIndex];
+        if (!status.HasOk) return false;
+        ok = status.Ok;
+        reasons = status.Reasons;
+        return true;
     }
 
     // SlidingWindowModel类实现

--- a/dlcv_infer_cpp_dll/dlcv_infer.h
+++ b/dlcv_infer_cpp_dll/dlcv_infer.h
@@ -250,6 +250,12 @@ namespace dlcv_infer {
 
         static void GetLastInferTiming(double& dlcvInferMs, double& totalInferMs);
         static std::vector<FlowNodeTiming> GetLastFlowNodeTimings();
+        // 读取当前线程最近一次推理的流程判定状态；必须与 Infer/InferBatch/
+        // InferOneOutJson 在同一线程调用。未产生判定状态时返回 false。
+        static bool GetLastInspectionStatus(
+            bool& ok,
+            std::vector<std::string>& reasons,
+            size_t sampleIndex = 0);
 
     private:
         bool _isFlowGraphMode = false;

--- a/dlcv_infer_cpp_dll/flow/FlowGraphModel.cpp
+++ b/dlcv_infer_cpp_dll/flow/FlowGraphModel.cpp
@@ -184,6 +184,7 @@ static FlowBatchResult AggregateFrontendResults(ExecutionContext& ctx, int image
     FlowBatchResult batch;
     if (imageCount <= 0) return batch;
     batch.PerImageResults.assign(static_cast<size_t>(imageCount), std::vector<FlowResultItem>());
+    batch.PerImageStatuses.assign(static_cast<size_t>(imageCount), FlowInspectionStatus());
 
     const std::vector<FlowFrontendByNodePayload> payloads = CollectFrontendPayloads(ctx);
     for (const auto& payload : payloads) {
@@ -193,6 +194,30 @@ static FlowBatchResult AggregateFrontendResults(ExecutionContext& ctx, int image
             const int targetIndex = ResolvePerImageTargetIndex(item, i, imageCount);
             if (targetIndex < 0 || targetIndex >= imageCount) continue;
             AppendResultsDedup(batch.PerImageResults[static_cast<size_t>(targetIndex)], item.Results);
+            if (item.HasOk) {
+                FlowInspectionStatus& status = batch.PerImageStatuses[static_cast<size_t>(targetIndex)];
+                if (!status.HasOk) {
+                    status.HasOk = true;
+                    status.Ok = item.Ok;
+                    status.Reason = item.Reason;
+                } else {
+                    status.Ok = status.Ok && item.Ok;
+                    Json merged = Json::array();
+                    const auto appendReasons = [&merged](const Json& reasons) {
+                        if (reasons.is_array()) {
+                            for (const auto& reason : reasons) {
+                                if (std::find(merged.begin(), merged.end(), reason) == merged.end()) merged.push_back(reason);
+                            }
+                        } else if (!reasons.is_null() &&
+                                   std::find(merged.begin(), merged.end(), reasons) == merged.end()) {
+                            merged.push_back(reasons);
+                        }
+                    };
+                    appendReasons(status.Reason);
+                    appendReasons(item.Reason);
+                    status.Reason = merged.empty() ? Json() : std::move(merged);
+                }
+            }
         }
     }
 
@@ -541,9 +566,15 @@ Json FlowGraphModel::InferOneOutJson(const cv::Mat& image, const Json& paramsJso
     if (image.empty()) throw std::invalid_argument("image is empty");
     Json root = InferInternal(std::vector<cv::Mat>{ image }, paramsJson);
     try {
-        if (root.is_object() && root.contains("result_list")) {
-            const auto& rl = root.at("result_list");
-            if (rl.is_array()) return rl;
+        if (root.is_object() && root.contains("result_list") && root.at("result_list").is_array()) {
+            if (root.contains("ok") && root.at("ok").is_boolean()) {
+                Json out = Json::object();
+                out["result_list"] = root.at("result_list");
+                out["ok"] = root.at("ok");
+                if (root.contains("reason")) out["reason"] = root.at("reason");
+                return out;
+            }
+            return root.at("result_list");
         }
     } catch (...) {}
     return Json::array();

--- a/dlcv_infer_cpp_dll/flow/FlowPayloadTypes.h
+++ b/dlcv_infer_cpp_dll/flow/FlowPayloadTypes.h
@@ -90,12 +90,20 @@ struct FlowByImageEntry final {
     int OriginalWidth = 0;
     int OriginalHeight = 0;
     std::vector<FlowResultItem> Results;
+    bool HasOk = false;
+    bool Ok = false;
+    Json Reason;
 
     Json ToJson() const {
         Json out = Json::object();
         out["origin_index"] = OriginIndex;
         out["original_size"] = Json::array({ OriginalWidth, OriginalHeight });
         out["results"] = FlowResultItemsToJsonArray(Results);
+        if (HasOk) {
+            out["ok"] = Ok;
+            out["reason"] = Reason.is_null() || (Reason.is_array() && Reason.empty())
+                ? Json() : Reason;
+        }
         return out;
     }
 
@@ -117,6 +125,13 @@ struct FlowByImageEntry final {
                 for (const auto& one : src.at("results")) {
                     out.Results.push_back(FlowResultItem::FromJson(one));
                 }
+            }
+        } catch (...) {}
+        try {
+            if (src.contains("ok") && src.at("ok").is_boolean()) {
+                out.HasOk = true;
+                out.Ok = src.at("ok").get<bool>();
+                out.Reason = src.contains("reason") ? src.at("reason") : Json();
             }
         } catch (...) {}
         return out;
@@ -154,23 +169,39 @@ struct FlowFrontendByNodePayload final {
     FlowFrontendPayload Payload;
 };
 
+struct FlowInspectionStatus final {
+    bool HasOk = false;
+    bool Ok = false;
+    Json Reason;
+};
+
 struct FlowBatchResult final {
     std::vector<std::vector<FlowResultItem>> PerImageResults;
+    std::vector<FlowInspectionStatus> PerImageStatuses;
 
     Json ToFlowRootJson() const {
         Json out = Json::object();
         if (PerImageResults.size() <= 1) {
-            if (PerImageResults.empty()) {
-                out["result_list"] = Json::array();
-            } else {
-                out["result_list"] = FlowResultItemsToJsonArray(PerImageResults[0]);
+            out["result_list"] = PerImageResults.empty()
+                ? Json::array() : FlowResultItemsToJsonArray(PerImageResults[0]);
+            if (!PerImageStatuses.empty() && PerImageStatuses[0].HasOk) {
+                out["ok"] = PerImageStatuses[0].Ok;
+                const Json& reason = PerImageStatuses[0].Reason;
+                out["reason"] = reason.is_null() || (reason.is_array() && reason.empty())
+                    ? Json() : reason;
             }
             return out;
         }
 
         Json batch = Json::array();
-        for (const auto& one : PerImageResults) {
-            batch.push_back(Json::object({ {"result_list", FlowResultItemsToJsonArray(one)} }));
+        for (size_t i = 0; i < PerImageResults.size(); ++i) {
+            Json one = Json::object({ {"result_list", FlowResultItemsToJsonArray(PerImageResults[i])} });
+            if (i < PerImageStatuses.size() && PerImageStatuses[i].HasOk) {
+                one["ok"] = PerImageStatuses[i].Ok;
+                one["reason"] = PerImageStatuses[i].Reason.is_array() && !PerImageStatuses[i].Reason.empty()
+                    ? PerImageStatuses[i].Reason : Json();
+            }
+            batch.push_back(std::move(one));
         }
         out["result_list"] = batch;
         return out;

--- a/dlcv_infer_cpp_dll/flow/modules/OutputModules.cpp
+++ b/dlcv_infer_cpp_dll/flow/modules/OutputModules.cpp
@@ -394,6 +394,48 @@ static std::vector<FlowResultItem> BuildOutResultItemsTyped(const ModuleImage& w
     return outResults;
 }
 
+static FlowInspectionStatus ReadInspectionStatus(const Json& entry) {
+    FlowInspectionStatus status;
+    try {
+        if (entry.is_object() && entry.contains("ok") && entry.at("ok").is_boolean()) {
+            status.HasOk = true;
+            status.Ok = entry.at("ok").get<bool>();
+            status.Reason = entry.contains("reason") ? entry.at("reason") : Json();
+        }
+    } catch (...) {}
+    return status;
+}
+
+static void MergeInspectionStatus(FlowInspectionStatus& target, const FlowInspectionStatus& source) {
+    if (!source.HasOk) return;
+    if (!target.HasOk) {
+        target = source;
+        return;
+    }
+    target.Ok = target.Ok && source.Ok;
+    Json merged = Json::array();
+    const auto appendReasons = [&merged](const Json& reasons) {
+        if (reasons.is_array()) {
+            for (const auto& reason : reasons) {
+                if (std::find(merged.begin(), merged.end(), reason) == merged.end()) merged.push_back(reason);
+            }
+        } else if (!reasons.is_null() &&
+                   std::find(merged.begin(), merged.end(), reasons) == merged.end()) {
+            merged.push_back(reasons);
+        }
+    };
+    appendReasons(target.Reason);
+    appendReasons(source.Reason);
+    target.Reason = merged.empty() ? Json() : std::move(merged);
+}
+
+static void ApplyInspectionStatus(const FlowInspectionStatus& status, FlowByImageEntry& entry) {
+    if (!status.HasOk) return;
+    entry.HasOk = true;
+    entry.Ok = status.Ok;
+    entry.Reason = status.Reason;
+}
+
 class ReturnJsonModule final : public BaseModule {
 public:
     using BaseModule::BaseModule;
@@ -424,8 +466,11 @@ private:
                 InitializeByImageEntry(wrap, byImageEntry);
                 try {
                     const auto& entry = results.at(i);
-                    if (entry.is_object() && entry.contains("sample_results") && entry.at("sample_results").is_array()) {
-                        byImageEntry.Results = BuildOutResultItemsTyped(wrap, entry.at("sample_results"));
+                    if (entry.is_object()) {
+                        ApplyInspectionStatus(ReadInspectionStatus(entry), byImageEntry);
+                        if (entry.contains("sample_results") && entry.at("sample_results").is_array()) {
+                            byImageEntry.Results = BuildOutResultItemsTyped(wrap, entry.at("sample_results"));
+                        }
                     }
                 } catch (...) {}
                 payload.ByImage.push_back(std::move(byImageEntry));
@@ -435,12 +480,30 @@ private:
             std::unordered_map<std::string, std::vector<const Json*>> transToDets;
             std::unordered_map<int, std::vector<const Json*>> indexToDets;
             std::unordered_map<int, std::vector<const Json*>> originToDets;
+            std::unordered_map<std::string, FlowInspectionStatus> transToStatus;
+            std::unordered_map<int, FlowInspectionStatus> indexToStatus;
+            std::unordered_map<int, FlowInspectionStatus> originToStatus;
 
             for (const auto& entryToken : results) {
                 if (!entryToken.is_object()) continue;
                 const Json& entry = entryToken;
                 if (!entry.contains("type") || !entry.at("type").is_string()) continue;
                 if (entry.at("type").get<std::string>() != "local") continue;
+
+                const FlowInspectionStatus status = ReadInspectionStatus(entry);
+                int statusIndex = -1;
+                int statusOriginIndex = -1;
+                try { statusIndex = entry.contains("index") ? entry.at("index").get<int>() : -1; } catch (...) {}
+                try { statusOriginIndex = entry.contains("origin_index") ? entry.at("origin_index").get<int>() : -1; } catch (...) {}
+                if (statusIndex >= 0) MergeInspectionStatus(indexToStatus[statusIndex], status);
+                if (statusOriginIndex >= 0) MergeInspectionStatus(originToStatus[statusOriginIndex], status);
+                try {
+                    if (entry.contains("transform") && entry.at("transform").is_object()) {
+                        const std::string statusSig = SerializeTransformKey(TransformationState::FromJson(entry.at("transform")));
+                        if (!statusSig.empty()) MergeInspectionStatus(transToStatus[statusSig], status);
+                    }
+                } catch (...) {}
+
                 if (!entry.contains("sample_results") || !entry.at("sample_results").is_array()) continue;
 
                 std::vector<const Json*> detList;
@@ -496,6 +559,19 @@ private:
                 if (dets != nullptr) {
                     byImageEntry.Results = BuildOutResultItemsTyped(wrap, *dets);
                 }
+
+                const FlowInspectionStatus* status = nullptr;
+                auto itStatusIdx = indexToStatus.find(static_cast<int>(i));
+                if (itStatusIdx != indexToStatus.end()) status = &itStatusIdx->second;
+                if (status == nullptr) {
+                    auto itStatusOrg = originToStatus.find(wrap.OriginalIndex);
+                    if (itStatusOrg != originToStatus.end()) status = &itStatusOrg->second;
+                }
+                if (status == nullptr && !sig.empty()) {
+                    auto itStatusTransform = transToStatus.find(sig);
+                    if (itStatusTransform != transToStatus.end()) status = &itStatusTransform->second;
+                }
+                if (status != nullptr) ApplyInspectionStatus(*status, byImageEntry);
                 payload.ByImage.push_back(std::move(byImageEntry));
             }
         }

--- a/dlcv_infer_cpp_dll/flow/modules/PostProcessModules.cpp
+++ b/dlcv_infer_cpp_dll/flow/modules/PostProcessModules.cpp
@@ -2328,6 +2328,187 @@ private:
     }
 };
 
+/// post_process/category_count_check
+class CategoryCountCheckModule final : public BaseModule {
+public:
+    using BaseModule::BaseModule;
+
+    ModuleIO Process(const std::vector<ModuleImage>& imageList, const Json& resultList) override {
+        Json results = resultList.is_array() ? resultList : Json::array();
+        return ProcessCore(imageList, std::move(results));
+    }
+
+    ModuleIO ProcessOwned(const std::vector<ModuleImage>& imageList, Json&& resultList) override {
+        Json results = resultList.is_array() ? std::move(resultList) : Json::array();
+        return ProcessCore(imageList, std::move(results));
+    }
+
+private:
+    struct Rule final {
+        std::string Category;
+        std::string Operator;
+        int Expect = 0;
+    };
+
+    static int ParseExpect(const Json& value) {
+        try {
+            double number = 0.0;
+            if (value.is_number()) number = value.get<double>();
+            else if (value.is_string()) number = std::stod(value.get<std::string>());
+            else return 1;
+            if (!std::isfinite(number)) return 1;
+            if (number <= 0.0) return 0;
+            if (number >= static_cast<double>(std::numeric_limits<int>::max())) {
+                return std::numeric_limits<int>::max();
+            }
+            return static_cast<int>(number);
+        } catch (...) {
+            return 1;
+        }
+    }
+
+    std::vector<Rule> ParseRules() const {
+        Json raw = Json::array();
+        try {
+            if (Properties.is_object() && Properties.contains("rules")) raw = Properties.at("rules");
+            if (raw.is_string()) raw = Json::parse(raw.get<std::string>());
+        } catch (...) {
+            return {};
+        }
+        if (!raw.is_array()) return {};
+
+        std::vector<Rule> rules;
+        for (const auto& item : raw) {
+            if (!item.is_object()) continue;
+            Rule rule;
+            try {
+                if (item.contains("category")) {
+                    const Json& value = item.at("category");
+                    rule.Category = value.is_string() ? value.get<std::string>() : value.dump();
+                }
+            } catch (...) {}
+            try {
+                if (item.contains("operator")) {
+                    const Json& value = item.at("operator");
+                    rule.Operator = value.is_string() ? value.get<std::string>() : value.dump();
+                }
+            } catch (...) {}
+            if (rule.Operator != "gt" && rule.Operator != "lt" && rule.Operator != "equal") {
+                rule.Operator = "equal";
+            }
+            rule.Expect = item.contains("expect") ? ParseExpect(item.at("expect")) : 0;
+            rules.push_back(std::move(rule));
+        }
+        return rules;
+    }
+
+    static int CountMatching(const Json& detections, const std::string& category) {
+        if (!detections.is_array()) return 0;
+        int count = 0;
+        for (const auto& detection : detections) {
+            if (!detection.is_object()) continue;
+            if (category.empty() || detection.value("category_name", std::string()) == category) {
+                if (count < std::numeric_limits<int>::max()) count++;
+            }
+        }
+        return count;
+    }
+
+    static bool Evaluate(int count, const Rule& rule) {
+        if (rule.Operator == "gt") return count > rule.Expect;
+        if (rule.Operator == "lt") return count < rule.Expect;
+        return count == rule.Expect;
+    }
+
+    static std::string FormatReason(const Rule& rule, int actual) {
+        const std::string category = rule.Category.empty() ? "全部类别" : rule.Category;
+        const char* op = rule.Operator == "gt" ? ">" : (rule.Operator == "lt" ? "<" : "=");
+        return "类别" + category + "期望" + op + std::to_string(rule.Expect) + ",实际" + std::to_string(actual);
+    }
+
+    ModuleIO ProcessCore(const std::vector<ModuleImage>& imageList, Json&& results) {
+        const std::vector<Rule> rules = ParseRules();
+        bool allOk = true;
+        std::vector<std::string> allReasons;
+        std::unordered_map<int, std::vector<size_t>> groups;
+
+        for (size_t i = 0; i < results.size(); ++i) {
+            const Json& entry = results.at(i);
+            if (!entry.is_object() || entry.value("type", std::string()) != "local") continue;
+            int key = -1;
+            try {
+                const int originIndex = entry.value("origin_index", -1);
+                const int index = entry.value("index", -1);
+                key = originIndex >= 0 ? originIndex : (index >= 0 ? index : -1);
+            } catch (...) {}
+            groups[key].push_back(i);
+        }
+
+        for (const auto& group : groups) {
+            Json detections = Json::array();
+            for (size_t index : group.second) {
+                const Json& entry = results.at(index);
+                if (!entry.contains("sample_results") || !entry.at("sample_results").is_array()) continue;
+                for (const auto& detection : entry.at("sample_results")) detections.push_back(detection);
+            }
+
+            bool moduleOk = true;
+            std::vector<std::string> groupReasons;
+            for (const Rule& rule : rules) {
+                const int count = CountMatching(detections, rule.Category);
+                if (!Evaluate(count, rule)) {
+                    moduleOk = false;
+                    groupReasons.push_back(FormatReason(rule, count));
+                }
+            }
+
+            for (size_t index : group.second) {
+                Json& entry = results.at(index);
+                Json reasons = Json::array();
+                if (entry.contains("reason")) {
+                    const Json& existingReason = entry.at("reason");
+                    if (existingReason.is_array()) reasons = existingReason;
+                    else if (!existingReason.is_null()) {
+                        reasons.push_back(existingReason.is_string() ? existingReason : Json(existingReason.dump()));
+                    }
+                }
+
+                const bool hasExistingOk = entry.contains("ok") && !entry.at("ok").is_null();
+                bool entryOk = moduleOk;
+                if (hasExistingOk && moduleOk) {
+                    entryOk = entry.at("ok").is_boolean() ? entry.at("ok").get<bool>() : true;
+                }
+                if (!moduleOk) {
+                    entryOk = false;
+                    for (const std::string& reason : groupReasons) {
+                        if (std::find(reasons.begin(), reasons.end(), Json(reason)) == reasons.end()) reasons.push_back(reason);
+                    }
+                }
+
+                entry["ok"] = entryOk;
+                entry["reason"] = reasons.empty() ? Json() : reasons;
+                if (!entryOk) {
+                    allOk = false;
+                    for (const auto& reason : reasons) {
+                        if (!reason.is_string()) continue;
+                        const std::string text = reason.get<std::string>();
+                        if (std::find(allReasons.begin(), allReasons.end(), text) == allReasons.end()) allReasons.push_back(text);
+                    }
+                }
+            }
+        }
+
+        ScalarOutputsByName["ok"] = allOk;
+        std::string reasonText;
+        for (size_t i = 0; i < allReasons.size(); ++i) {
+            if (i > 0) reasonText += "; ";
+            reasonText += allReasons[i];
+        }
+        ScalarOutputsByName["reason"] = reasonText;
+        return ModuleIO(imageList, std::move(results), Json::array());
+    }
+};
+
 /// post_process/count_results, features/count_results
 class CountResultsModule final : public BaseModule {
 public:
@@ -2422,6 +2603,7 @@ DLCV_FLOW_REGISTER_MODULE("post_process/multi_category_filter", MultiCategoryFil
 DLCV_FLOW_REGISTER_MODULE("features/multi_category_filter", MultiCategoryFilterModule)
 DLCV_FLOW_REGISTER_MODULE("post_process/result_filter_advanced", ResultFilterAdvancedModule)
 DLCV_FLOW_REGISTER_MODULE("features/result_filter_advanced", ResultFilterAdvancedModule)
+DLCV_FLOW_REGISTER_MODULE("post_process/category_count_check", CategoryCountCheckModule)
 DLCV_FLOW_REGISTER_MODULE("post_process/count_results", CountResultsModule)
 DLCV_FLOW_REGISTER_MODULE("features/count_results", CountResultsModule)
 DLCV_FLOW_REGISTER_MODULE("post_process/text_replacement", TextReplacementModule)

--- a/dlcv_infer_cpp_qt_demo/ImageViewerWidget.cpp
+++ b/dlcv_infer_cpp_qt_demo/ImageViewerWidget.cpp
@@ -50,6 +50,17 @@ void ImageViewerWidget::setShowStatusText(bool enabled) {
     update();
 }
 
+void ImageViewerWidget::setInspectionStatus(bool ok) {
+    hasInspectionStatus_ = true;
+    inspectionOk_ = ok;
+    update();
+}
+
+void ImageViewerWidget::clearInspectionStatus() {
+    hasInspectionStatus_ = false;
+    update();
+}
+
 void ImageViewerWidget::setShowVisualization(bool enabled) {
     showVisualization_ = enabled;
     update();
@@ -96,12 +107,24 @@ void ImageViewerWidget::paintEvent(QPaintEvent* event) {
         shouldDrawStatus = true;
     }
 
+    if (hasInspectionStatus_) {
+        statusText = inspectionOk_ ? "OK" : "NG";
+        shouldDrawStatus = true;
+    }
+
     if (shouldDrawStatus) {
         painter.save();
-        QFont font("Microsoft YaHei", 24);
+        QFont font("Microsoft YaHei", 22, QFont::Bold);
         painter.setFont(font);
-        painter.setPen(statusText == "OK" ? Qt::green : Qt::red);
-        painter.drawText(QPointF(10, 42), statusText);
+        if (hasInspectionStatus_) {
+            const QRectF badgeRect(12.0, 12.0, 78.0, 50.0);
+            painter.fillRect(badgeRect, QColor(96, 96, 96, 230));
+            painter.setPen(inspectionOk_ ? QColor(0, 220, 0) : QColor(255, 45, 45));
+            painter.drawText(badgeRect, Qt::AlignCenter, statusText);
+        } else {
+            painter.setPen(statusText == "OK" ? Qt::green : Qt::red);
+            painter.drawText(QPointF(10, 42), statusText);
+        }
         painter.restore();
     }
 }

--- a/dlcv_infer_cpp_qt_demo/ImageViewerWidget.h
+++ b/dlcv_infer_cpp_qt_demo/ImageViewerWidget.h
@@ -37,6 +37,9 @@ public:
     void setShowStatusText(bool enabled);
     bool showStatusText() const { return showStatusText_; }
 
+    void setInspectionStatus(bool ok);
+    void clearInspectionStatus();
+
     void setShowVisualization(bool enabled);
     bool showVisualization() const { return showVisualization_; }
 
@@ -85,6 +88,8 @@ private:
     QPoint lastMousePosition_;
 
     bool showStatusText_ = false;
+    bool hasInspectionStatus_ = false;
+    bool inspectionOk_ = false;
     bool showVisualization_ = true;
     LabelTextMode labelDisplayMode_ = LabelTextMode::CategoryAndScore;
 

--- a/dlcv_infer_cpp_qt_demo/MainWindow.cpp
+++ b/dlcv_infer_cpp_qt_demo/MainWindow.cpp
@@ -551,6 +551,7 @@ void MainWindow::onInfer() {
     if (pressureTestRunning_) {
         return;
     }
+    imageViewer_->clearInspectionStatus();
 
     if (!ensureModelLoaded() || !ensureImageSelected()) {
         return;
@@ -576,6 +577,9 @@ void MainWindow::onInfer() {
 
     dlcv_infer::Result output({}); // placeholder
     double elapsedMs = 0.0;
+    bool hasInspectionStatus = false;
+    bool inspectionOk = false;
+    std::vector<std::string> inspectionReasons;
     try
     {
         json params;
@@ -586,6 +590,8 @@ void MainWindow::onInfer() {
 
         const auto start = std::chrono::steady_clock::now();
         output = model_->InferBatch(imageList, params);
+        hasInspectionStatus = dlcv_infer::Model::GetLastInspectionStatus(
+            inspectionOk, inspectionReasons, 0);
         const auto end = std::chrono::steady_clock::now();
         elapsedMs = std::chrono::duration<double, std::milli>(end - start).count();
     }
@@ -599,6 +605,7 @@ void MainWindow::onInfer() {
     const std::vector<dlcv_infer::ObjectResult> firstResults =
         output.sampleResults.empty() ? std::vector<dlcv_infer::ObjectResult>{} : output.sampleResults.front().results;
     imageViewer_->setImageAndResults(currentBgrImage_, firstResults);
+    if (hasInspectionStatus) imageViewer_->setInspectionStatus(inspectionOk);
 
     QString text;
     text += QString("图片: %1\n").arg(imagePath_);
@@ -606,6 +613,12 @@ void MainWindow::onInfer() {
     text += QString("threshold: %1\n").arg(spinThreshold_->value(), 0, 'f', 2);
     text += QString("推理时间: %1ms\n").arg(elapsedMs, 0, 'f', 2);
     text += QString("推理结果: %1个\n").arg(static_cast<int>(firstResults.size()));
+    if (!inspectionReasons.empty()) {
+        text += QStringLiteral("原因: %1\n").arg(QString::fromUtf8(inspectionReasons.front().c_str()));
+        for (size_t i = 1; i < inspectionReasons.size(); ++i) {
+            text += QStringLiteral("      %1\n").arg(QString::fromUtf8(inspectionReasons[i].c_str()));
+        }
+    }
     if (firstResults.empty()) {
         text += "未检测到目标。\n";
     } else {
@@ -619,6 +632,7 @@ void MainWindow::onInferJson() {
     if (pressureTestRunning_) {
         return;
     }
+    imageViewer_->clearInspectionStatus();
 
     if (!ensureModelLoaded() || !ensureImageSelected()) {
         return;
@@ -644,6 +658,11 @@ void MainWindow::onInferJson() {
         params["calc_mean"] = checkCalcMean_->isChecked();
 
         const json resultArray = model_->InferOneOutJson(inferImage, params);
+        bool inspectionOk = false;
+        std::vector<std::string> inspectionReasons;
+        if (dlcv_infer::Model::GetLastInspectionStatus(inspectionOk, inspectionReasons, 0)) {
+            imageViewer_->setInspectionStatus(inspectionOk);
+        }
         if (resultArray.empty()) {
             json debugObj;
             debugObj["input"] = describeOpenCvImageForUi(inferImage, true).toUtf8().toStdString();

--- a/dlcv_infer_cpp_qt_demo/main.cpp
+++ b/dlcv_infer_cpp_qt_demo/main.cpp
@@ -434,12 +434,16 @@ bool TryReadJsonScore(const json& token, double& score) {
 }
 
 PathSummary SummarizeJson(const json& result, double threshold) {
-    if (!result.is_array()) {
-        throw std::runtime_error("InferOneOutJson did not return a JSON array");
+    const json* resultList = &result;
+    if (result.is_object() && result.contains("result_list") && result.at("result_list").is_array()) {
+        resultList = &result.at("result_list");
+    }
+    if (!resultList->is_array()) {
+        throw std::runtime_error("InferOneOutJson did not return a JSON array or result_list wrapper");
     }
 
     PathSummary summary;
-    for (const auto& token : result) {
+    for (const auto& token : *resultList) {
         if (!token.is_object()) {
             AddSummaryItem(
                 summary,
@@ -552,6 +556,12 @@ int RunInferCommand(const InferOptions& options) {
     FreeAllModelsGuard cleanup;
     PathSummary structuredSummary;
     PathSummary jsonSummary;
+    bool structuredHasInspection = false;
+    bool structuredOk = false;
+    std::vector<std::string> structuredReasons;
+    bool jsonHasInspection = false;
+    bool jsonOk = false;
+    std::vector<std::string> jsonReasons;
     {
         CoutSilencer silenceApiLogs;
         dlcv_infer::Model model(options.modelPath.toStdWString(), options.device);
@@ -568,7 +578,10 @@ int RunInferCommand(const InferOptions& options) {
     };
 
         const dlcv_infer::Result structuredResult = model.Infer(inferImage, params);
+        structuredHasInspection = dlcv_infer::Model::GetLastInspectionStatus(
+            structuredOk, structuredReasons, 0);
         const json jsonResult = model.InferOneOutJson(inferImage, params);
+        jsonHasInspection = dlcv_infer::Model::GetLastInspectionStatus(jsonOk, jsonReasons, 0);
         structuredSummary = SummarizeStructured(structuredResult, options.threshold);
         jsonSummary = SummarizeJson(jsonResult, options.threshold);
     }
@@ -578,6 +591,10 @@ int RunInferCommand(const InferOptions& options) {
         structuredSummary.belowThreshold.empty() && jsonSummary.belowThreshold.empty();
     const bool meanCheckPassed =
         !options.calcMean || (HasCompleteMeans(structuredSummary) && HasCompleteMeans(jsonSummary));
+    const bool inspectionConsistent =
+        structuredHasInspection == jsonHasInspection &&
+        (!structuredHasInspection ||
+         (structuredOk == jsonOk && structuredReasons == jsonReasons));
 
     const json summary = {
         {"language", "cpp"},
@@ -589,7 +606,13 @@ int RunInferCommand(const InferOptions& options) {
         {"calc_mean", options.calcMean},
         {"structured", PathSummaryToJson(structuredSummary)},
         {"json", PathSummaryToJson(jsonSummary)},
+        {"inspection", json::object({
+            {"present", jsonHasInspection},
+            {"ok", jsonHasInspection ? json(jsonOk) : json()},
+            {"reason", jsonHasInspection && !jsonReasons.empty() ? json(jsonReasons) : json()}
+        })},
         {"consistent", consistent},
+        {"inspection_consistent", inspectionConsistent},
         {"threshold_check_passed", thresholdCheckPassed},
         {"mean_check_passed", meanCheckPassed}
     };
@@ -600,7 +623,7 @@ int RunInferCommand(const InferOptions& options) {
     if (options.hasOutput) {
         WriteJsonFile(options.outputPath, output);
     }
-    return consistent && thresholdCheckPassed && meanCheckPassed ? 0 : 3;
+    return consistent && inspectionConsistent && thresholdCheckPassed && meanCheckPassed ? 0 : 3;
 }
 
 std::string GetCppDllPath() {

--- a/模块、流程与模型推理标准文档.md
+++ b/模块、流程与模型推理标准文档.md
@@ -119,7 +119,7 @@ OpenIVS 的模型只有两类：
 | 类型 | 作用 | 结构 |
 | --- | --- | --- |
 | `ObjectResult` | 表示一个目标的完整结果 | 一个类别 + 一个几何位置 + 一个区域信息集合 |
-| `SampleResult` | 表示一张图上的所有目标 | `results` 列表 |
+| `SampleResult` | 表示一张图上的所有目标及可选流程判定 | `results` 列表，可选 `ok/reason` |
 | `Result` | 表示一次批量请求的所有图片结果 | `sample_results` 列表 |
 
 ### 3.2 `ObjectResult`
@@ -147,6 +147,8 @@ OpenIVS 的模型只有两类：
 ### 3.3 JSON 结果
 
 `InferOneOutJson()` 和 `FlowGraphModel` 的外部 JSON 输出都围绕固定语义组织。JSON 结果数组中的每一项都表示一条完整结果。
+
+未产生流程判定时，单图 JSON 保持结果数组。类型数量校验等模块产生判定后，单图 JSON 使用 `{"result_list":[...],"ok":true|false,"reason":null|[...]}` 包装；批量 Flow 结果在每张图的容器中携带对应 `ok/reason`。`ok=false` 表示至少一条校验未通过，`reason` 保存失败原因；旧流程不增加这两个字段。
 
 | JSON 字段 | 含义 | 说明 |
 | --- | --- | --- |
@@ -357,6 +359,7 @@ Flow 中的所有模块都围绕同一套运行时对象工作。这样做的直
 3. 把结果写入 `frontend_json.last` 与 `frontend_json.by_node`。
 4. 供 `FlowGraphModel` 读取并组织成 `result_list`。
 5. 对同一节点、同一张图、同一次请求内的重复结果做去重。
+6. 将局部结果中的 `ok/reason` 聚合到对应原图的输出项。
 
 ## 6. 模块体系
 
@@ -417,6 +420,7 @@ Flow 中的模块围绕四类数据工作：
 | `post_process/result_filter_region_global`、`features/result_filter_region_global` | 按原图坐标区域筛选结果 | 图像、结果、原图区域框 | 区域内结果、区域外结果、`has_positive` |
 | `post_process/result_category_override`、`features/result_category_override` | 用第二路结果覆盖主路的类别名 | 主路结果、额外结果 | 覆盖后的结果 |
 | `post_process/poly_filter`、`features/poly_filter` | 从 `polygon` 或 `mask` 中提取边界折线并写入 `extra_info.polyline` | 图像、结果、边界参数 | 带折线的结果 |
+| `post_process/category_count_check` | 按 `origin_index` 汇总同一原图的多个局部结果，再按类别和规则校验数量 | 图像、局部结果、`rules` | 带 `ok/reason` 的结果及标量判定 |
 
 ### 6.5 输出与模板模块
 


### PR DESCRIPTION
## 变更内容

- C#、C++ 同步实现类型数量校验模块，按原图聚合 local 结果，NG 状态保持粘性并合并去重 reason。
- C# 使用可空状态字段，C++ 通过 `GetLastInspectionStatus` 暴露判定状态，避免破坏既有公开结果结构和 ABI；旧流程无状态时保持原返回格式。
- 修复 C# 旧式结果仅能通过 transform 对齐时丢失 `ok/reason` 的兼容问题，并增加回归用例。
- C#、C++ Demo 左上角显示 OK/NG，reason 显示在左侧预测结果下方；灰色高不透明背景，无额外投影。
- C# API 与 Demo 版本更新为 `2026.8.20.1`。

## 验证

- C# `category-count-check-selftest`：通过。
- C++ `category-count-check-selftest`：通过。
- `DlcvDemo`、`DlcvCSharpTest`、`dlcv_infer_cpp_qt_demo`、`dlcv_infer_cpp_test` Debug x64 构建通过。
- 构建产物版本：API/Demo FileVersion 与 ProductVersion 均为 `2026.8.20.1`。
- 指定 `.dvst` 实际推理：8 个目标返回 OK；7 个目标返回 NG，并返回“类别黑块期望=8,实际7”。

请审核，当前 PR 未合并。