### PR TITLE
回滚：独立 C++ Model 的 C# index bridge

### DIFF
--- a/DlcvCsharpApi/Model.cs
+++ b/DlcvCsharpApi/Model.cs
@@ -81,44 +81,6 @@ namespace dlcv_infer_csharp
         private readonly object _batchMetaLock = new object();
         private List<JObject> _cachedSubModelBatchItems = new List<JObject>();
 
-        [StructLayout(LayoutKind.Sequential)]
-        private struct ModelIndexBridgeImage
-        {
-            public long DataPtr;
-            public int Height;
-            public int Width;
-            public int Channel;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        private struct ModelIndexBridgeImageList
-        {
-            public IntPtr Images;
-            public int Count;
-        }
-
-        [DllImport("dlcv_infer_cpp_dll.dll", CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr dlcv_infer_cpp_model_index_get_info(int modelIndex);
-
-        [DllImport("dlcv_infer_cpp_dll.dll", CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr dlcv_infer_cpp_model_index_infer(
-            int modelIndex,
-            ref ModelIndexBridgeImageList imageList,
-            IntPtr paramsJsonUtf8);
-
-        [DllImport("dlcv_infer_cpp_dll.dll", CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr dlcv_infer_cpp_model_index_result_json(IntPtr resultHandle);
-
-        [DllImport("dlcv_infer_cpp_dll.dll", CallingConvention = CallingConvention.Cdecl)]
-        private static extern void dlcv_infer_cpp_model_index_free_result(IntPtr resultHandle);
-
-        private bool UsesExternalModelIndexBridge =>
-            _dllLoader == null &&
-            _dvsModel == null &&
-            !_isDvpMode &&
-            !_isDvsMode &&
-            !_isRpcMode;
-
         public Model()
         {
 
@@ -622,13 +584,6 @@ namespace dlcv_infer_csharp
         public void FreeModel()
         {
             _expectedChCache = -2;
-
-            // 空构造后手动设置的 index 绑定到独立 C++ Model，C# 始终只借用。
-            if (UsesExternalModelIndexBridge)
-            {
-                modelIndex = -1;
-                return;
-            }
 
             // 仅借用/共享模式，不释放底层模型，只标记无效
             if (!OwnModelIndex)
@@ -1480,11 +1435,7 @@ namespace dlcv_infer_csharp
         public JObject GetModelInfo()
         {
             JObject modelInfo = null;
-            if (UsesExternalModelIndexBridge)
-            {
-                modelInfo = GetModelInfoByExternalIndex();
-            }
-            else if (_isDvpMode)
+            if (_isDvpMode)
             {
                 modelInfo = GetModelInfoDvp();
             }
@@ -1539,57 +1490,6 @@ namespace dlcv_infer_csharp
             }
             UpdateModelMetaCache(modelInfo);
             return modelInfo;
-        }
-
-        private static string PtrToUtf8String(IntPtr value)
-        {
-            if (value == IntPtr.Zero) return null;
-            int length = 0;
-            while (Marshal.ReadByte(value, length) != 0) length++;
-            var bytes = new byte[length];
-            Marshal.Copy(value, bytes, 0, length);
-            return Encoding.UTF8.GetString(bytes);
-        }
-
-        private static JObject ReadModelIndexBridgeResult(IntPtr resultHandle)
-        {
-            if (resultHandle == IntPtr.Zero)
-                throw new Exception("model index bridge returned null result");
-
-            IntPtr jsonPtr = dlcv_infer_cpp_model_index_result_json(resultHandle);
-            string json = PtrToUtf8String(jsonPtr);
-            if (string.IsNullOrWhiteSpace(json))
-                throw new Exception("model index bridge returned empty result");
-            return JObject.Parse(json);
-        }
-
-        private JObject GetModelInfoByExternalIndex()
-        {
-            if (modelIndex < 0)
-                throw new InvalidOperationException("modelIndex 未设置或对应 C++ Model 已释放");
-
-            IntPtr resultHandle = dlcv_infer_cpp_model_index_get_info(modelIndex);
-            try
-            {
-                JObject result = ReadModelIndexBridgeResult(resultHandle);
-                if ((result["code"]?.Value<int>() ?? 0) != 0)
-                    throw new Exception("获取模型信息失败: " + result["message"]);
-                return result;
-            }
-            finally
-            {
-                if (resultHandle != IntPtr.Zero)
-                    dlcv_infer_cpp_model_index_free_result(resultHandle);
-            }
-        }
-
-        private void FreeInferResult(IntPtr resultHandle)
-        {
-            if (resultHandle == IntPtr.Zero) return;
-            if (UsesExternalModelIndexBridge)
-                dlcv_infer_cpp_model_index_free_result(resultHandle);
-            else
-                _dllLoader?.dlcv_free_model_result(resultHandle);
         }
 
         private JObject GetModelInfoDvp()
@@ -1660,10 +1560,6 @@ namespace dlcv_infer_csharp
 
             try
             {
-                if (UsesExternalModelIndexBridge)
-                {
-                    return InferInternalByExternalIndex(normalized, params_json);
-                }
                 if (_isDvpMode)
                 {
                     return InferInternalDvp(normalized, params_json);
@@ -1853,83 +1749,6 @@ namespace dlcv_infer_csharp
             catch (Exception ex)
             {
                 throw new Exception($"DVP 推理失败: {ex.Message}", ex);
-            }
-        }
-
-        private Tuple<JObject, IntPtr> InferInternalByExternalIndex(List<Mat> images, JObject params_json)
-        {
-            if (modelIndex < 0)
-                throw new InvalidOperationException("modelIndex 未设置或对应 C++ Model 已释放");
-            if (images == null || images.Count == 0)
-                throw new ArgumentException("图像列表不能为空", nameof(images));
-
-            var processImages = new List<Tuple<Mat, bool>>();
-            GCHandle imageHandle = default(GCHandle);
-            GCHandle paramsHandle = default(GCHandle);
-            IntPtr resultHandle = IntPtr.Zero;
-            try
-            {
-                var nativeImages = new ModelIndexBridgeImage[images.Count];
-                for (int i = 0; i < images.Count; i++)
-                {
-                    Mat processImage = images[i];
-                    bool needDispose = false;
-                    if (processImage == null || processImage.Empty())
-                        throw new ArgumentException("输入图像不能为空", nameof(images));
-                    if (!processImage.IsContinuous())
-                    {
-                        processImage = processImage.Clone();
-                        needDispose = true;
-                    }
-                    processImages.Add(Tuple.Create(processImage, needDispose));
-                    nativeImages[i] = new ModelIndexBridgeImage
-                    {
-                        DataPtr = processImage.Data.ToInt64(),
-                        Height = processImage.Height,
-                        Width = processImage.Width,
-                        Channel = processImage.Channels()
-                    };
-                }
-
-                imageHandle = GCHandle.Alloc(nativeImages, GCHandleType.Pinned);
-                var imageList = new ModelIndexBridgeImageList
-                {
-                    Images = imageHandle.AddrOfPinnedObject(),
-                    Count = nativeImages.Length
-                };
-
-                string paramsText = (params_json ?? new JObject()).ToString(Formatting.None);
-                byte[] paramsBytes = Encoding.UTF8.GetBytes(paramsText + "\0");
-                paramsHandle = GCHandle.Alloc(paramsBytes, GCHandleType.Pinned);
-
-                resultHandle = dlcv_infer_cpp_model_index_infer(
-                    modelIndex,
-                    ref imageList,
-                    paramsHandle.AddrOfPinnedObject());
-                JObject resultObject = ReadModelIndexBridgeResult(resultHandle);
-                if ((resultObject["code"]?.Value<int>() ?? 0) != 0)
-                {
-                    string message = resultObject["message"]?.ToString() ?? "unknown error";
-                    dlcv_infer_cpp_model_index_free_result(resultHandle);
-                    resultHandle = IntPtr.Zero;
-                    throw new Exception("Inference failed: " + message);
-                }
-                return Tuple.Create(resultObject, resultHandle);
-            }
-            catch
-            {
-                if (resultHandle != IntPtr.Zero)
-                    dlcv_infer_cpp_model_index_free_result(resultHandle);
-                throw;
-            }
-            finally
-            {
-                if (paramsHandle.IsAllocated) paramsHandle.Free();
-                if (imageHandle.IsAllocated) imageHandle.Free();
-                foreach (var pair in processImages)
-                {
-                    if (pair.Item2) pair.Item1.Dispose();
-                }
             }
         }
 
@@ -2307,7 +2126,7 @@ namespace dlcv_infer_csharp
                     // 处理完后释放结果，DVP模式下指针为空，不需要释放
                     if (resultTuple.Item2 != IntPtr.Zero)
                     {
-                        FreeInferResult(resultTuple.Item2);
+                        _dllLoader?.dlcv_free_model_result(resultTuple.Item2);
                     }
                 }
             }
@@ -2357,7 +2176,7 @@ namespace dlcv_infer_csharp
                 // 处理完后释放结果，DVP模式下指针为空，不需要释放
                 if (resultTuple.Item2 != IntPtr.Zero)
                 {
-                    FreeInferResult(resultTuple.Item2);
+                    DllLoader.Instance.dlcv_free_model_result(resultTuple.Item2);
                 }
             }
         }
@@ -2472,7 +2291,7 @@ namespace dlcv_infer_csharp
                 // 处理完后释放结果
                 if (resultTuple.Item2 != IntPtr.Zero)
                 {
-                    FreeInferResult(resultTuple.Item2);
+                    DllLoader.Instance.dlcv_free_model_result(resultTuple.Item2);
                 }
             }
         }

--- a/Test/DlcvCSharpTest/Program.cs
+++ b/Test/DlcvCSharpTest/Program.cs
@@ -36,15 +36,6 @@ namespace DlcvCSharpTest
         private const string FlowInstanceSegFilterModelPath = @"Y:\zxc\模块化任务测试\实例分割筛选测试_120_50.dvst";
         private const string FlowInstanceSegFilterImagePath = @"Y:\zxc\模块化任务测试\实例分割\实例分割滑窗大图.png";
 
-        [DllImport("dlcv_infer_c_dll.dll", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-        private static extern int dlcv_infer_cpp_load_model_c(string modelPath, int deviceId);
-
-        [DllImport("dlcv_infer_c_dll.dll", CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr dlcv_infer_cpp_get_last_error_c();
-
-        [DllImport("dlcv_infer_c_dll.dll", CallingConvention = CallingConvention.Cdecl)]
-        private static extern int dlcv_infer_cpp_free_model_c(int modelIndex);
-
         private static readonly List<ModelCase> DefaultCases = new List<ModelCase>
         {
             new ModelCase("AOI-旋转框检测_120_50.dvt", "AOI-1.jpg"),
@@ -175,11 +166,6 @@ namespace DlcvCSharpTest
                 if (args != null && args.Length >= 1 && string.Equals(args[0], "dvst-double-load-selftest", StringComparison.OrdinalIgnoreCase))
                 {
                     return RunDvstDoubleLoadSelfTest();
-                }
-
-                if (args != null && args.Length >= 5 && string.Equals(args[0], "external-index-selftest", StringComparison.OrdinalIgnoreCase))
-                {
-                    return RunExternalIndexSelfTest(args);
                 }
 
                 if (args != null && args.Length >= 2)
@@ -4409,151 +4395,6 @@ namespace DlcvCSharpTest
             public IntPtr PagefileUsage;
             public IntPtr PeakPagefileUsage;
             public IntPtr PrivateUsage;
-        }
-
-        private static int RunExternalIndexSelfTest(string[] args)
-        {
-            Console.WriteLine("==== 独立 C++ Model -> C# 空构造 index 专项测试 ====");
-            bool dvtOk = RunExternalIndexCase("DVT", args[1], args[2]);
-            bool dvstOk = RunExternalIndexCase("DVST", args[3], args[4]);
-            bool ok = dvtOk && dvstOk;
-            Console.WriteLine(ok ? "External index test PASSED" : "External index test FAILED");
-            return ok ? 0 : 1;
-        }
-
-        private static bool RunExternalIndexCase(string name, string modelPath, string imagePath)
-        {
-            Console.WriteLine();
-            Console.WriteLine($"[{name}] model={modelPath}");
-            Console.WriteLine($"[{name}] image={imagePath}");
-            if (!File.Exists(modelPath) || !File.Exists(imagePath))
-            {
-                Console.WriteLine($"[{name}] FAIL: 模型或图片不存在");
-                return false;
-            }
-
-            int modelIndex = -1;
-            try
-            {
-                modelIndex = dlcv_infer_cpp_load_model_c(modelPath, GpuDeviceId);
-                if (modelIndex < 0)
-                {
-                    string error = Marshal.PtrToStringAnsi(dlcv_infer_cpp_get_last_error_c());
-                    Console.WriteLine($"[{name}] FAIL: C++ Model 加载失败: {error}");
-                    return false;
-                }
-
-                using (var borrowedModel = new Model())
-                using (var source = Cv2.ImRead(imagePath, ImreadModes.Unchanged))
-                using (var input = PrepareRgbInput(source))
-                {
-                    borrowedModel.modelIndex = modelIndex;
-                    borrowedModel.OwnModelIndex = false;
-
-                    JObject info = borrowedModel.GetModelInfo();
-                    if (info == null || !info.HasValues)
-                    {
-                        Console.WriteLine($"[{name}] FAIL: GetModelInfo 返回空对象");
-                        return false;
-                    }
-
-                    var result = borrowedModel.Infer(input, new JObject
-                    {
-                        ["threshold"] = 0.5,
-                        ["with_mask"] = true,
-                        ["calc_mean"] = false
-                    });
-                    if (result.SampleResults == null || result.SampleResults.Count != 1)
-                    {
-                        Console.WriteLine($"[{name}] FAIL: 推理没有返回单图结果");
-                        return false;
-                    }
-
-                    int objectCount = result.SampleResults[0].Results != null
-                        ? result.SampleResults[0].Results.Count
-                        : 0;
-                    Console.WriteLine($"[{name}] PASS: index={modelIndex}, info字段={info.Count}, 目标数={objectCount}");
-                    foreach (var sample in result.SampleResults)
-                    {
-                        if (sample.Results == null) continue;
-                        foreach (var item in sample.Results)
-                        {
-                            item.Mask?.Dispose();
-                        }
-                    }
-                }
-
-                using (var stillAliveModel = new Model())
-                {
-                    stillAliveModel.modelIndex = modelIndex;
-                    stillAliveModel.OwnModelIndex = false;
-                    JObject stillAliveInfo = stillAliveModel.GetModelInfo();
-                    if (stillAliveInfo == null || !stillAliveInfo.HasValues)
-                    {
-                        Console.WriteLine($"[{name}] FAIL: C# 借用对象释放后 C++ 模型不可访问");
-                        return false;
-                    }
-                }
-                Console.WriteLine($"[{name}] PASS: C# Dispose 未释放独立 C++ 模型");
-
-                int releasedIndex = modelIndex;
-                if (dlcv_infer_cpp_free_model_c(releasedIndex) != 0)
-                {
-                    Console.WriteLine($"[{name}] FAIL: C++ 模型释放失败");
-                    return false;
-                }
-                modelIndex = -1;
-
-                try
-                {
-                    using (var staleModel = new Model())
-                    {
-                        staleModel.modelIndex = releasedIndex;
-                        staleModel.OwnModelIndex = false;
-                        staleModel.GetModelInfo();
-                    }
-                    Console.WriteLine($"[{name}] FAIL: C++ 模型释放后旧 index 仍可访问");
-                    return false;
-                }
-                catch
-                {
-                    Console.WriteLine($"[{name}] PASS: C++ 模型释放后旧 index 已失效");
-                }
-                return true;
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"[{name}] FAIL: {ex}");
-                return false;
-            }
-            finally
-            {
-                if (modelIndex >= 0)
-                {
-                    dlcv_infer_cpp_free_model_c(modelIndex);
-                }
-            }
-        }
-
-        private static Mat PrepareRgbInput(Mat source)
-        {
-            if (source == null || source.Empty())
-            {
-                throw new InvalidOperationException("图片读取失败");
-            }
-            if (source.Channels() == 3)
-            {
-                var rgb = new Mat();
-                Cv2.CvtColor(source, rgb, ColorConversionCodes.BGR2RGB);
-                return rgb;
-            }
-            if (source.Channels() == 4)
-            {
-                var rgb = new Mat();
-                Cv2.CvtColor(source, rgb, ColorConversionCodes.BGRA2RGB);
-                return rgb;
-            }
-            return source.Clone();
         }
 
         private static int RunDvstDoubleLoadSelfTest()

--- a/dlcv_infer_cpp_dll/dlcv_infer.cpp
+++ b/dlcv_infer_cpp_dll/dlcv_infer.cpp
@@ -1169,43 +1169,6 @@ namespace dlcv_infer {
     static std::mutex g_modelIndexRefMu;
     static std::unordered_map<int, int> g_modelIndexRefCount;
 
-    // 同进程内已加载 C++ Model 的非拥有注册表，供 C# 空构造后按 index 借用。
-    // 同一个底层 index 可能因 content-hash 去重被多个 Model 共享，因此保留全部活跃实例。
-    static std::mutex g_registeredModelMu;
-    static std::unordered_map<int, std::vector<Model*>> g_registeredModels;
-
-    static void RegisterModelForIndexBridge(Model* model) {
-        if (!model || model->modelIndex < 0) return;
-        std::lock_guard<std::mutex> lk(g_registeredModelMu);
-        auto& models = g_registeredModels[model->modelIndex];
-        if (std::find(models.begin(), models.end(), model) == models.end()) {
-            models.push_back(model);
-        }
-    }
-
-    static void ReplaceModelForIndexBridge(int modelIndex, Model* oldModel, Model* newModel) {
-        if (modelIndex < 0 || !oldModel || !newModel) return;
-        std::lock_guard<std::mutex> lk(g_registeredModelMu);
-        auto it = g_registeredModels.find(modelIndex);
-        if (it == g_registeredModels.end()) return;
-        auto modelIt = std::find(it->second.begin(), it->second.end(), oldModel);
-        if (modelIt != it->second.end()) {
-            *modelIt = newModel;
-        }
-    }
-
-    static void UnregisterModelForIndexBridge(int modelIndex, Model* model) {
-        if (modelIndex < 0 || !model) return;
-        std::lock_guard<std::mutex> lk(g_registeredModelMu);
-        auto it = g_registeredModels.find(modelIndex);
-        if (it == g_registeredModels.end()) return;
-        auto& models = it->second;
-        models.erase(std::remove(models.begin(), models.end(), model), models.end());
-        if (models.empty()) {
-            g_registeredModels.erase(it);
-        }
-    }
-
     // dvst（流程模型）的 modelIndex 由本层自管理，从 10000 起递增，
     // 与底层 dvt 返回的 model_index（0 起递增）分区，避免上层按 modelIndex 索引时 dvst 与 dvt 撞键。
     static std::mutex g_flowModelIndexMu;
@@ -1582,7 +1545,6 @@ namespace dlcv_infer {
                     throw std::runtime_error(report.dump());
                 }
                 modelIndex = AllocateFlowModelIndex();
-                RegisterModelForIndexBridge(this);
                 return;
             } catch (const std::exception& ex) {
                 delete _flowModel;
@@ -1627,7 +1589,6 @@ namespace dlcv_infer {
             std::lock_guard<std::mutex> lk(g_modelIndexRefMu);
             g_modelIndexRefCount[modelIndex]++;
         }
-        RegisterModelForIndexBridge(this);
     }
 
     Model::Model(const std::wstring& modelPath, int device_id)
@@ -1651,7 +1612,6 @@ namespace dlcv_infer {
                     throw std::runtime_error(report.dump());
                 }
                 modelIndex = AllocateFlowModelIndex();
-                RegisterModelForIndexBridge(this);
                 return;
             } catch (const std::exception& ex) {
                 delete _flowModel;
@@ -1696,7 +1656,6 @@ namespace dlcv_infer {
             std::lock_guard<std::mutex> lk(g_modelIndexRefMu);
             g_modelIndexRefCount[modelIndex]++;
         }
-        RegisterModelForIndexBridge(this);
     }
 
     Model::Model(Model&& other) noexcept
@@ -1710,7 +1669,6 @@ namespace dlcv_infer {
         _dllLoader(other._dllLoader),
         _loadedDogProvider(other._loadedDogProvider),
         _loadedNativeDllName(std::move(other._loadedNativeDllName)) {
-        ReplaceModelForIndexBridge(modelIndex, &other, this);
         other.modelIndex = -1;
         other.OwnModelIndex = true;
         other._isFlowGraphMode = false;
@@ -1740,7 +1698,6 @@ namespace dlcv_infer {
         _dllLoader = other._dllLoader;
         _loadedDogProvider = other._loadedDogProvider;
         _loadedNativeDllName = std::move(other._loadedNativeDllName);
-        ReplaceModelForIndexBridge(modelIndex, &other, this);
 
         other.modelIndex = -1;
         other.OwnModelIndex = true;
@@ -1761,9 +1718,6 @@ namespace dlcv_infer {
 
     void Model::FreeModel() {
         _expectedChCache = -2;
-        if (modelIndex != -1) {
-            UnregisterModelForIndexBridge(modelIndex, this);
-        }
         if (_isFlowGraphMode) {
             delete _flowModel;
             _flowModel = nullptr;
@@ -2615,159 +2569,3 @@ namespace dlcv_infer {
     }
 
 }
-
-namespace {
-
-struct ModelIndexBridgeResult {
-    std::string jsonText;
-    std::vector<cv::Mat> masks;
-};
-
-ModelIndexBridgeResult* MakeModelIndexBridgeError(const std::string& message) {
-    auto* result = new ModelIndexBridgeResult();
-    Json root;
-    root["code"] = -1;
-    root["message"] = message;
-    result->jsonText = root.dump();
-    return result;
-}
-
-std::string ModelIndexBridgeCategoryNameToUtf8(const std::string& categoryName) {
-    try {
-        return dlcv_infer::convertGbkToUtf8(categoryName);
-    } catch (...) {
-        return categoryName;
-    }
-}
-
-} // namespace
-
-extern "C" {
-
-void* dlcv_infer_cpp_model_index_get_info(int model_index) {
-    try {
-        std::lock_guard<std::mutex> lk(dlcv_infer::g_registeredModelMu);
-        const auto it = dlcv_infer::g_registeredModels.find(model_index);
-        if (it == dlcv_infer::g_registeredModels.end() || it->second.empty()) {
-            return MakeModelIndexBridgeError("model index is not registered or has been released");
-        }
-
-        auto result = std::make_unique<ModelIndexBridgeResult>();
-        result->jsonText = it->second.back()->GetModelInfo().dump();
-        return result.release();
-    } catch (const std::exception& ex) {
-        return MakeModelIndexBridgeError(ex.what());
-    } catch (...) {
-        return MakeModelIndexBridgeError("unknown error while getting model info");
-    }
-}
-
-void* dlcv_infer_cpp_model_index_infer(
-    int model_index,
-    const DlcvModelIndexBridgeImageList* image_list,
-    const char* params_json_utf8) {
-    if (!image_list || image_list->n <= 0 || !image_list->images) {
-        return MakeModelIndexBridgeError("invalid image list");
-    }
-
-    try {
-        std::lock_guard<std::mutex> lk(dlcv_infer::g_registeredModelMu);
-        const auto it = dlcv_infer::g_registeredModels.find(model_index);
-        if (it == dlcv_infer::g_registeredModels.end() || it->second.empty()) {
-            return MakeModelIndexBridgeError("model index is not registered or has been released");
-        }
-
-        std::vector<cv::Mat> images;
-        images.reserve(image_list->n);
-        for (int i = 0; i < image_list->n; ++i) {
-            const DlcvModelIndexBridgeImage& image = image_list->images[i];
-            if (image.data_ptr == 0 || image.height <= 0 || image.width <= 0 || image.channel <= 0) {
-                return MakeModelIndexBridgeError("invalid image data");
-            }
-            images.emplace_back(
-                image.height,
-                image.width,
-                CV_8UC(image.channel),
-                reinterpret_cast<void*>(static_cast<uintptr_t>(image.data_ptr)));
-        }
-
-        dlcv_infer::json params = dlcv_infer::json::object();
-        if (params_json_utf8 && params_json_utf8[0] != '\0') {
-            params = dlcv_infer::json::parse(params_json_utf8);
-            if (!params.is_object()) {
-                return MakeModelIndexBridgeError("params_json must be a JSON object");
-            }
-        }
-
-        dlcv_infer::Result inferResult = it->second.back()->InferBatch(images, params);
-        auto result = std::make_unique<ModelIndexBridgeResult>();
-        size_t maskCount = 0;
-        for (const auto& sample : inferResult.sampleResults) {
-            for (const auto& item : sample.results) {
-                if (item.withMask && !item.mask.empty()) ++maskCount;
-            }
-        }
-        result->masks.reserve(maskCount);
-
-        Json root;
-        root["code"] = 0;
-        root["message"] = "success";
-        root["sample_results"] = Json::array();
-        for (const auto& sample : inferResult.sampleResults) {
-            Json sampleJson;
-            sampleJson["results"] = Json::array();
-            for (const auto& item : sample.results) {
-                Json itemJson;
-                itemJson["category_id"] = item.categoryId;
-                itemJson["category_name"] = ModelIndexBridgeCategoryNameToUtf8(item.categoryName);
-                itemJson["score"] = item.score;
-                itemJson["area"] = item.area;
-                itemJson["bbox"] = item.bbox;
-                itemJson["with_bbox"] = item.withBbox;
-                itemJson["with_angle"] = item.withAngle;
-                itemJson["angle"] = item.angle;
-                itemJson["with_mean"] = item.withMean;
-                itemJson["foreground_mean"] = item.foregroundMean;
-                itemJson["background_mean"] = item.backgroundMean;
-
-                if (item.withMask && !item.mask.empty()) {
-                    result->masks.push_back(item.mask.clone());
-                    const cv::Mat& mask = result->masks.back();
-                    itemJson["with_mask"] = true;
-                    itemJson["mask"] = Json::object({
-                        {"mask_ptr", static_cast<uint64_t>(reinterpret_cast<uintptr_t>(mask.data))},
-                        {"height", mask.rows},
-                        {"width", mask.cols}
-                    });
-                } else {
-                    itemJson["with_mask"] = false;
-                    itemJson["mask"] = Json::object({
-                        {"mask_ptr", 0},
-                        {"height", -1},
-                        {"width", -1}
-                    });
-                }
-                sampleJson["results"].push_back(std::move(itemJson));
-            }
-            root["sample_results"].push_back(std::move(sampleJson));
-        }
-
-        result->jsonText = root.dump();
-        return result.release();
-    } catch (const std::exception& ex) {
-        return MakeModelIndexBridgeError(ex.what());
-    } catch (...) {
-        return MakeModelIndexBridgeError("unknown error while running inference");
-    }
-}
-
-const char* dlcv_infer_cpp_model_index_result_json(void* result_handle) {
-    if (!result_handle) return nullptr;
-    return static_cast<ModelIndexBridgeResult*>(result_handle)->jsonText.c_str();
-}
-
-void dlcv_infer_cpp_model_index_free_result(void* result_handle) {
-    delete static_cast<ModelIndexBridgeResult*>(result_handle);
-}
-
-} // extern "C"

--- a/dlcv_infer_cpp_dll/dlcv_infer.h
+++ b/dlcv_infer_cpp_dll/dlcv_infer.h
@@ -326,29 +326,4 @@ namespace dlcv_infer {
         static int nvmlDeviceGetName(nvmlDevice_t device, char* name, unsigned int length);
         static int nvmlDeviceGetHandleByIndex(unsigned int index, nvmlDevice_t* device);
     };
-
-}
-
-// 供 C# 在同一进程内按 modelIndex 借用独立 C++ Model 的内部桥接接口。
-// Model 的所有权仍属于原 C++ 调用方；释放原 Model 后，该 index 立即失效。
-extern "C" {
-    struct DlcvModelIndexBridgeImage {
-        long long data_ptr;
-        int height;
-        int width;
-        int channel;
-    };
-
-    struct DlcvModelIndexBridgeImageList {
-        DlcvModelIndexBridgeImage* images;
-        int n;
-    };
-
-    DLCV_INFER_CPP_DLL_API void* dlcv_infer_cpp_model_index_get_info(int model_index);
-    DLCV_INFER_CPP_DLL_API void* dlcv_infer_cpp_model_index_infer(
-        int model_index,
-        const DlcvModelIndexBridgeImageList* image_list,
-        const char* params_json_utf8);
-    DLCV_INFER_CPP_DLL_API const char* dlcv_infer_cpp_model_index_result_json(void* result_handle);
-    DLCV_INFER_CPP_DLL_API void dlcv_infer_cpp_model_index_free_result(void* result_handle);
 }


### PR DESCRIPTION
## 摘要

回滚 PR #219（提交 `a5e3d3f`）中“独立 C++ `Model` 加载后，C# 空构造 `Model` 通过 `modelIndex` 借用”的实现。

本 PR 只撤销 #219 涉及的 4 个文件，不修改普通 DVT/DVST 加载、推理和现有 `Model(modelPath, deviceId)` 接口。

## 回滚原因

1. 实现引入了进程级 `modelIndex -> Model*` 原始指针注册表，模型所有权和生命周期变成隐式全局状态。
2. C# 通过 `_dllLoader == null` 等内部状态推断“外部 index 模式”，空构造对象的语义发生隐式变化，没有明确的公开句柄类型或绑定接口。
3. bridge 在 C++ 侧重新拼装 JSON、mask 指针和结果内存释放逻辑，与已有 DVT/DVST 结果路径形成第二套协议，后续容易出现字段和内存语义不一致。
4. bridge 在查询和完整推理期间持有全局注册表 mutex，会串行化所有通过该 bridge 的调用，并把释放等待与推理耗时耦合。
5. `modelIndex` 只在同一进程、同一个 DLL 实例以及原 C++ `Model` 仍存活时有效，无法作为稳定的跨模块公共句柄契约。

因此先回滚该实现，后续如仍需此能力，建议设计显式的非拥有 handle/bind API，并复用现有结果 ABI，而不是通过空构造状态自动识别。

## 影响

回滚后不再支持以下非正式调用方式：

```csharp
var model = new Model();
model.modelIndex = cppIndex;
model.OwnModelIndex = false;
model.GetModelInfo();
```

以下正式路径不受影响：

```csharp
using (var model = new Model(modelPath, deviceId))
{
    var info = model.GetModelInfo();
}
```

## 最小复现

下面代码通过现有 C API 在同一进程构造 C++ `Model`，然后复现 C# 空构造对象只设置 index 的场景。回滚后，该场景不再受支持；`GetModelInfo()` 无法把该 index 绑定到 C++ 对象。

```csharp
using System;
using System.Runtime.InteropServices;
using dlcv_infer_csharp;

class Repro
{
    [DllImport("dlcv_infer_c_dll.dll", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
    static extern int dlcv_infer_cpp_load_model_c(string path, int deviceId);

    [DllImport("dlcv_infer_c_dll.dll", CallingConvention = CallingConvention.Cdecl)]
    static extern int dlcv_infer_cpp_free_model_c(int modelIndex);

    static void Main()
    {
        int index = dlcv_infer_cpp_load_model_c(@"模型.dvt", 0);
        try
        {
            using (var model = new Model())
            {
                model.modelIndex = index;
                model.OwnModelIndex = false;
                Console.WriteLine(model.GetModelInfo());
            }
        }
        finally
        {
            dlcv_infer_cpp_free_model_c(index);
        }
    }
}
```

将 `模型.dvt` 替换为 `.dvst` 可复现相同的外部 index 绑定场景。

## 验证

- `dlcv_infer_cpp_dll`：Debug/x64 构建成功。
- `DlcvCSharpTest`：Debug/x64 构建成功；仅保留已有 CS0162 warning。
- 普通 DVT：`Model(modelPath, 0)`，batch=1，推理通过。
- 普通 DVST：`Model(modelPath, 0)`，batch=1，推理通过。
- 已确认 `model_index_get_info`、`model_index_infer`、`UsesExternalModelIndexBridge` 和 `external-index-selftest` 均已移除。