### PR TITLE
fix: 修复正式打包证书选择并发布 2026.9.2.0

### DIFF
--- a/1_编译打包.bat
+++ b/1_编译打包.bat
@@ -1,19 +1,5 @@
-python "%~dp0sync_assembly_version.py"
-
-"C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe" DlcvDemo\DlcvDemo.csproj /p:Configuration=Release /p:Platform=x64
-
-rm -rf dlcvpro_infer_csharp
-mkdir dlcvpro_infer_csharp
-
-xcopy DlcvDemo\bin\*.exe dlcvpro_infer_csharp\ /Y
-xcopy DlcvDemo\bin\*.config dlcvpro_infer_csharp\ /Y
-xcopy DlcvDemo\bin\*.dll dlcvpro_infer_csharp\ /Y
-xcopy hasp_26146.ini dlcvpro_infer_csharp\ /Y
-
-
-C:\sign-tool\signtool.exe sign /n 深度视觉（广东）人工智能研究有限公司 /t http://time.certum.pl /fd sha256 /v  "dlcvpro_infer_csharp\C# 测试程序.exe"
-
-python -m build --wheel --outdir ./dist
-
+@echo off
+python "%~dp0build_package.py"
+set "BUILD_EXIT_CODE=%ERRORLEVEL%"
 pause
-
+exit /b %BUILD_EXIT_CODE%

--- a/DlcvCsharpApi/Properties/AssemblyInfo.cs
+++ b/DlcvCsharpApi/Properties/AssemblyInfo.cs
@@ -29,6 +29,6 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.9.1.0")]
-[assembly: AssemblyFileVersion("2026.9.1.0")]
-[assembly: AssemblyInformationalVersion("2026.9.1.0a0")]
+[assembly: AssemblyVersion("2026.9.2.0")]
+[assembly: AssemblyFileVersion("2026.9.2.0")]
+[assembly: AssemblyInformationalVersion("2026.9.2.0")]

--- a/DlcvDemo/Properties/AssemblyInfo.cs
+++ b/DlcvDemo/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.9.1.0")]
-[assembly: AssemblyFileVersion("2026.9.1.0")]
-[assembly: AssemblyInformationalVersion("2026.9.1.0a0")]
+[assembly: AssemblyVersion("2026.9.2.0")]
+[assembly: AssemblyFileVersion("2026.9.2.0")]
+[assembly: AssemblyInformationalVersion("2026.9.2.0")]
 [assembly: NeutralResourcesLanguage("zh-CN")]

--- a/build_package.py
+++ b/build_package.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -16,6 +17,7 @@ DEMO_EXE_NAME = "C# 测试程序.exe"
 SIGNTOOL_PATH = Path(r"C:\sign-tool\signtool.exe")
 SIGN_CERT_SUBJECT = "深度视觉（广东）人工智能研究有限公司"
 TIMESTAMP_URL = "http://time.certum.pl"
+CODE_SIGNING_EKU = "1.3.6.1.5.5.7.3.3"
 
 
 def parse_args() -> argparse.Namespace:
@@ -37,6 +39,65 @@ def run_step(name: str, command: list[str]) -> None:
     print(f"[build_package] {name}")
     print(f"[build_package] command: {subprocess.list2cmdline(command)}")
     subprocess.run(command, cwd=REPO_ROOT, check=True)
+
+
+def find_signing_certificate_thumbprint() -> str:
+    powershell = shutil.which("powershell.exe")
+    if powershell is None:
+        raise FileNotFoundError("未找到 powershell.exe，无法读取代码签名证书")
+
+    subject_code_units = ", ".join(str(ord(character)) for character in SIGN_CERT_SUBJECT)
+    script = f"""
+$subjectName = -join @({subject_code_units} | ForEach-Object {{ [char]$_ }})
+$codeSigningEku = '{CODE_SIGNING_EKU}'
+$now = Get-Date
+$certificates = @(Get-ChildItem -LiteralPath 'Cert:\\CurrentUser\\My' | Where-Object {{
+    $certificate = $_
+    $ekuExtension = $certificate.Extensions |
+        Where-Object {{ $_.Oid.Value -eq '2.5.29.37' }} |
+        Select-Object -First 1
+    $hasCodeSigningEku = $null -ne $ekuExtension -and
+        @($ekuExtension.EnhancedKeyUsages | Where-Object {{ $_.Value -eq $codeSigningEku }}).Count -gt 0
+    $certificate.GetNameInfo(
+        [System.Security.Cryptography.X509Certificates.X509NameType]::SimpleName,
+        $false
+    ) -ceq $subjectName -and
+        $certificate.HasPrivateKey -and
+        $certificate.NotBefore -le $now -and
+        $certificate.NotAfter -ge $now -and
+        $hasCodeSigningEku
+}})
+if ($certificates.Count -ne 1) {{
+    [Console]::Error.Write($certificates.Count)
+    exit 1
+}}
+[Console]::Out.Write($certificates[0].Thumbprint.Replace(' ', ''))
+"""
+    powershell_env = os.environ.copy()
+    powershell_env["PSModulePath"] = os.pathsep.join(
+        os.path.expandvars(path)
+        for path in (
+            r"%USERPROFILE%\Documents\WindowsPowerShell\Modules",
+            r"%ProgramFiles%\WindowsPowerShell\Modules",
+            r"%SystemRoot%\System32\WindowsPowerShell\v1.0\Modules",
+        )
+    )
+    result = subprocess.run(
+        [powershell, "-NoProfile", "-NonInteractive", "-Command", script],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="ascii",
+        env=powershell_env,
+    )
+    if result.returncode != 0:
+        certificate_count = result.stderr.strip() or "未知"
+        raise RuntimeError(f"有效代码签名证书数量不是 1：{certificate_count}")
+    thumbprint = result.stdout.strip()
+    if re.fullmatch(r"[0-9A-Fa-f]{40}", thumbprint) is None:
+        raise RuntimeError("代码签名证书指纹格式无效")
+    return thumbprint
 
 
 def rebuild_staging_directory() -> None:
