### PR TITLE
同步区域类别检查到 C# 和 C++

### DIFF
--- a/DlcvCsharpApi/DlcvCsharpApi.csproj
+++ b/DlcvCsharpApi/DlcvCsharpApi.csproj
@@ -92,6 +92,7 @@
     <Compile Include="flow\modules\MaskRleUtils.cs" />
     <Compile Include="flow\modules\ComponentSizeMeasure.cs" />
     <Compile Include="flow\modules\CategoryCountCheck.cs" />
+    <Compile Include="flow\modules\RegionCategoryCheck.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="sntl_admin_csharp.cs" />
     <Compile Include="sequence\Schemas.cs" />

--- a/DlcvCsharpApi/Properties/AssemblyInfo.cs
+++ b/DlcvCsharpApi/Properties/AssemblyInfo.cs
@@ -29,6 +29,6 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.8.20.2")]
-[assembly: AssemblyFileVersion("2026.8.20.2")]
-[assembly: AssemblyInformationalVersion("2026.8.20.2")]
+[assembly: AssemblyVersion("2026.8.21.0")]
+[assembly: AssemblyFileVersion("2026.8.21.0")]
+[assembly: AssemblyInformationalVersion("2026.8.21.0")]

--- a/DlcvCsharpApi/flow/modules/RegionCategoryCheck.cs
+++ b/DlcvCsharpApi/flow/modules/RegionCategoryCheck.cs
@@ -1,0 +1,329 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using Newtonsoft.Json.Linq;
+
+namespace DlcvModules
+{
+    /// <summary>
+    /// post_process/region_category_check：逐条 local 结果按区域和类别校验数量。
+    /// </summary>
+    public class RegionCategoryCheck : BaseModule
+    {
+        static RegionCategoryCheck()
+        {
+            ModuleRegistry.Register("post_process/region_category_check", typeof(RegionCategoryCheck));
+        }
+
+        public RegionCategoryCheck(
+            int nodeId,
+            string title = null,
+            Dictionary<string, object> properties = null,
+            ExecutionContext context = null)
+            : base(nodeId, title, properties, context)
+        {
+        }
+
+        public override ModuleIO Process(List<ModuleImage> imageList = null, JArray resultList = null)
+        {
+            var images = imageList ?? new List<ModuleImage>();
+            var results = resultList ?? new JArray();
+            var rules = ParseRules();
+            string matchMode = ReadStringProperty("match_mode", "center_in_region");
+            double iouThreshold = ReadDoubleProperty("iou_threshold", 0.3);
+            bool generateVirtual = ReadBoolProperty("generate_virtual_box", true);
+            bool markOutside = ReadBoolProperty("mark_outside_as_excess", true);
+            bool allOk = true;
+            var allReasons = new List<string>();
+
+            foreach (JToken token in results)
+            {
+                var entry = token as JObject;
+                if (entry == null || !string.Equals(entry["type"]?.ToString(), "local", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var detections = entry["sample_results"] as JArray ?? new JArray();
+                var sourceDetections = new List<JObject>();
+                foreach (JToken detectionToken in detections)
+                {
+                    var detection = detectionToken as JObject;
+                    if (detection != null) sourceDetections.Add(detection);
+                }
+                var violations = new List<string>();
+
+                for (int ruleIndex = 0; ruleIndex < rules.Count; ruleIndex++)
+                {
+                    Rule rule = rules[ruleIndex];
+                    var inRegion = new List<JObject>();
+                    var outside = new List<JObject>();
+
+                    for (int detectionIndex = 0; detectionIndex < sourceDetections.Count; detectionIndex++)
+                    {
+                        JObject detection = sourceDetections[detectionIndex];
+                        if (!string.Equals(detection["category_name"]?.ToString(), rule.Category, StringComparison.Ordinal))
+                        {
+                            continue;
+                        }
+
+                        if (IsInRegion(detection, rule, matchMode, iouThreshold))
+                        {
+                            inRegion.Add(detection);
+                        }
+                        else
+                        {
+                            outside.Add(detection);
+                        }
+                    }
+
+                    if (inRegion.Count < rule.Expect)
+                    {
+                        int shortCount = rule.Expect - inRegion.Count;
+                        for (int i = 0; i < shortCount; i++)
+                        {
+                            string reason = rule.Category + " 缺失";
+                            if (generateVirtual)
+                            {
+                                detections.Add(new JObject
+                                {
+                                    ["category_name"] = rule.Category,
+                                    ["score"] = 0,
+                                    ["bbox"] = new JArray(rule.X, rule.Y, rule.Width, rule.Height),
+                                    ["reason"] = reason,
+                                    ["is_virtual"] = true
+                                });
+                            }
+                            violations.Add(reason);
+                        }
+                    }
+
+                    if (inRegion.Count > rule.Expect)
+                    {
+                        string reason = rule.Category + " 区域内超量";
+                        for (int i = rule.Expect; i < inRegion.Count; i++)
+                        {
+                            inRegion[i]["reason"] = reason;
+                            inRegion[i]["is_virtual"] = false;
+                        }
+                        violations.Add(reason);
+                    }
+
+                    if (markOutside && outside.Count > 0)
+                    {
+                        string reason = rule.Category + " 区域外检出";
+                        for (int i = 0; i < outside.Count; i++)
+                        {
+                            outside[i]["reason"] = reason;
+                            outside[i]["is_virtual"] = false;
+                        }
+                        violations.Add(reason);
+                    }
+                }
+
+                bool moduleOk = violations.Count == 0;
+                bool? existingOk = ReadNullableBool(entry["ok"]);
+                bool entryOk = existingOk.HasValue
+                    ? (moduleOk ? existingOk.Value : false)
+                    : moduleOk;
+                var existingReasons = entry["reason"] as JArray;
+                var entryReasons = existingReasons != null
+                    ? (JArray)existingReasons.DeepClone()
+                    : new JArray();
+
+                for (int i = 0; i < violations.Count; i++)
+                {
+                    entryReasons.Add(violations[i]);
+                }
+
+                entry["ok"] = entryOk;
+                entry["reason"] = entryReasons.Count > 0
+                    ? (JToken)entryReasons
+                    : JValue.CreateNull();
+                entry["sample_results"] = detections;
+
+                if (!entryOk)
+                {
+                    allOk = false;
+                    foreach (JToken reason in entryReasons)
+                    {
+                        if (reason != null && reason.Type != JTokenType.Null)
+                        {
+                            allReasons.Add(reason.ToString());
+                        }
+                    }
+                }
+            }
+
+            ScalarOutputsByName["ok"] = allOk;
+            ScalarOutputsByName["reason"] = allReasons.Count > 0
+                ? string.Join("; ", allReasons)
+                : string.Empty;
+
+            return new ModuleIO(images, results);
+        }
+
+        private List<Rule> ParseRules()
+        {
+            if (Properties == null || !Properties.TryGetValue("rules", out object raw) || raw == null)
+            {
+                return new List<Rule>();
+            }
+
+            JToken parsed = null;
+            if (raw is string text)
+            {
+                try { parsed = JToken.Parse(text); } catch { return new List<Rule>(); }
+            }
+            else if (raw is JToken token)
+            {
+                parsed = token;
+            }
+            else if (raw is IEnumerable && !(raw is string))
+            {
+                try { parsed = JToken.FromObject(raw); } catch { return new List<Rule>(); }
+            }
+            else
+            {
+                try { parsed = JToken.FromObject(raw); } catch { return new List<Rule>(); }
+            }
+
+            var array = parsed as JArray;
+            if (array == null && parsed is JObject single)
+            {
+                array = new JArray(single);
+            }
+
+            var rules = new List<Rule>();
+            if (array == null) return rules;
+
+            foreach (JToken token in array)
+            {
+                var item = token as JObject;
+                if (item == null) continue;
+                rules.Add(new Rule(
+                    ReadDouble(item["x"], 0.0),
+                    ReadDouble(item["y"], 0.0),
+                    ReadDouble(item["w"], 0.0),
+                    ReadDouble(item["h"], 0.0),
+                    item["category"] == null || item["category"].Type == JTokenType.Null
+                        ? string.Empty
+                        : item["category"].ToString(),
+                    ReadInt(item["expect"], 0)));
+            }
+            return rules;
+        }
+
+        private static bool IsInRegion(JObject detection, Rule rule, string mode, double iouThreshold)
+        {
+            var bbox = detection["bbox"] as JArray;
+            if (bbox == null || bbox.Count != 4) return false;
+
+            double x = ReadDouble(bbox[0], double.NaN);
+            double y = ReadDouble(bbox[1], double.NaN);
+            double width = ReadDouble(bbox[2], double.NaN);
+            double height = ReadDouble(bbox[3], double.NaN);
+            if (double.IsNaN(x) || double.IsNaN(y) || double.IsNaN(width) || double.IsNaN(height)) return false;
+
+            double x2 = x + width;
+            double y2 = y + height;
+            double regionX2 = rule.X + rule.Width;
+            double regionY2 = rule.Y + rule.Height;
+
+            if (string.Equals(mode, "center_in_region", StringComparison.Ordinal))
+            {
+                double centerX = x + width / 2.0;
+                double centerY = y + height / 2.0;
+                return rule.X <= centerX && centerX <= regionX2 &&
+                    rule.Y <= centerY && centerY <= regionY2;
+            }
+
+            if (string.Equals(mode, "iou", StringComparison.Ordinal))
+            {
+                double intersectionWidth = Math.Max(0.0, Math.Min(x2, regionX2) - Math.Max(x, rule.X));
+                double intersectionHeight = Math.Max(0.0, Math.Min(y2, regionY2) - Math.Max(y, rule.Y));
+                double intersectionArea = intersectionWidth * intersectionHeight;
+                double boxArea = Math.Max(1e-8, width * height);
+                return intersectionArea / boxArea >= iouThreshold;
+            }
+
+            return !(x2 <= rule.X || x >= regionX2 || y2 <= rule.Y || y >= regionY2);
+        }
+
+        private string ReadStringProperty(string key, string defaultValue)
+        {
+            if (Properties != null && Properties.TryGetValue(key, out object raw) && raw != null)
+            {
+                return raw.ToString();
+            }
+            return defaultValue;
+        }
+
+        private double ReadDoubleProperty(string key, double defaultValue)
+        {
+            if (Properties != null && Properties.TryGetValue(key, out object raw) && raw != null)
+            {
+                try { return Convert.ToDouble(raw, CultureInfo.InvariantCulture); } catch { }
+            }
+            return defaultValue;
+        }
+
+        private bool ReadBoolProperty(string key, bool defaultValue)
+        {
+            if (Properties != null && Properties.TryGetValue(key, out object raw) && raw != null)
+            {
+                try
+                {
+                    if (raw is bool value) return value;
+                    if (bool.TryParse(raw.ToString(), out bool parsed)) return parsed;
+                    return Convert.ToInt32(raw, CultureInfo.InvariantCulture) != 0;
+                }
+                catch { }
+            }
+            return defaultValue;
+        }
+
+        private static double ReadDouble(JToken token, double defaultValue)
+        {
+            if (token == null || token.Type == JTokenType.Null) return defaultValue;
+            try { return Convert.ToDouble(token.ToString(), CultureInfo.InvariantCulture); }
+            catch { return defaultValue; }
+        }
+
+        private static int ReadInt(JToken token, int defaultValue)
+        {
+            double value = ReadDouble(token, defaultValue);
+            if (double.IsNaN(value) || double.IsInfinity(value)) return defaultValue;
+            if (value >= int.MaxValue) return int.MaxValue;
+            if (value <= int.MinValue) return int.MinValue;
+            return (int)value;
+        }
+
+        private static bool? ReadNullableBool(JToken token)
+        {
+            if (token == null || token.Type == JTokenType.Null) return null;
+            try { return token.Value<bool>(); } catch { return null; }
+        }
+
+        private sealed class Rule
+        {
+            public double X { get; private set; }
+            public double Y { get; private set; }
+            public double Width { get; private set; }
+            public double Height { get; private set; }
+            public string Category { get; private set; }
+            public int Expect { get; private set; }
+
+            public Rule(double x, double y, double width, double height, string category, int expect)
+            {
+                X = x;
+                Y = y;
+                Width = width;
+                Height = height;
+                Category = category;
+                Expect = expect;
+            }
+        }
+    }
+}

--- a/DlcvDemo/Properties/AssemblyInfo.cs
+++ b/DlcvDemo/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.8.20.2")]
-[assembly: AssemblyFileVersion("2026.8.20.2")]
-[assembly: AssemblyInformationalVersion("2026.8.20.2")]
+[assembly: AssemblyVersion("2026.8.21.0")]
+[assembly: AssemblyFileVersion("2026.8.21.0")]
+[assembly: AssemblyInformationalVersion("2026.8.21.0")]
 [assembly: NeutralResourcesLanguage("zh-CN")]

--- a/dlcv_infer_cpp_dll/flow/modules/PostProcessModules.cpp
+++ b/dlcv_infer_cpp_dll/flow/modules/PostProcessModules.cpp
@@ -2328,6 +2328,245 @@ private:
     }
 };
 
