### PR TITLE
C# 测试程序打印流程输出状态和原因

### DIFF
--- a/C#测试程序开发文档.md
+++ b/C#测试程序开发文档.md
@@ -210,7 +210,7 @@
   - **颜色**：根据类别（OK/NG）区分颜色（如绿/红）。
   - **无结果状态**：当 `SampleResults.Count==0` 时，自动显示左上角状态文本 `No Result`（控件会将 `ShowStatusText` 置为 `true`）。
   - **流程判定状态**：`CSharpSampleResult.Ok` 有值时优先在图像左上角显示带阴影的灰色半透明方块，方块内为绿色 `OK` 或红色 `NG`，不再根据类别名推测状态；`Ok` 无值时保留原有 `ShowStatusText` 行为。
-  - **失败原因**：`CSharpSampleResult.Reason` 非空时，显示在左侧预测结果文本下方。
+  - **流程输出文本**：`CSharpSampleResult.Ok` 有值时，在左侧预测结果中显示 `流程输出结果：OK` 或 `流程输出结果：NG`；`CSharpSampleResult.Reason` 非空时，紧接下一行显示 `流程输出原因：{reason}`。
 
 ### 6. 主流程与状态（必须一致）
 

--- a/DlcvCsharpApi/Properties/AssemblyInfo.cs
+++ b/DlcvCsharpApi/Properties/AssemblyInfo.cs
@@ -29,6 +29,6 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.8.20.1")]
-[assembly: AssemblyFileVersion("2026.8.20.1")]
-[assembly: AssemblyInformationalVersion("2026.8.20.1")]
+[assembly: AssemblyVersion("2026.8.20.2")]
+[assembly: AssemblyFileVersion("2026.8.20.2")]
+[assembly: AssemblyInformationalVersion("2026.8.20.2")]

--- a/DlcvDemo/Form1.cs
+++ b/DlcvDemo/Form1.cs
@@ -531,10 +531,12 @@ namespace DlcvDemo
                 sb.AppendLine($"推理时间: {delay_ms:F2}ms");
 
                 List<CSharpObjectResult> objects = null;
+                bool? inspectionOk = null;
                 string reason = null;
                 if (result.SampleResults != null && result.SampleResults.Count > 0)
                 {
                     objects = result.SampleResults[0].Results;
+                    inspectionOk = result.SampleResults[0].Ok;
                     reason = result.SampleResults[0].Reason;
                 }
                 if (objects == null)
@@ -543,9 +545,13 @@ namespace DlcvDemo
                 }
 
                 sb.AppendLine($"推理结果: {objects.Count}个");
+                if (inspectionOk.HasValue)
+                {
+                    sb.AppendLine(inspectionOk.Value ? "流程输出结果：OK" : "流程输出结果：NG");
+                }
                 if (!string.IsNullOrWhiteSpace(reason))
                 {
-                    sb.AppendLine("原因: " + reason);
+                    sb.AppendLine("流程输出原因：" + reason);
                 }
                 if (objects.Count == 0)
                 {

--- a/DlcvDemo/MainWindow.xaml.cs
+++ b/DlcvDemo/MainWindow.xaml.cs
@@ -626,10 +626,12 @@ namespace DlcvDemo
                 sb.AppendLine($"推理时间: {delay_ms:F2}ms");
 
                 List<CSharpObjectResult> objects = null;
+                bool? inspectionOk = null;
                 string reason = null;
                 if (result.SampleResults != null && result.SampleResults.Count > 0)
                 {
                     objects = result.SampleResults[0].Results;
+                    inspectionOk = result.SampleResults[0].Ok;
                     reason = result.SampleResults[0].Reason;
                 }
                 if (objects == null)
@@ -638,9 +640,13 @@ namespace DlcvDemo
                 }
 
                 sb.AppendLine($"推理结果: {objects.Count}个");
+                if (inspectionOk.HasValue)
+                {
+                    sb.AppendLine(inspectionOk.Value ? "流程输出结果：OK" : "流程输出结果：NG");
+                }
                 if (!string.IsNullOrWhiteSpace(reason))
                 {
-                    sb.AppendLine("原因: " + reason);
+                    sb.AppendLine("流程输出原因：" + reason);
                 }
                 if (objects.Count == 0)
                 {

--- a/DlcvDemo/Properties/AssemblyInfo.cs
+++ b/DlcvDemo/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.8.20.1")]
-[assembly: AssemblyFileVersion("2026.8.20.1")]
-[assembly: AssemblyInformationalVersion("2026.8.20.1")]
+[assembly: AssemblyVersion("2026.8.20.2")]
+[assembly: AssemblyFileVersion("2026.8.20.2")]
+[assembly: AssemblyInformationalVersion("2026.8.20.2")]
 [assembly: NeutralResourcesLanguage("zh-CN")]


### PR DESCRIPTION
## 修改内容
- C# 测试程序在结果包含判定状态时输出 流程输出结果：OK 或 流程输出结果：NG
- 判定原因紧接状态下一行输出为 流程输出原因：{reason}
- 同步 WPF 正式界面与 WinForms 兼容实现
- Ok 为空时不增加状态或原因文本，兼容旧流程模型

## 验证
- Debug / x64 构建 DlcvDemo 成功
- 8 个目标样例输出 流程输出结果：OK
- 7 个目标样例连续输出 流程输出结果：NG 和 流程输出原因：类别黑块期望=8,实际7
- 旧流程模型未增加流程输出状态或原因文本