### PR TITLE
test: 补全 OpenIVS C# 固定模型统一回归测试

### DIFF
--- a/C#模型测试工程开发文档.md
+++ b/C#模型测试工程开发文档.md
@@ -11,6 +11,7 @@
 
 - 模型加载成功/失败判断
 - 推理成功/失败判断
+- 固定模型预测结果回归校验
 - 推理结果类别列表输出（按出现次数展开）
 - 3 秒平均推理速度
 - Batch 推理速度（单独字段）
@@ -32,7 +33,7 @@
   - 推理前将图片从 BGR 转为 RGB
   - 结果中的 `Mask` 显式 `Dispose`
   - 内存采样使用 `GetProcessMemoryInfo`
-  - 支持 `demo2-rgb-selftest` 子命令：反射驱动 `DlcvDemo2.Form1` 的私有图片加载与 `RunPipeline`，对同一张图分别执行“Demo2 实际入口 RGB”“手工 RGB”“原始 BGR”三条路径并输出签名比对结果
+  - 支持 `demo2-rgb-selftest` 子命令：反射调用 `DlcvDemo2.Form1` 的 `PrepareImageForModelInput` 与 `RunPipeline`，对同一张图分别执行“Demo2 实际入口 RGB”“手工 RGB”“原始 BGR”三种处理并输出签名比对结果
 
 ### 2.2 C++ 工程
 
@@ -48,23 +49,40 @@
     - 若调用 `dlcv_infer::Model(const std::wstring& modelPath, ...)`（推荐）：可直接传 Windows UTF-16 路径，内部处理转码，避免测试代码到处写转换函数
   - Windows 控制台保持 GBK。程序内部生成的 UTF-8 文本在输出前转换为 GBK，再通过 `cout` 或 `cerr` 输出，不设置控制台代码页；模型结果中已经是本地编码的类别名不重复转换。
 
-## 3. 默认测试用例映射
+## 3. 默认固定模型回归用例
 
-- `AOI-旋转框检测.dvt` -> `AOI-测试.jpg`
-- `猫狗-分类.dvt` -> `猫狗-猫.jpg`
-- `气球-实例分割.dvt` -> `气球.jpg`
-- `气球-语义分割.dvt` -> `气球.jpg`
-- `手机屏幕-实例分割.dvt` -> `手机屏幕.jpg`
-- `引脚定位-目标检测.dvt` -> `引脚定位-目标检测.jpg`
-- `OCR.dvt` -> `OCR-1.jpg`
+- `测试无监督-v5_120_50_s.dvt` -> `1786969663716.jpg`
+- `猫狗-分类_120_50_s.dvt` -> `猫狗-狗.jpg`
+- `猫狗-分类_120_50_v.dvt` -> `猫狗-狗.jpg`
+- `气球-大模型_20260830_010011_120_50_s.dvt` -> `气球.jpg`
+- `气球-实例分割_120_50_s.dvt` -> `气球.jpg`
+- `气球-实例分割_120_50_v.dvt` -> `气球.jpg`
+- `气球-语义分割_120_50_s.dvt` -> `气球.jpg`
+- `手机屏幕-实例分割_120_50_s.dvt` -> `手机屏幕.jpg`
+- `引脚定位-目标检测_120_50_s.dvt` -> `引脚定位-目标检测.jpg`
+- `AOI-旋转框检测_120_50_s.dvt` -> `AOI-测试.jpg`
+- `OCR_120_50_s.dvt` -> `OCR-472.jpg`
+
+模型与图片从 `Y:\测试模型` 读取。模型或图片缺失时用例失败。
+
+每个用例依次校验样本数量、结果数量、`category_id`、`category_name`、`with_bbox`、`with_mask`、`with_angle`、score、bbox、area、angle 和 mask。数值容差如下：
+
+- score：`0.002`
+- bbox：`1.0`
+- area：`128.0`
+- angle：`0.05`
+- mask 非零像素数：`128`
+
+mask 校验包含单通道、宽度、高度和非零像素数。DVT 的 mask 通过 C# API 按 bbox 尺寸缩放，固定基准记录 `CSharpObjectResult.Mask` 的实际输出。
 
 ## 4. 输出格式
 
 控制台输出 markdown 表格，列如下：
 
-- 模型
+- 用例
 - 加载（成功/失败 + 耗时 + 增量 + provider + DLL 名）
 - 推理（成功/失败）
+- 结果校验（结果一致/失败字段）
 - 类别列表（例如：气球，气球）
 - 3秒速度
 - Batch速度（单独一列，不支持显示 N/A）