+/// post_process/region_category_check
+class RegionCategoryCheckModule final : public BaseModule {
+public:
+    using BaseModule::BaseModule;
+
+    ModuleIO Process(const std::vector<ModuleImage>& imageList, const Json& resultList) override {
+        Json results = resultList.is_array() ? resultList : Json::array();
+        return ProcessCore(imageList, std::move(results));
+    }
+
+    ModuleIO ProcessOwned(const std::vector<ModuleImage>& imageList, Json&& resultList) override {
+        Json results = resultList.is_array() ? std::move(resultList) : Json::array();
+        return ProcessCore(imageList, std::move(results));
+    }
+
+private:
+    struct Rule final {
+        double X = 0.0;
+        double Y = 0.0;
+        double Width = 0.0;
+        double Height = 0.0;
+        std::string Category;
+        int Expect = 0;
+    };
+
+    static double ParseNumber(const Json& value, double defaultValue) {
+        try {
+            if (value.is_number()) return value.get<double>();
+            if (value.is_string()) return std::stod(value.get<std::string>());
+        } catch (...) {}
+        return defaultValue;
+    }
+
+    static int ParseExpect(const Json& value) {
+        const double number = ParseNumber(value, 0.0);
+        if (!std::isfinite(number)) return 0;
+        if (number >= static_cast<double>(std::numeric_limits<int>::max())) {
+            return std::numeric_limits<int>::max();
+        }
+        if (number <= static_cast<double>(std::numeric_limits<int>::min())) {
+            return std::numeric_limits<int>::min();
+        }
+        return static_cast<int>(number);
+    }
+
+    std::vector<Rule> ParseRules() const {
+        Json raw = Json::array();
+        try {
+            if (Properties.is_object() && Properties.contains("rules")) raw = Properties.at("rules");
+            if (raw.is_string()) raw = Json::parse(raw.get<std::string>());
+        } catch (...) {
+            return {};
+        }
+
+        if (raw.is_object()) raw = Json::array({ raw });
+        if (!raw.is_array()) return {};
+
+        std::vector<Rule> rules;
+        for (const auto& item : raw) {
+            if (!item.is_object()) continue;
+            Rule rule;
+            if (item.contains("x")) rule.X = ParseNumber(item.at("x"), 0.0);
+            if (item.contains("y")) rule.Y = ParseNumber(item.at("y"), 0.0);
+            if (item.contains("w")) rule.Width = ParseNumber(item.at("w"), 0.0);
+            if (item.contains("h")) rule.Height = ParseNumber(item.at("h"), 0.0);
+            if (item.contains("category") && !item.at("category").is_null()) {
+                rule.Category = item.at("category").is_string()
+                    ? item.at("category").get<std::string>()
+                    : item.at("category").dump();
+            }
+            if (item.contains("expect")) rule.Expect = ParseExpect(item.at("expect"));
+            rules.push_back(std::move(rule));
+        }
+        return rules;
+    }
+
+    static bool IsInRegion(
+        const Json& detection,
+        const Rule& rule,
+        const std::string& mode,
+        double iouThreshold
+    ) {
+        if (!detection.is_object() || !detection.contains("bbox")) return false;
+        const Json& bbox = detection.at("bbox");
+        if (!bbox.is_array() || bbox.size() != 4) return false;
+
+        const double x = ParseNumber(bbox.at(0), std::numeric_limits<double>::quiet_NaN());
+        const double y = ParseNumber(bbox.at(1), std::numeric_limits<double>::quiet_NaN());
+        const double width = ParseNumber(bbox.at(2), std::numeric_limits<double>::quiet_NaN());
+        const double height = ParseNumber(bbox.at(3), std::numeric_limits<double>::quiet_NaN());
+        if (!std::isfinite(x) || !std::isfinite(y) || !std::isfinite(width) || !std::isfinite(height)) {
+            return false;
+        }
+
+        const double x2 = x + width;
+        const double y2 = y + height;
+        const double regionX2 = rule.X + rule.Width;
+        const double regionY2 = rule.Y + rule.Height;
+
+        if (mode == "center_in_region") {
+            const double centerX = x + width / 2.0;
+            const double centerY = y + height / 2.0;
+            return rule.X <= centerX && centerX <= regionX2 &&
+                rule.Y <= centerY && centerY <= regionY2;
+        }
+
+        if (mode == "iou") {
+            const double intersectionWidth = std::max(0.0, std::min(x2, regionX2) - std::max(x, rule.X));
+            const double intersectionHeight = std::max(0.0, std::min(y2, regionY2) - std::max(y, rule.Y));
+            const double intersectionArea = intersectionWidth * intersectionHeight;
+            const double boxArea = std::max(1e-8, width * height);
+            return intersectionArea / boxArea >= iouThreshold;
+        }
+
+        return !(x2 <= rule.X || x >= regionX2 || y2 <= rule.Y || y >= regionY2);
+    }
+
+    static std::string ReadCategoryName(const Json& detection) {
+        try {
+            if (!detection.is_object() || !detection.contains("category_name")) return std::string();
+            const Json& value = detection.at("category_name");
+            if (value.is_string()) return value.get<std::string>();
+            if (!value.is_null()) return value.dump();
+        } catch (...) {}
+        return std::string();
+    }
+
+    ModuleIO ProcessCore(const std::vector<ModuleImage>& imageList, Json&& results) {
+        const std::vector<Rule> rules = ParseRules();
+        const std::string matchMode = ReadString("match_mode", "center_in_region");
+        const double iouThreshold = ReadDouble("iou_threshold", 0.3);
+        const bool generateVirtual = ReadBool("generate_virtual_box", true);
+        const bool markOutside = ReadBool("mark_outside_as_excess", true);
+        bool allOk = true;
+        std::vector<std::string> allReasons;
+
+        for (auto& entry : results) {
+            if (!entry.is_object() || entry.value("type", std::string()) != "local") continue;
+
+            Json detections = entry.contains("sample_results") && entry.at("sample_results").is_array()
+                ? entry.at("sample_results")
+                : Json::array();
+            const size_t sourceCount = detections.size();
+            std::vector<std::string> violations;
+
+            for (const auto& rule : rules) {
+                std::vector<size_t> inRegion;
+                std::vector<size_t> outside;
+
+                for (size_t detectionIndex = 0; detectionIndex < sourceCount; detectionIndex++) {
+                    const Json& detection = detections.at(detectionIndex);
+                    if (!detection.is_object() || ReadCategoryName(detection) != rule.Category) continue;
+                    if (IsInRegion(detection, rule, matchMode, iouThreshold)) {
+                        inRegion.push_back(detectionIndex);
+                    } else {
+                        outside.push_back(detectionIndex);
+                    }
+                }
+
+                if (static_cast<int>(inRegion.size()) < rule.Expect) {
+                    const int shortCount = rule.Expect - static_cast<int>(inRegion.size());
+                    for (int i = 0; i < shortCount; i++) {
+                        const std::string reason = rule.Category + " 缺失";
+                        if (generateVirtual) {
+                            Json virtualDetection = Json::object();
+                            virtualDetection["category_name"] = rule.Category;
+                            virtualDetection["score"] = 0;
+                            virtualDetection["bbox"] = Json::array({ rule.X, rule.Y, rule.Width, rule.Height });
+                            virtualDetection["reason"] = reason;
+                            virtualDetection["is_virtual"] = true;
+                            detections.push_back(std::move(virtualDetection));
+                        }
+                        violations.push_back(reason);
+                    }
+                }
+
+                if (static_cast<int>(inRegion.size()) > rule.Expect) {
+                    const std::string reason = rule.Category + " 区域内超量";
+                    const size_t firstExcess = rule.Expect > 0 ? static_cast<size_t>(rule.Expect) : 0;
+                    for (size_t i = firstExcess; i < inRegion.size(); i++) {
+                        Json& detection = detections.at(inRegion[i]);
+                        detection["reason"] = reason;
+                        detection["is_virtual"] = false;
+                    }
+                    violations.push_back(reason);
+                }
+
+                if (markOutside && !outside.empty()) {
+                    const std::string reason = rule.Category + " 区域外检出";
+                    for (size_t detectionIndex : outside) {
+                        Json& detection = detections.at(detectionIndex);
+                        detection["reason"] = reason;
+                        detection["is_virtual"] = false;
+                    }
+                    violations.push_back(reason);
+                }
+            }
+
+            const bool moduleOk = violations.empty();
+            bool entryOk = moduleOk;
+            if (entry.contains("ok") && entry.at("ok").is_boolean()) {
+                const bool existingOk = entry.at("ok").get<bool>();
+                entryOk = moduleOk ? existingOk : false;
+            }
+
+            Json entryReasons = Json::array();
+            if (entry.contains("reason") && entry.at("reason").is_array()) {
+                entryReasons = entry.at("reason");
+            }
+            for (const auto& reason : violations) entryReasons.push_back(reason);
+
+            entry["ok"] = entryOk;
+            entry["reason"] = entryReasons.empty() ? Json(nullptr) : std::move(entryReasons);
+            entry["sample_results"] = std::move(detections);
+
+            if (!entryOk) {
+                allOk = false;
+                const Json& reasons = entry.at("reason");
+                if (reasons.is_array()) {
+                    for (const auto& reason : reasons) {
+                        if (reason.is_null()) continue;
+                        allReasons.push_back(reason.is_string() ? reason.get<std::string>() : reason.dump());
+                    }
+                }
+            }
+        }
+
+        ScalarOutputsByName["ok"] = allOk;
+        std::string reasonText;
+        for (size_t i = 0; i < allReasons.size(); i++) {
+            if (i > 0) reasonText += "; ";
+            reasonText += allReasons[i];
+        }
+        ScalarOutputsByName["reason"] = reasonText;
+
+        return ModuleIO(imageList, results, Json::array());
+    }
+};
+
 /// post_process/category_count_check
 class CategoryCountCheckModule final : public BaseModule {
 public:
@@ -2603,6 +2842,7 @@ DLCV_FLOW_REGISTER_MODULE("post_process/multi_category_filter", MultiCategoryFil
 DLCV_FLOW_REGISTER_MODULE("features/multi_category_filter", MultiCategoryFilterModule)
 DLCV_FLOW_REGISTER_MODULE("post_process/result_filter_advanced", ResultFilterAdvancedModule)
 DLCV_FLOW_REGISTER_MODULE("features/result_filter_advanced", ResultFilterAdvancedModule)
+DLCV_FLOW_REGISTER_MODULE("post_process/region_category_check", RegionCategoryCheckModule)
 DLCV_FLOW_REGISTER_MODULE("post_process/category_count_check", CategoryCountCheckModule)
 DLCV_FLOW_REGISTER_MODULE("post_process/count_results", CountResultsModule)
 DLCV_FLOW_REGISTER_MODULE("features/count_results", CountResultsModule)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import shutil
 
 from setuptools import setup
 
-version = '2026.8.20.0'
+version = '2026.8.21.0'
 
 package_name = "dlcvpro_infer_csharp"  # 包名
 packages: list = [package_name]  # 需要打包的包


### PR DESCRIPTION
## 修改内容

- 在 C# `DlcvCsharpApi` 中新增并注册 `post_process/region_category_check`，使加速 `.dvst` 不再静默跳过区域类别检查节点。
- 在 C++ `dlcv_infer_cpp_dll` 中新增并注册同名模块，解决 `module_not_registered`。
- 对齐 Python 的逐 local 区域校验语义：支持规则数组/单对象/JSON 字符串、中心点/覆盖率/相交匹配、缺失/区域内超量/区域外检出、虚拟框以及粘性 `ok/reason`。
- 仅处理 `type=local` 的结果；未使用该节点的旧流程保持原有行为。
- 将 C# API、C# Demo 和 wheel 包版本统一更新为 `2026.8.21.0`。

## 验证

- 原始流程 JSON：OK 图得到 4 个 local 区域，黑块数量为 `[2,2,2,2]`，整体 OK；NG 图为 `[2,2,1,2]`，整体 NG，原因“黑块 缺失”。
- C# 使用指定加速 DVST 实际推理：8 个目标返回 `ok=true`；7 个目标返回 `ok=false`，原因“黑块 缺失”。
- C++ Qt Demo 使用指定加速 DVST 实际推理：8 个目标返回 `ok=true`；7 个目标返回 `ok=false`，原因“黑块 缺失”。
- `DlcvCsharpApi`、`DlcvDemo`、`dlcv_infer_cpp_dll`、`dlcv_infer_cpp_qt_demo` 均以 Debug/x64 构建成功。
- 构建产物 `DlcvCsharpApi.dll` 与 `DlcvDemo.exe` 的 AssemblyVersion、FileVersion、ProductVersion 均为 `2026.8.21.0`。