@@ -135,15 +196,18 @@ def main() -> int:
         )
 
         demo_exe = copy_package_files()
+        certificate_thumbprint = find_signing_certificate_thumbprint()
         run_step(
             "签名 C# 测试程序",
             [
                 str(SIGNTOOL_PATH),
                 "sign",
-                "/n",
-                SIGN_CERT_SUBJECT,
-                "/t",
+                "/sha1",
+                certificate_thumbprint,
+                "/tr",
                 TIMESTAMP_URL,
+                "/td",
+                "sha256",
                 "/fd",
                 "sha256",
                 "/v",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import shutil
 
 from setuptools import setup
 
-version = '2026.9.1.0a0'
+version = '2026.9.2.0'
 
 package_name = "dlcvpro_infer_csharp"  # 包名
 packages: list = [package_name]  # 需要打包的包

--- a/开发文档.md
+++ b/开发文档.md
@@ -46,8 +46,8 @@
 
 ## C# 正式编译、打包与安装
 
-- C# 测试程序的正式编译打包入口为仓库根目录 `build_package.py`。
-- `python build_package.py` 依次同步程序集版本，通过 `.cursor/skills/vs-build/scripts/build.py` 以 `Release`、`x64`、`Build`、`minimal` 构建 `DlcvDemo/DlcvDemo.csproj`，重建 `dlcvpro_infer_csharp` 暂存目录，复制程序文件，签名 `C# 测试程序.exe`，并在 `dist/` 生成 wheel。
+- C# 测试程序的正式编译打包入口为仓库根目录 `1_编译打包.bat`，该脚本调用 `python build_package.py` 并返回实际构建状态。
+- `python build_package.py` 依次同步程序集版本，通过 `.cursor/skills/vs-build/scripts/build.py` 以 `Release`、`x64`、`Build`、`minimal` 构建 `DlcvDemo/DlcvDemo.csproj`，重建 `dlcvpro_infer_csharp` 暂存目录，复制程序文件，从当前用户证书存储选择唯一有效的代码签名证书，按证书指纹签名 `C# 测试程序.exe`，并在 `dist/` 生成 wheel。
 - `python build_package.py --install` 在完成上述步骤后，使用当前 Python 环境的 `pip --force-reinstall` 安装本次生成的 wheel。
 - 脚本任一步骤失败时以非零状态退出；成功时输出最终 wheel 路径和安装状态。
 - C++ Qt 测试程序不进入 C# wheel，仍通过 `.cursor/skills/vs-build/scripts/build.py` 单独构建 `dlcv_infer_cpp_qt_demo/dlcv_infer_cpp_qt_demo.vcxproj`。


### PR DESCRIPTION
## 变更内容

- 将版本更新为正式版 `2026.9.2.0`，同步 C# 程序集版本。
- 统一由 `1_编译打包.bat` 调用 `build_package.py`，并返回实际构建状态。
- 从当前用户证书存储筛选唯一有效的代码签名证书，按证书指纹调用 SignTool。
- 使用 RFC 3161 时间戳参数，并为 Windows PowerShell 设置自身模块目录，确保自动构建能够读取证书存储。
- 更新正式编译、签名和打包说明。

## 验证结果

- `1_编译打包.bat` 执行成功。
- SignTool 成功签名 1 个文件，0 个警告、0 个错误。
- 正式版 wheel 内程序签名状态为 `Valid`。
- `2_安装新版.bat` 安装成功，已安装版本为 `2026.9.2.0`。
- 实际分类模型推理通过，结构化与 JSON 结果一致，类别和分数符合基准。