@@ -149,6 +167,12 @@
 ```
 
 ## 6. 构建与运行
+
+### 6.1 统一测试入口
+
+`Test\DlcvCSharpTest\RunAllTests.ps1 [日志路径]` 是日常完整验证入口。脚本隐藏启动一次 `DlcvCSharpTest.exe all-tests`，统一收集 C# 和原生库输出，测试结束后只在控制台显示各组测试状态、耗时及最终统计。全部原始输出保存到一个日志文件；未提供日志路径时，日志保存为程序目录下的 `bin\x64\Release\DlcvCSharpTest-all-tests.log`。
+
+测试程序在单个进程内依次执行 14 项无外部参数自测和 11 个固定模型回归用例。完整清单执行结束后再返回，任一测试失败时返回 `1`，参数或日志路径无效时返回 `2`。日常完整验证只需启动脚本一次，无须分别调用各个 `*-selftest` 子命令。
 
 - 解决方案级构建、项目级构建与发布前构建验证统一通过 `.cursor/skills/vs-build/scripts/build.py` 执行，入口见 `开发文档.md` 的“统一编译说明”
 - 运行文件：

--- a/DlcvCsharpApi/Properties/AssemblyInfo.cs
+++ b/DlcvCsharpApi/Properties/AssemblyInfo.cs
@@ -29,6 +29,6 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.8.25.0")]
-[assembly: AssemblyFileVersion("2026.8.25.0")]
-[assembly: AssemblyInformationalVersion("2026.8.25.0a1")]
+[assembly: AssemblyVersion("2026.9.1.0")]
+[assembly: AssemblyFileVersion("2026.9.1.0")]
+[assembly: AssemblyInformationalVersion("2026.9.1.0a0")]

--- a/DlcvDemo/Properties/AssemblyInfo.cs
+++ b/DlcvDemo/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.8.25.0")]
-[assembly: AssemblyFileVersion("2026.8.25.0")]
-[assembly: AssemblyInformationalVersion("2026.8.25.0a1")]
+[assembly: AssemblyVersion("2026.9.1.0")]
+[assembly: AssemblyFileVersion("2026.9.1.0")]
+[assembly: AssemblyInformationalVersion("2026.9.1.0a0")]
 [assembly: NeutralResourcesLanguage("zh-CN")]

--- a/Test/DlcvCSharpTest/DlcvCSharpTest.csproj
+++ b/Test/DlcvCSharpTest/DlcvCSharpTest.csproj
@@ -71,6 +71,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DvsTempArtifactMonitor.cs" />
+    <Compile Include="ModelRegressionCases.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Test/DlcvCSharpTest/ModelRegressionCases.cs
+++ b/Test/DlcvCSharpTest/ModelRegressionCases.cs
@@ -1,0 +1,136 @@
+using System.Collections.Generic;
+
+namespace DlcvCSharpTest
+{
+    internal sealed class ModelRegressionCase
+    {
+        public readonly string Name;
+        public readonly string ModelFile;
+        public readonly string ImageFile;
+        public readonly List<ModelRegressionSample> Samples;
+
+        public ModelRegressionCase(string name, string modelFile, string imageFile, params ModelRegressionSample[] samples)
+        {
+            Name = name;
+            ModelFile = modelFile;
+            ImageFile = imageFile;
+            Samples = new List<ModelRegressionSample>(samples);
+        }
+    }
+
+    internal sealed class ModelRegressionSample
+    {
+        public readonly List<ModelRegressionResult> Results;
+
+        public ModelRegressionSample(params ModelRegressionResult[] results)
+        {
+            Results = new List<ModelRegressionResult>(results);
+        }
+    }
+
+    internal sealed class ModelRegressionResult
+    {
+        public readonly int CategoryId;
+        public readonly string CategoryName;
+        public readonly double Score;
+        public readonly double[] Bbox;
+        public readonly double Area;
+        public readonly double Angle;
+        public readonly bool WithBbox;
+        public readonly bool WithMask;
+        public readonly bool WithAngle;
+        public readonly ModelRegressionMask Mask;
+
+        public ModelRegressionResult(int categoryId, string categoryName, double score, double[] bbox,
+            double area, double angle, bool withBbox, bool withMask, bool withAngle, ModelRegressionMask mask)
+        {
+            CategoryId = categoryId;
+            CategoryName = categoryName;
+            Score = score;
+            Bbox = bbox;
+            Area = area;
+            Angle = angle;
+            WithBbox = withBbox;
+            WithMask = withMask;
+            WithAngle = withAngle;
+            Mask = mask;
+        }
+    }
+
+    internal sealed class ModelRegressionMask
+    {
+        public readonly int Width;
+        public readonly int Height;
+        public readonly int NonZero;
+
+        public ModelRegressionMask(int width, int height, int nonZero)
+        {
+            Width = width;
+            Height = height;
+            NonZero = nonZero;
+        }
+    }
+
+    internal static class ModelRegressionCases
+    {
+        public const double ScoreTolerance = 0.002;
+        public const double BboxTolerance = 1.0;
+        public const double AreaTolerance = 128.0;
+        public const double AngleTolerance = 0.05;
+        public const int MaskNonZeroTolerance = 128;
+
+        // 结果字段基准来自 dlcv_infer 的 shared_model_regression_cases.json；mask 统计按 C# API 缩放后的局部 Mat 记录。
+        public static readonly List<ModelRegressionCase> Cases = new List<ModelRegressionCase>
+        {
+            Case("测试无监督 DVT", "测试无监督-v5_120_50_s.dvt", "1786969663716.jpg",
+                Sample(Result(0, "NG", 1.0, B(0.0, 13.0, 438.0, 611.0), 248859.5, -100.0, true, true, false, M(438, 611, 249853)))),
+            Case("猫狗分类 Sentinel DVT", "猫狗-分类_120_50_s.dvt", "猫狗-狗.jpg",
+                Sample(Result(0, "狗", 0.9951171875, B(-1.0, -1.0, -1.0, -1.0), -1.0, -100.0, false, false, false, null))),
+            Case("猫狗分类 Virbox DVT", "猫狗-分类_120_50_v.dvt", "猫狗-狗.jpg",
+                Sample(Result(0, "狗", 0.9951171875, B(-1.0, -1.0, -1.0, -1.0), -1.0, -100.0, false, false, false, null))),
+            Case("气球大模型 DVT", "气球-大模型_20260830_010011_120_50_s.dvt", "气球.jpg",
+                Sample(Result(0, "气球", 0.9591543078422546, B(77.875, 59.8125, 486.25, 569.625), 220828.0, -100.0, true, true, false, M(486, 569, 219656)))),
+            Case("气球实例分割 Sentinel DVT", "气球-实例分割_120_50_s.dvt", "气球.jpg",
+                Sample(Result(0, "气球", 0.9892578125, B(41.79999923706055, 29.100000381469727, 517.4000244140625, 622.5000610351562), 228600.0, -100.0, true, true, false, M(517, 622, 227891)))),
+            Case("气球实例分割 Virbox DVT", "气球-实例分割_120_50_v.dvt", "气球.jpg",
+                Sample(Result(0, "气球", 0.9990234375, B(56.20000076293945, 46.0, 505.4000244140625, 588.7999877929688), 227980.0, -100.0, true, true, false, M(505, 588, 227775)))),
+            Case("气球语义分割 DVT", "气球-语义分割_120_50_s.dvt", "气球.jpg",
+                Sample(Result(0, "气球", 1.0, B(68.5714340209961, 54.85714340209961, 498.2857360839844, 579.4285888671875), 219930.140625, -100.0, true, true, false, M(498, 579, 222774)))),
+            Case("手机屏幕实例分割 DVT", "手机屏幕-实例分割_120_50_s.dvt", "手机屏幕.jpg",
+                Sample(Result(0, "划痕", 0.9970703125, B(390.0, 131.28750610351562, 177.857177734375, 39.48750305175781), 1510.0, -100.0, true, true, false, M(177, 39, 1510)))),
+            Case("引脚定位目标检测 DVT", "引脚定位-目标检测_120_50_s.dvt", "引脚定位-目标检测.jpg",
+                Sample(
+                    Result(0, "引脚", 1.0, B(108.65478515625, 73.37890625, 25.25830078125, 33.5849609375), 848.0, -100.0, true, false, false, null),
+                    Result(0, "引脚", 1.0, B(44.564208984375, 187.3984375, 26.297607421875, 46.28515625), 1217.0, -100.0, true, false, false, null),
+                    Result(0, "引脚", 1.0, B(169.3125, 188.52734375, 28.72265625, 45.4384765625), 1305.0, -100.0, true, false, false, null))),
+            Case("AOI 旋转框检测 DVT", "AOI-旋转框检测_120_50_s.dvt", "AOI-测试.jpg",
+                Sample(
+                    Result(5, "电阻", 1.0, B(627.8125, 1191.875, 220.15625, 107.109375), 23580.0, -0.775390625, true, false, true, null),
+                    Result(5, "电阻", 1.0, B(479.0625, 951.25, 170.3125, 84.6875), 14423.0, 0.82421875, true, false, true, null),
+                    Result(5, "电阻", 1.0, B(806.875, 821.25, 176.5625, 81.015625), 14304.0, -0.78466796875, true, false, true, null),
+                    Result(2, "三极管", 0.95947265625, B(523.75, 556.875, 550.3125, 507.8125), 279455.0, 0.802734375, true, false, true, null),
+                    Result(2, "三极管", 0.95166015625, B(220.9375, 1198.75, 629.375, 508.75), 320194.0, -0.798828125, true, false, true, null))),
+            Case("OCR DVT", "OCR_120_50_s.dvt", "OCR-472.jpg",
+                Sample(Result(0, "472", 0.9928385615348816, B(-1.0, -1.0, -1.0, -1.0), -1.0, -100.0, false, false, false, null)))
+        };
+
+        private static ModelRegressionCase Case(string name, string model, string image, params ModelRegressionSample[] samples)
+        {
+            return new ModelRegressionCase(name, model, image, samples);
+        }
+
+        private static ModelRegressionSample Sample(params ModelRegressionResult[] results)
+        {
+            return new ModelRegressionSample(results);
+        }
+
+        private static ModelRegressionResult Result(int categoryId, string categoryName, double score, double[] bbox,
+            double area, double angle, bool withBbox, bool withMask, bool withAngle, ModelRegressionMask mask)
+        {
+            return new ModelRegressionResult(categoryId, categoryName, score, bbox, area, angle, withBbox, withMask, withAngle, mask);
+        }
+
+        private static double[] B(params double[] values) { return values; }
+        private static ModelRegressionMask M(int width, int height, int nonZero) { return new ModelRegressionMask(width, height, nonZero); }
+    }
+}

--- a/Test/DlcvCSharpTest/Program.cs
+++ b/Test/DlcvCSharpTest/Program.cs
@@ -38,16 +38,16 @@ namespace DlcvCSharpTest
 
         private static readonly List<ModelCase> DefaultCases = new List<ModelCase>
         {
-            new ModelCase("AOI-旋转框检测_120_50.dvt", "AOI-1.jpg"),
-            new ModelCase("AOI_120_50.dvst", "AOI-1.jpg"),
-            new ModelCase("猫狗-分类_120_50.dvt", "猫狗-猫.jpg"),
+            new ModelCase("AOI-旋转框检测_120_50_s.dvt", "AOI-1.jpg"),
+            new ModelCase("AOI_120_50_s.dvst", "AOI-1.jpg"),
+            new ModelCase("猫狗-分类_120_50_s.dvt", "猫狗-猫.jpg"),
             new ModelCase("猫狗-分类_120_50_v.dvt", "猫狗-猫.jpg"),
-            new ModelCase("气球-实例分割_120_50.dvt", "气球.jpg"),
+            new ModelCase("气球-实例分割_120_50_s.dvt", "气球.jpg"),
             new ModelCase("气球-实例分割_120_50_v.dvt", "气球.jpg"),
-            new ModelCase("气球-语义分割_120_50.dvt", "气球.jpg"),
-            new ModelCase("手机屏幕-实例分割_120_50.dvt", "手机屏幕.jpg"),
-            new ModelCase("引脚定位-目标检测_120_50.dvt", "引脚定位-目标检测.jpg"),
-            new ModelCase("OCR_120_50.dvt", "OCR-1.jpg")
+            new ModelCase("气球-语义分割_120_50_s.dvt", "气球.jpg"),
+            new ModelCase("手机屏幕-实例分割_120_50_s.dvt", "手机屏幕.jpg"),
+            new ModelCase("引脚定位-目标检测_120_50_s.dvt", "引脚定位-目标检测.jpg"),
+            new ModelCase("OCR_120_50_s.dvt", "OCR-1.jpg")
         };
 
         private static int Main(string[] args)
@@ -1302,7 +1302,7 @@ namespace DlcvCSharpTest
                 total++;
                 var row = RunCase(modelPath, imagePath);
                 rows.Add(row);
-                if (row.LoadStatus.StartsWith("成功") && row.InferStatus == "成功") pass++;
+                if (row.LoadStatus.StartsWith("成功") && row.InferStatus.StartsWith("成功")) pass++;
             }
 
             rows.Add(new CaseRow
@@ -5114,9 +5114,9 @@ namespace DlcvCSharpTest
                 return 1;
             }
 
-            MethodInfo tryLoadImageForInfer = formType.GetMethod("TryLoadImageForInfer", BindingFlags.NonPublic | BindingFlags.Static);
+            MethodInfo prepareImageForModelInput = formType.GetMethod("PrepareImageForModelInput", BindingFlags.NonPublic | BindingFlags.Static);
             MethodInfo runPipeline = formType.GetMethod("RunPipeline", BindingFlags.NonPublic | BindingFlags.Instance);
-            if (tryLoadImageForInfer == null || runPipeline == null)
+            if (prepareImageForModelInput == null || runPipeline == null)
             {
                 Console.WriteLine("未找到 Demo2 关键私有方法");
                 return 1;
@@ -5154,16 +5154,8 @@ namespace DlcvCSharpTest
                 componentField.SetValue(form, componentModel);
                 icField.SetValue(form, icModel);
 
-                object[] loadArgs = { imagePath, null, null, string.Empty };
-                bool loaded = (bool)tryLoadImageForInfer.Invoke(null, loadArgs);
-                if (!loaded)
-                {
-                    Console.WriteLine("TryLoadImageForInfer 失败: " + Convert.ToString(loadArgs[3], CultureInfo.InvariantCulture));
-                    return 1;
-                }
-
-                imageBgr = loadArgs[1] as Mat;
-                entryRgb = loadArgs[2] as Mat;
+                imageBgr = Cv2.ImRead(imagePath, ImreadModes.Unchanged);
+                entryRgb = prepareImageForModelInput.Invoke(null, new object[] { imageBgr }) as Mat;
                 if (imageBgr == null || imageBgr.Empty() || entryRgb == null || entryRgb.Empty())
                 {
                     Console.WriteLine("Demo2 加载图片后得到空图");
@@ -5256,7 +5248,7 @@ namespace DlcvCSharpTest
                 {
                     new { BaseName = "IC", Expected = true },
                     new { BaseName = "ic", Expected = true },
-                    new { BaseName = "BGA", Expected = true },
+                    new { BaseName = "IC-BGA", Expected = true },
                     new { BaseName = "座子", Expected = true },
                     new { BaseName = "开关", Expected = true },
                     new { BaseName = "晶振", Expected = true },

--- a/Test/DlcvCSharpTest/Program.cs
+++ b/Test/DlcvCSharpTest/Program.cs
@@ -36,19 +36,27 @@ namespace DlcvCSharpTest
         private const string FlowInstanceSegFilterModelPath = @"Y:\zxc\模块化任务测试\实例分割筛选测试_120_50.dvst";
         private const string FlowInstanceSegFilterImagePath = @"Y:\zxc\模块化任务测试\实例分割\实例分割滑窗大图.png";
 
-        private static readonly List<ModelCase> DefaultCases = new List<ModelCase>
+        private static readonly List<ModelRegressionCase> DefaultCases = ModelRegressionCases.Cases;
+
+        private sealed class UnifiedTestCase
         {
-            new ModelCase("AOI-旋转框检测_120_50_s.dvt", "AOI-1.jpg"),
-            new ModelCase("AOI_120_50_s.dvst", "AOI-1.jpg"),
-            new ModelCase("猫狗-分类_120_50_s.dvt", "猫狗-猫.jpg"),
-            new ModelCase("猫狗-分类_120_50_v.dvt", "猫狗-猫.jpg"),
-            new ModelCase("气球-实例分割_120_50_s.dvt", "气球.jpg"),
-            new ModelCase("气球-实例分割_120_50_v.dvt", "气球.jpg"),
-            new ModelCase("气球-语义分割_120_50_s.dvt", "气球.jpg"),
-            new ModelCase("手机屏幕-实例分割_120_50_s.dvt", "手机屏幕.jpg"),
-            new ModelCase("引脚定位-目标检测_120_50_s.dvt", "引脚定位-目标检测.jpg"),
-            new ModelCase("OCR_120_50_s.dvt", "OCR-1.jpg")
-        };
+            public readonly string Name;
+            public readonly Func<int> Run;
+
+            public UnifiedTestCase(string name, Func<int> run)
+            {
+                Name = name;
+                Run = run;
+            }
+        }
+
+        private sealed class UnifiedTestResult
+        {
+            public string Name;
+            public int ExitCode;
+            public long ElapsedMilliseconds;
+            public string Error;
+        }
 
         private static int Main(string[] args)
         {
@@ -56,6 +64,11 @@ namespace DlcvCSharpTest
             Model.EnableConsoleLog = false;
             try
             {
+                if (args != null && args.Length >= 1 && string.Equals(args[0], "all-tests", StringComparison.OrdinalIgnoreCase))
+                {
+                    return RunAllTests(args);
+                }
+
                 if (args != null && args.Length >= 1 && string.Equals(args[0], "model-channel-order-selftest", StringComparison.OrdinalIgnoreCase))
                 {
                     return RunModelChannelOrderSelfTest();
@@ -213,6 +226,126 @@ namespace DlcvCSharpTest
                 try { Utils.FreeAllModels(); } catch { }
                 ForceGc();
             }
+        }
+
+        private static int RunAllTests(string[] args)
+        {
+            if (args == null || args.Length > 2)
+            {
+                Console.WriteLine("用法: all-tests [日志路径]");
+                return 2;
+            }
+
+            string logPath;
+            try
+            {
+                logPath = args.Length == 2
+                    ? Path.GetFullPath(args[1])
+                    : Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "DlcvCSharpTest-all-tests.log");
+                string logDirectory = Path.GetDirectoryName(logPath);
+                if (!string.IsNullOrEmpty(logDirectory)) Directory.CreateDirectory(logDirectory);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("日志路径无效: " + ex.Message);
+                return 2;
+            }
+
+            var tests = new List<UnifiedTestCase>
+            {
+                new UnifiedTestCase("模型通道顺序", RunModelChannelOrderSelfTest),
+                new UnifiedTestCase("掩膜旋转框", RunMaskToRBoxSelfTest),
+                new UnifiedTestCase("曲线文字仿射变换", RunCurveTextAffineSelfTest),
+                new UnifiedTestCase("AI方向仿射变换", RunAiOrientationAffineSelfTest),
+                new UnifiedTestCase("检测框重复结果过滤", RunBBoxIoUDedupSelfTest),
+                new UnifiedTestCase("结果数量检查", RunCountResultsSelfTest),
+                new UnifiedTestCase("类别数量检查", RunCategoryCountCheckSelfTest),
+                new UnifiedTestCase("模板数量优先级", RunTemplateCountPrioritySelfTest),
+                new UnifiedTestCase("生成图扩展", RunImageGenerationExpandSelfTest),
+                new UnifiedTestCase("跨模型标签合并", RunCrossModelLabelMergeSelfTest),
+                new UnifiedTestCase("矩形图像矫正", RunRectImageCorrectionSelfTest),
+                new UnifiedTestCase("Demo2路由规则", RunDemo2RouteRuleSelfTest),
+                new UnifiedTestCase("掩膜输出开关", RunWithMaskSelfTest),
+                new UnifiedTestCase("均值计算", RunCalcMeanSelfTest),
+                new UnifiedTestCase("固定模型结果回归", RunDefaultCases)
+            };
+
+            var results = new List<UnifiedTestResult>(tests.Count);
+            TextWriter consoleOutput = Console.Out;
+            var totalWatch = Stopwatch.StartNew();
+            try
+            {
+                using (var log = new StreamWriter(logPath, false, new UTF8Encoding(false)))
+                {
+                    log.AutoFlush = true;
+                    Console.SetOut(log);
+                    Console.WriteLine("==== C# 统一测试详细输出 ====");
+                    Console.WriteLine("开始时间: " + DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture));
+                    Console.WriteLine("用例数量: " + tests.Count);
+
+                    foreach (var test in tests)
+                    {
+                        Console.WriteLine();
+                        Console.WriteLine("==== 开始: " + test.Name + " ====");
+                        var watch = Stopwatch.StartNew();
+                        int exitCode = 1;
+                        string error = null;
+                        try
+                        {
+                            exitCode = test.Run();
+                        }
+                        catch (Exception ex)
+                        {
+                            error = ex.ToString();
+                            Console.WriteLine("测试异常: " + error);
+                        }
+                        finally
+                        {
+                            watch.Stop();
+                            try { Utils.FreeAllModels(); } catch (Exception ex) { Console.WriteLine("释放模型异常: " + ex.Message); }
+                            ForceGc();
+                        }
+
+                        results.Add(new UnifiedTestResult
+                        {
+                            Name = test.Name,
+                            ExitCode = exitCode,
+                            ElapsedMilliseconds = watch.ElapsedMilliseconds,
+                            Error = error
+                        });
+                        Console.WriteLine("==== 结束: " + test.Name + "，状态=" + (exitCode == 0 ? "通过" : "失败")
+                            + "，耗时=" + watch.Elapsed.TotalSeconds.ToString("F2", CultureInfo.InvariantCulture) + "秒 ====");
+                    }
+
+                    totalWatch.Stop();
+                    Console.WriteLine();
+                    Console.WriteLine("==== C# 统一测试详细输出结束 ====");
+                }
+            }
+            catch (Exception ex)
+            {
+                totalWatch.Stop();
+                Console.SetOut(consoleOutput);
+                Console.WriteLine("统一测试无法写入日志: " + ex.Message);
+                return 2;
+            }
+            finally
+            {
+                Console.SetOut(consoleOutput);
+            }
+
+            int passed = results.Count(r => r.ExitCode == 0);
+            Console.WriteLine("==== C# 统一测试汇总 ====");
+            Console.WriteLine("总数: " + results.Count + "，通过: " + passed + "，失败: " + (results.Count - passed));
+            foreach (var result in results)
+            {
+                Console.WriteLine("[" + (result.ExitCode == 0 ? "通过" : "失败") + "] " + result.Name
+                    + "，耗时=" + (result.ElapsedMilliseconds / 1000.0).ToString("F2", CultureInfo.InvariantCulture) + "秒"
+                    + (string.IsNullOrEmpty(result.Error) ? string.Empty : "，异常已记录"));
+            }
+            Console.WriteLine("总耗时: " + totalWatch.Elapsed.TotalSeconds.ToString("F2", CultureInfo.InvariantCulture) + "秒");
+            Console.WriteLine("详细日志: " + logPath);
+            return passed == results.Count ? 0 : 1;
         }
 
         private static readonly HashSet<string> WorkflowCommands = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
@@ -1236,7 +1369,7 @@ namespace DlcvCSharpTest
 
         private static int RunDefaultCases()
         {
-            Console.WriteLine("==== C# 默认测试（DefaultCases） ====");
+            Console.WriteLine("==== C# 固定模型结果回归测试 ====");
             Console.WriteLine("模型目录: " + ModelRoot);
             Console.WriteLine("固定设备: GPU(" + GpuDeviceId + ")");
             Console.WriteLine("固定Batch: " + FixedBatchSize);
@@ -1248,14 +1381,14 @@ namespace DlcvCSharpTest
                 Console.WriteLine("模型目录不存在: " + ModelRoot);
             }
 
-            // 内存泄露专项：只跑一个实例分割模型
+            // 内存检查只使用清单中的实例分割模型。
             string leakModelPath = null;
             string leakImagePath = null;
             if (modelRootOk)
             {
                 foreach (var c in DefaultCases)
                 {
-                    if (!c.ModelFile.Contains("实例分割")) continue;
+                    if (!c.Name.Contains("实例分割")) continue;
                     string mp = Path.Combine(ModelRoot, c.ModelFile);
                     string ip = Path.Combine(ModelRoot, c.ImageFile);
                     if (!File.Exists(mp) || !File.Exists(ip)) continue;
@@ -1266,7 +1399,7 @@ namespace DlcvCSharpTest
             }
 
             var rows = new List<CaseRow>(DefaultCases.Count);
-            int total = 0;
+            int total = DefaultCases.Count;
             int pass = 0;
             foreach (var c in DefaultCases)
             {
@@ -1276,10 +1409,11 @@ namespace DlcvCSharpTest
                 {
                     rows.Add(new CaseRow
                     {
-                        ModelName = c.ModelFile,
-                        LoadStatus = "跳过",
-                        InferStatus = "-",
-                        CategoryList = "模型目录不存在",
+                        ModelName = c.Name,
+                        LoadStatus = "失败",
+                        InferStatus = "未执行",
+                        ResultStatus = "失败：模型目录不存在",
+                        CategoryList = "-",
                         SpeedText = "-",
                         BatchText = "-"
                     });
@@ -1289,20 +1423,20 @@ namespace DlcvCSharpTest
                 {
                     rows.Add(new CaseRow
                     {
-                        ModelName = Path.GetFileName(modelPath),
-                        LoadStatus = "跳过",
-                        InferStatus = "-",
-                        CategoryList = "模型或图片不存在",
+                        ModelName = c.Name,
+                        LoadStatus = "失败",
+                        InferStatus = "未执行",
+                        ResultStatus = "失败：" + (!File.Exists(modelPath) ? "模型不存在" : "图片不存在"),
+                        CategoryList = "-",
                         SpeedText = "-",
                         BatchText = "-"
                     });
                     continue;
                 }
 
-                total++;
-                var row = RunCase(modelPath, imagePath);
+                var row = RunCase(c, modelPath, imagePath);
                 rows.Add(row);
-                if (row.LoadStatus.StartsWith("成功") && row.InferStatus.StartsWith("成功")) pass++;
+                if (row.LoadStatus.StartsWith("成功") && row.InferStatus.StartsWith("成功") && row.ResultStatus == "结果一致") pass++;
             }
 
             rows.Add(new CaseRow
@@ -1310,7 +1444,8 @@ namespace DlcvCSharpTest
                 ModelName = "汇总",
                 LoadStatus = "总数=" + total,
                 InferStatus = "成功=" + pass,
-                CategoryList = "失败=" + (total - pass),
+                ResultStatus = "失败=" + (total - pass),
+                CategoryList = "-",
                 SpeedText = "-",
                 BatchText = "-"
             });
@@ -1318,18 +1453,18 @@ namespace DlcvCSharpTest
             PrintHeader();
             foreach (var r in rows)
             {
-                PrintRow(r.ModelName, r.LoadStatus, r.InferStatus, r.CategoryList, r.SpeedText, r.BatchText);
+                PrintRow(r.ModelName, r.LoadStatus, r.InferStatus, r.ResultStatus, r.CategoryList, r.SpeedText, r.BatchText);
             }
             PrintFooter();
 
             Console.WriteLine("==== 内存泄露专项(仅测1个实例分割模型) ====");
             if (!modelRootOk)
             {
-                Console.WriteLine("跳过：模型目录不存在");
+                Console.WriteLine("失败：模型目录不存在");
             }
             else if (string.IsNullOrEmpty(leakModelPath) || string.IsNullOrEmpty(leakImagePath))
             {
-                Console.WriteLine("跳过：未找到可用实例分割模型");
+                Console.WriteLine("失败：未找到可用实例分割模型");
             }
             else
             {
@@ -2105,13 +2240,14 @@ namespace DlcvCSharpTest
             return true;
         }
 
-        private static CaseRow RunCase(string modelPath, string imagePath)
+        private static CaseRow RunCase(ModelRegressionCase regressionCase, string modelPath, string imagePath)
         {
             var row = new CaseRow
             {
-                ModelName = Path.GetFileName(modelPath),
+                ModelName = regressionCase.Name,
                 LoadStatus = "失败",
                 InferStatus = "失败",
+                ResultStatus = "未校验",
                 CategoryList = "-",
                 SpeedText = "-",
                 BatchText = "-"
@@ -2139,6 +2275,7 @@ namespace DlcvCSharpTest
 
             if (model == null || model.modelIndex == -1)
             {
+                try { if (model != null) model.Dispose(); } catch { }
                 return row;
             }
 
@@ -2151,20 +2288,36 @@ namespace DlcvCSharpTest
                 rgb = new Mat();
                 Cv2.CvtColor(bgr, rgb, ColorConversionCodes.BGR2RGB);
 
-                var p = new JObject { ["threshold"] = 0.05, ["with_mask"] = true };
+                var p = new JObject { ["threshold"] = 0.5, ["with_mask"] = true };
                 try
                 {
                     var swInfer = Stopwatch.StartNew();
                     var r = model.InferBatch(new List<Mat> { rgb }, p);
                     swInfer.Stop();
-                    row.InferStatus = (r.SampleResults != null && r.SampleResults.Count > 0) ? "成功(" + swInfer.Elapsed.TotalMilliseconds.ToString("F2", CultureInfo.InvariantCulture) + "ms)" : "失败";
-                    row.CategoryList = BuildCategoryList(r);
-                    if (string.IsNullOrWhiteSpace(row.CategoryList)) row.CategoryList = "(空)";
-                    DisposeResultMasks(r);
+                    try
+                    {
+                        row.InferStatus = (r.SampleResults != null && r.SampleResults.Count > 0) ? "成功(" + swInfer.Elapsed.TotalMilliseconds.ToString("F2", CultureInfo.InvariantCulture) + "ms)" : "失败";
+                        row.CategoryList = BuildCategoryList(r);
+                        if (string.IsNullOrWhiteSpace(row.CategoryList)) row.CategoryList = "(空)";
+                        string validationFailure;
+                        if (ValidateRegressionResult(regressionCase, r, out validationFailure))
+                        {
+                            row.ResultStatus = "结果一致";
+                        }
+                        else
+                        {
+                            row.ResultStatus = "失败：" + validationFailure;
+                        }
+                    }
+                    finally
+                    {
+                        DisposeResultMasks(r);
+                    }
                 }
                 catch (Exception ex)
                 {
                     row.InferStatus = "失败";
+                    row.ResultStatus = "未校验";
                     row.CategoryList = "错误:" + Trim(ex.Message);
                 }
 
@@ -2189,6 +2342,7 @@ namespace DlcvCSharpTest
             catch (Exception ex)
             {
                 row.InferStatus = "失败";
+                row.ResultStatus = "未校验";
                 row.CategoryList = "错误:" + Trim(ex.Message);
             }
             finally
@@ -2200,6 +2354,144 @@ namespace DlcvCSharpTest
             try { model.Dispose(); } catch { }
             ForceGc();
             return row;
+        }
+
+        private static bool ValidateRegressionResult(ModelRegressionCase regressionCase, Utils.CSharpResult actual, out string failure)
+        {
+            var failures = new List<string>();
+            int actualSampleCount = actual.SampleResults == null ? 0 : actual.SampleResults.Count;
+            if (actualSampleCount != regressionCase.Samples.Count)
+            {
+                failures.Add(RegressionMismatch(regressionCase.Name, "samples.count", regressionCase.Samples.Count, actualSampleCount, 0));
+            }
+
+            int sampleCount = Math.Min(regressionCase.Samples.Count, actualSampleCount);
+            for (int sampleIndex = 0; sampleIndex < sampleCount; sampleIndex++)
+            {
+                var expectedSample = regressionCase.Samples[sampleIndex];
+                var actualSample = actual.SampleResults[sampleIndex];
+                int actualResultCount = actualSample.Results == null ? 0 : actualSample.Results.Count;
+                if (actualResultCount != expectedSample.Results.Count)
+                {
+                    failures.Add(RegressionMismatch(regressionCase.Name, "samples[" + sampleIndex + "].results.count", expectedSample.Results.Count, actualResultCount, 0));
+                }
+
+                int resultCount = Math.Min(expectedSample.Results.Count, actualResultCount);
+                for (int resultIndex = 0; resultIndex < resultCount; resultIndex++)
+                {
+                    ValidateRegressionObject(regressionCase.Name, sampleIndex, resultIndex,
+                        expectedSample.Results[resultIndex], actualSample.Results[resultIndex], failures);
+                }
+            }
+
+            failure = failures.Count == 0 ? string.Empty : string.Join("；", failures);
+            return failures.Count == 0;
+        }
+
+        private static void ValidateRegressionObject(string caseName, int sampleIndex, int resultIndex,
+            ModelRegressionResult expected, Utils.CSharpObjectResult actual, List<string> failures)
+        {
+            string path = "samples[" + sampleIndex + "].results[" + resultIndex + "]";
+            if (actual.CategoryId != expected.CategoryId)
+            {
+                failures.Add(RegressionMismatch(caseName, path + ".category_id", expected.CategoryId, actual.CategoryId, 0));
+            }
+            if (!string.Equals(actual.CategoryName, expected.CategoryName, StringComparison.Ordinal))
+            {
+                failures.Add(RegressionMismatch(caseName, path + ".category_name", expected.CategoryName, actual.CategoryName, "无"));
+            }
+            if (actual.WithBbox != expected.WithBbox)
+            {
+                failures.Add(RegressionMismatch(caseName, path + ".with_bbox", expected.WithBbox, actual.WithBbox, "无"));
+            }
+            if (actual.WithMask != expected.WithMask)
+            {
+                failures.Add(RegressionMismatch(caseName, path + ".with_mask", expected.WithMask, actual.WithMask, "无"));
+            }
+            if (actual.WithAngle != expected.WithAngle)
+            {
+                failures.Add(RegressionMismatch(caseName, path + ".with_angle", expected.WithAngle, actual.WithAngle, "无"));
+            }
+            ValidateRegressionNumber(caseName, path + ".score", expected.Score, actual.Score, ModelRegressionCases.ScoreTolerance, failures);
+            ValidateRegressionBbox(caseName, path, expected.Bbox, actual.Bbox, failures);
+            ValidateRegressionNumber(caseName, path + ".area", expected.Area, actual.Area, ModelRegressionCases.AreaTolerance, failures);
+            ValidateRegressionNumber(caseName, path + ".angle", expected.Angle, actual.Angle, ModelRegressionCases.AngleTolerance, failures);
+
+            if (expected.WithMask)
+            {
+                ValidateRegressionMask(caseName, path + ".mask", expected.Mask, actual.Mask, failures);
+            }
+            else if (actual.Mask != null && !actual.Mask.Empty())
+            {
+                failures.Add(RegressionMismatch(caseName, path + ".mask", "空引用", "非空 Mat", "无"));
+            }
+        }
+
+        private static void ValidateRegressionBbox(string caseName, string path, double[] expected, List<double> actual, List<string> failures)
+        {
+            int actualCount = actual == null ? 0 : actual.Count;
+            if (actualCount != expected.Length)
+            {
+                failures.Add(RegressionMismatch(caseName, path + ".bbox.count", expected.Length, actualCount, 0));
+            }
+            int count = Math.Min(expected.Length, actualCount);
+            for (int index = 0; index < count; index++)
+            {
+                ValidateRegressionNumber(caseName, path + ".bbox[" + index + "]", expected[index], actual[index], ModelRegressionCases.BboxTolerance, failures);
+            }
+        }
+
+        private static void ValidateRegressionMask(string caseName, string path, ModelRegressionMask expected, Mat actual, List<string> failures)
+        {
+            if (actual == null)
+            {
+                failures.Add(RegressionMismatch(caseName, path, "非空 Mat", "空引用", "无"));
+                return;
+            }
+            if (actual.Empty())
+            {
+                failures.Add(RegressionMismatch(caseName, path, "非空 Mat", "空 Mat", "无"));
+                return;
+            }
+            if (actual.Width != expected.Width)
+            {
+                failures.Add(RegressionMismatch(caseName, path + ".width", expected.Width, actual.Width, 0));
+            }
+            if (actual.Height != expected.Height)
+            {
+                failures.Add(RegressionMismatch(caseName, path + ".height", expected.Height, actual.Height, 0));
+            }
+            if (actual.Channels() != 1)
+            {
+                failures.Add(RegressionMismatch(caseName, path + ".channels", 1, actual.Channels(), 0));
+                return;
+            }
+            int actualNonZero = Cv2.CountNonZero(actual);
+            if (Math.Abs(actualNonZero - expected.NonZero) > ModelRegressionCases.MaskNonZeroTolerance)
+            {
+                failures.Add(RegressionMismatch(caseName, path + ".nonzero", expected.NonZero, actualNonZero, ModelRegressionCases.MaskNonZeroTolerance));
+            }
+        }
+
+        private static void ValidateRegressionNumber(string caseName, string path, double expected, double actual, double tolerance, List<string> failures)
+        {
+            if (double.IsNaN(actual) || double.IsInfinity(actual) || Math.Abs(expected - actual) > tolerance)
+            {
+                failures.Add(RegressionMismatch(caseName, path, expected, actual, tolerance));
+            }
+        }
+
+        private static string RegressionMismatch(string caseName, string path, object expected, object actual, object tolerance)
+        {
+            return caseName + " " + path + "，期望=" + FormatRegressionValue(expected)
+                + "，实际=" + FormatRegressionValue(actual) + "，容差=" + FormatRegressionValue(tolerance);
+        }
+
+        private static string FormatRegressionValue(object value)
+        {
+            if (value == null) return "空引用";
+            var number = value as IFormattable;
+            return number == null ? value.ToString() : number.ToString(null, CultureInfo.InvariantCulture);
         }
 
         private static bool IsInstanceSegModel(string modelPath)
@@ -2325,13 +2617,13 @@ namespace DlcvCSharpTest
 
         private static void PrintHeader()
         {
-            Console.WriteLine("| 模型 | 加载 | 推理 | 类别列表 | 3秒速度 | Batch速度 |");
-            Console.WriteLine("|---|---|---|---|---|---|");
+            Console.WriteLine("| 用例 | 加载 | 推理 | 结果校验 | 类别列表 | 3秒速度 | Batch速度 |");
+            Console.WriteLine("|---|---|---|---|---|---|---|");
         }
 
-        private static void PrintRow(string model, string load, string infer, string cats, string speed, string batch)
+        private static void PrintRow(string model, string load, string infer, string validation, string cats, string speed, string batch)
         {
-            Console.WriteLine("| " + Safe(model) + " | " + Safe(load) + " | " + Safe(infer) + " | " + Safe(cats) + " | " + Safe(speed) + " | " + Safe(batch) + " |");
+            Console.WriteLine("| " + Safe(model) + " | " + Safe(load) + " | " + Safe(infer) + " | " + Safe(validation) + " | " + Safe(cats) + " | " + Safe(speed) + " | " + Safe(batch) + " |");
         }
 
         private static void PrintFooter()
@@ -5749,18 +6041,12 @@ namespace DlcvCSharpTest
         }
 
 
-        private struct ModelCase
-        {
-            public readonly string ModelFile;
-            public readonly string ImageFile;
-            public ModelCase(string modelFile, string imageFile) { ModelFile = modelFile; ImageFile = imageFile; }
-        }
-
         private struct CaseRow
         {
             public string ModelName;
             public string LoadStatus;
             public string InferStatus;
+            public string ResultStatus;
             public string CategoryList;
             public string SpeedText;
             public string BatchText;

--- a/Test/DlcvCSharpTest/RunAllTests.ps1
+++ b/Test/DlcvCSharpTest/RunAllTests.ps1
@@ -1,0 +1,116 @@
+﻿[CmdletBinding()]
+param(
+    [string]$LogPath
+)
+
+$ErrorActionPreference = "Stop"
+$testExePath = Join-Path $PSScriptRoot "bin\x64\Release\DlcvCSharpTest.exe"
+if (-not (Test-Path -LiteralPath $testExePath -PathType Leaf)) {
+    Write-Error "测试程序不存在，请先构建 Release|x64：$testExePath"
+    exit 2
+}
+
+if ([string]::IsNullOrWhiteSpace($LogPath)) {
+    $LogPath = Join-Path $PSScriptRoot "bin\x64\Release\DlcvCSharpTest-all-tests.log"
+}
+
+$finalLogPath = [IO.Path]::GetFullPath($LogPath)
+$finalLogDirectory = [IO.Path]::GetDirectoryName($finalLogPath)
+if (-not [string]::IsNullOrEmpty($finalLogDirectory)) {
+    [IO.Directory]::CreateDirectory($finalLogDirectory) | Out-Null
+}
+
+$testRunId = [Guid]::NewGuid().ToString("N")
+$testTempDirectory = [IO.Path]::GetTempPath()
+$testTempPrefix = Join-Path $testTempDirectory ("OpenIVS-DlcvCSharpTest-" + $testRunId)
+$managedLogPath = $testTempPrefix + "-managed.log"
+$stdoutLogPath = $testTempPrefix + "-stdout.log"
+$stderrLogPath = $testTempPrefix + "-stderr.log"
+$testProcess = $null
+
+function Add-Utf8Text {
+    param(
+        [IO.Stream]$Destination,
+        [string]$Text
+    )
+
+    $utf8 = New-Object Text.UTF8Encoding($false)
+    $bytes = $utf8.GetBytes($Text)
+    $Destination.Write($bytes, 0, $bytes.Length)
+}
+
+function Add-FileContent {
+    param(
+        [IO.Stream]$Destination,
+        [string]$SourcePath
+    )
+
+    if (-not [IO.File]::Exists($SourcePath)) {
+        return
+    }
+    $source = [IO.File]::OpenRead($SourcePath)
+    try {
+        $source.CopyTo($Destination)
+    }
+    finally {
+        $source.Dispose()
+    }
+}
+
+try {
+    $testProcess = Start-Process `
+        -FilePath $testExePath `
+        -ArgumentList @("all-tests", ('"' + $managedLogPath + '"')) `
+        -WindowStyle Hidden `
+        -RedirectStandardOutput $stdoutLogPath `
+        -RedirectStandardError $stderrLogPath `
+        -Wait `
+        -PassThru
+
+    $finalLog = [IO.File]::Open($finalLogPath, [IO.FileMode]::Create, [IO.FileAccess]::Write, [IO.FileShare]::Read)
+    try {
+        Add-Utf8Text $finalLog "==== 程序标准输出 ====`r`n"
+        Add-FileContent $finalLog $stdoutLogPath
+        Add-Utf8Text $finalLog "`r`n==== 程序标准错误 ====`r`n"
+        Add-FileContent $finalLog $stderrLogPath
+        Add-Utf8Text $finalLog "`r`n==== 各项测试详细输出 ====`r`n"
+        Add-FileContent $finalLog $managedLogPath
+    }
+    finally {
+        $finalLog.Dispose()
+    }
+
+    $stdoutText = [Text.Encoding]::UTF8.GetString([IO.File]::ReadAllBytes($stdoutLogPath))
+    $stdoutLines = $stdoutText -split "`r?`n"
+    $summaryStart = -1
+    for ($index = $stdoutLines.Length - 1; $index -ge 0; $index--) {
+        if ($stdoutLines[$index] -eq "==== C# 统一测试汇总 ====") {
+            $summaryStart = $index
+            break
+        }
+    }
+
+    if ($summaryStart -ge 0) {
+        for ($index = $summaryStart; $index -lt $stdoutLines.Length; $index++) {
+            $line = $stdoutLines[$index]
+            if ($line.StartsWith("详细日志:")) {
+                Write-Output ("详细日志: " + $finalLogPath)
+                break
+            }
+            Write-Output $line
+        }
+    }
+    else {
+        Write-Output "统一测试未生成汇总信息"
+        Write-Output ("详细日志: " + $finalLogPath)
+    }
+
+    exit $testProcess.ExitCode
+}
+finally {
+    foreach ($temporaryPath in @($managedLogPath, $stdoutLogPath, $stderrLogPath)) {
+        if ([IO.File]::Exists($temporaryPath)) {
+            [IO.File]::Delete($temporaryPath)
+        }
+    }
+}

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import shutil
 
 from setuptools import setup
 
-version = '2026.8.25.0a1'
+version = '2026.9.1.0a0'
 
 package_name = "dlcvpro_infer_csharp"  # 包名
 packages: list = [package_name]  # 需要打包的包


### PR DESCRIPTION
## 变更说明

- 修正 C# 测试程序的 Demo2 调用和类别名称
- 更新版本号至 `2026.9.1.0a0`
- 增加 C# 单进程统一测试入口，隐藏执行并集中记录输出
- 增加 11 个固定模型的加载、推理及结果校验
- 校验类别、置信度、检测框、面积、角度及掩膜统计

## 验证结果

- `Release|x64` 构建通过
- 统一测试共 15 个测试组，全部通过
- 固定模型回归共 11 个用例，全部通过
- 已检查提交内容和提交历史，未发现密码、Token、密钥、客户标识或实际模型与图片文件

## 提交记录

- 修正 C# 测试程序
- 更新版本号
- 补全统一模型结果测试
