### PR TITLE
fix: 修复C#测试程序重复打包

### DIFF
--- a/C#测试程序开发文档.md
+++ b/C#测试程序开发文档.md
@@ -32,6 +32,7 @@
   - 说明：当前源码中 **没有**为 `DlcvDemo` 配置“自动复制 `AIModelRPC.exe`”的构建步骤；若要启用 RPC 模式，请确保 `AIModelRPC.exe` 位于以下任一路径（见 `DlcvCsharpApi/Model.cs` 的查找顺序）：
     - `DlcvDemo` 的输出目录（与主 EXE 同目录）
     - SDK 固定路径：`C:\dlcv\Lib\site-packages\dlcvpro_infer_csharp\AIModelRPC.exe`
+  - 正式打包从当前 Python 环境已安装的 `dlcvpro_infer_csharp` 包复制 `AIModelRPC.exe`，并签名后写入新 wheel；打包脚本不会收录 `DlcvDemo.exe` 或其他未列入发布文件清单的 exe。
 
 #### 2.2 运行时外部依赖（必须满足/按功能启用）
 

--- a/DlcvCsharpApi/Properties/AssemblyInfo.cs
+++ b/DlcvCsharpApi/Properties/AssemblyInfo.cs
@@ -29,6 +29,6 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.9.2.0")]
-[assembly: AssemblyFileVersion("2026.9.2.0")]
-[assembly: AssemblyInformationalVersion("2026.9.2.0")]
+[assembly: AssemblyVersion("2026.9.4.0")]
+[assembly: AssemblyFileVersion("2026.9.4.0")]
+[assembly: AssemblyInformationalVersion("2026.9.4.0a0")]

--- a/DlcvDemo/Properties/AssemblyInfo.cs
+++ b/DlcvDemo/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //      生成号
 //      修订号
 //
-[assembly: AssemblyVersion("2026.9.2.0")]
-[assembly: AssemblyFileVersion("2026.9.2.0")]
-[assembly: AssemblyInformationalVersion("2026.9.2.0")]
+[assembly: AssemblyVersion("2026.9.4.0")]
+[assembly: AssemblyFileVersion("2026.9.4.0")]
+[assembly: AssemblyInformationalVersion("2026.9.4.0a0")]
 [assembly: NeutralResourcesLanguage("zh-CN")]

--- a/Test/test_build_package.py
+++ b/Test/test_build_package.py
@@ -1,0 +1,56 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import build_package
+
+
+class CopyPackageFilesTest(unittest.TestCase):
+    def test_only_copies_declared_package_files(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir).resolve()
+            output_dir = repo_root / "DlcvDemo" / "bin"
+            staging_dir = repo_root / build_package.PACKAGE_NAME
+            rpc_exe_source = repo_root / "installed" / build_package.RPC_EXE_NAME
+            output_dir.mkdir(parents=True)
+            rpc_exe_source.parent.mkdir(parents=True)
+
+            for file_name in build_package.PACKAGE_OUTPUT_FILE_NAMES:
+                (output_dir / file_name).write_bytes(file_name.encode("utf-8"))
+
+            rpc_exe_source.write_bytes(b"rpc executable")
+            (output_dir / "AIModelRPC.exe").write_bytes(b"old rpc executable")
+            (output_dir / "DlcvDemo.exe").write_bytes(b"unexpected executable")
+            (output_dir / "DlcvDemo.exe.config").write_bytes(b"unexpected config")
+            (output_dir / "old-runtime.dll").write_bytes(b"unexpected library")
+            (repo_root / "hasp_26146.ini").write_text("test", encoding="utf-8")
+
+            with (
+                patch.object(build_package, "REPO_ROOT", repo_root),
+                patch.object(build_package, "DEMO_OUTPUT_DIR", output_dir),
+                patch.object(build_package, "STAGING_DIR", staging_dir),
+                patch.object(build_package, "RPC_EXE_SOURCE", rpc_exe_source),
+            ):
+                signed_executables = build_package.copy_package_files()
+
+            expected_names = set(build_package.PACKAGE_OUTPUT_FILE_NAMES)
+            expected_names.update({build_package.RPC_EXE_NAME, "hasp_26146.ini"})
+            actual_names = {path.name for path in staging_dir.iterdir()}
+
+            self.assertEqual(expected_names, actual_names)
+            self.assertEqual(
+                list(build_package.SIGNED_EXE_NAMES),
+                [path.name for path in signed_executables],
+            )
+            self.assertEqual(
+                b"rpc executable",
+                (staging_dir / build_package.RPC_EXE_NAME).read_bytes(),
+            )
+            self.assertNotIn("DlcvDemo.exe", actual_names)
+            self.assertNotIn("DlcvDemo.exe.config", actual_names)
+            self.assertNotIn("old-runtime.dll", actual_names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_package.py
+++ b/build_package.py
@@ -14,6 +14,26 @@ PACKAGE_NAME = "dlcvpro_infer_csharp"
 STAGING_DIR = REPO_ROOT / PACKAGE_NAME
 DEMO_OUTPUT_DIR = REPO_ROOT / "DlcvDemo" / "bin"
 DEMO_EXE_NAME = "C# 测试程序.exe"
+RPC_EXE_NAME = "AIModelRPC.exe"
+RPC_EXE_SOURCE = Path(sys.prefix) / "Lib" / "site-packages" / PACKAGE_NAME / RPC_EXE_NAME
+PACKAGE_OUTPUT_FILE_NAMES = (
+    DEMO_EXE_NAME,
+    f"{DEMO_EXE_NAME}.config",
+    "DlcvCsharpApi.dll",
+    "DlcvCsharpApi.dll.config",
+    "ImageViewer.dll",
+    "ImageViewer.dll.config",
+    "Newtonsoft.Json.dll",
+    "OpenCvSharp.dll",
+    "OpenCvSharp.Extensions.dll",
+    "PressureTestRunner.dll",
+    "System.Buffers.dll",
+    "System.Drawing.Common.dll",
+    "System.Memory.dll",
+    "System.Numerics.Vectors.dll",
+    "System.Runtime.CompilerServices.Unsafe.dll",
+)
+SIGNED_EXE_NAMES = (DEMO_EXE_NAME, RPC_EXE_NAME)
 SIGNTOOL_PATH = Path(r"C:\sign-tool\signtool.exe")
 SIGN_CERT_SUBJECT = "深度视觉（广东）人工智能研究有限公司"
 TIMESTAMP_URL = "http://time.certum.pl"
@@ -117,26 +137,28 @@ def rebuild_staging_directory() -> None:
     STAGING_DIR.mkdir()
 
 
-def copy_package_files() -> Path:
+def copy_package_files() -> list[Path]:
     if not DEMO_OUTPUT_DIR.is_dir():
         raise FileNotFoundError(f"未找到 C# 构建输出目录: {DEMO_OUTPUT_DIR}")
 
     rebuild_staging_directory()
 
-    for pattern in ("*.exe", "*.config", "*.dll"):
-        sources = sorted(path for path in DEMO_OUTPUT_DIR.glob(pattern) if path.is_file())
-        if not sources:
-            raise FileNotFoundError(f"构建输出中没有匹配文件: {DEMO_OUTPUT_DIR / pattern}")
-        for source in sources:
-            shutil.copy2(source, STAGING_DIR / source.name)
+    for file_name in PACKAGE_OUTPUT_FILE_NAMES:
+        source = DEMO_OUTPUT_DIR / file_name
+        require_file(source)
+        shutil.copy2(source, STAGING_DIR / source.name)
+
+    require_file(RPC_EXE_SOURCE)
+    shutil.copy2(RPC_EXE_SOURCE, STAGING_DIR / RPC_EXE_NAME)
 
     hasp_ini = REPO_ROOT / "hasp_26146.ini"
     require_file(hasp_ini)
     shutil.copy2(hasp_ini, STAGING_DIR / hasp_ini.name)
 
-    demo_exe = STAGING_DIR / DEMO_EXE_NAME
-    require_file(demo_exe)
-    return demo_exe
+    signed_executables = [STAGING_DIR / file_name for file_name in SIGNED_EXE_NAMES]
+    for executable in signed_executables:
+        require_file(executable)
+    return signed_executables
 
 
 def snapshot_wheels() -> dict[Path, tuple[int, int, int]]:
@@ -195,25 +217,26 @@ def main() -> int:
             ],
         )
 
-        demo_exe = copy_package_files()
+        signed_executables = copy_package_files()
         certificate_thumbprint = find_signing_certificate_thumbprint()
-        run_step(
-            "签名 C# 测试程序",
-            [
-                str(SIGNTOOL_PATH),
-                "sign",
-                "/sha1",
-                certificate_thumbprint,
-                "/tr",
-                TIMESTAMP_URL,
-                "/td",
-                "sha256",
-                "/fd",
-                "sha256",
-                "/v",
-                str(demo_exe),
-            ],
-        )
+        for executable in signed_executables:
+            run_step(
+                f"签名 {executable.name}",
+                [
+                    str(SIGNTOOL_PATH),
+                    "sign",
+                    "/sha1",
+                    certificate_thumbprint,
+                    "/tr",
+                    TIMESTAMP_URL,
+                    "/td",
+                    "sha256",
+                    "/fd",
+                    "sha256",
+                    "/v",
+                    str(executable),
+                ],
+            )
         wheels_before_build = snapshot_wheels()
         run_step(
             "构建 wheel",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import shutil
 
 from setuptools import setup
 
-version = '2026.9.2.0'
+version = '2026.9.4.0a0'
 
 package_name = "dlcvpro_infer_csharp"  # 包名
 packages: list = [package_name]  # 需要打包的包

--- a/开发文档.md
+++ b/开发文档.md
@@ -47,7 +47,7 @@
 ## C# 正式编译、打包与安装
 
 - C# 测试程序的正式编译打包入口为仓库根目录 `1_编译打包.bat`，该脚本调用 `python build_package.py` 并返回实际构建状态。
-- `python build_package.py` 依次同步程序集版本，通过 `.cursor/skills/vs-build/scripts/build.py` 以 `Release`、`x64`、`Build`、`minimal` 构建 `DlcvDemo/DlcvDemo.csproj`，重建 `dlcvpro_infer_csharp` 暂存目录，复制程序文件，从当前用户证书存储选择唯一有效的代码签名证书，按证书指纹签名 `C# 测试程序.exe`，并在 `dist/` 生成 wheel。
+- `python build_package.py` 依次同步程序集版本，通过 `.cursor/skills/vs-build/scripts/build.py` 以 `Release`、`x64`、`Build`、`minimal` 构建 `DlcvDemo/DlcvDemo.csproj`，重建 `dlcvpro_infer_csharp` 暂存目录，按发布文件清单复制主程序及运行库，从当前 Python 环境已安装的 `dlcvpro_infer_csharp` 包复制 `AIModelRPC.exe`，从当前用户证书存储选择唯一有效的代码签名证书，签名 `C# 测试程序.exe` 与 `AIModelRPC.exe`，并在 `dist/` 生成 wheel。内部构建产物 `DlcvDemo.exe` 及对应配置文件不进入 wheel。
 - `python build_package.py --install` 在完成上述步骤后，使用当前 Python 环境的 `pip --force-reinstall` 安装本次生成的 wheel。
 - 脚本任一步骤失败时以非零状态退出；成功时输出最终 wheel 路径和安装状态。
 - C++ Qt 测试程序不进入 C# wheel，仍通过 `.cursor/skills/vs-build/scripts/build.py` 单独构建 `dlcv_infer_cpp_qt_demo/dlcv_infer_cpp_qt_demo.vcxproj`。


### PR DESCRIPTION
## 问题说明

C# wheel 同时包含 `C# 测试程序.exe` 与 `DlcvDemo.exe`。两者来自同一次编译，前者是签名后的正式名称副本，后者是未签名的内部构建产物。原打包脚本还会通配复制输出目录中的历史文件。

## 修改内容

- 将 exe、config、dll 的目录通配复制改为明确发布文件清单。
- 排除 `DlcvDemo.exe` 与 `DlcvDemo.exe.config`。
- 从当前 Python 环境已安装的 `dlcvpro_infer_csharp` 包复制 RPC 模式需要的 `AIModelRPC.exe`。
- 对 `C# 测试程序.exe` 与 `AIModelRPC.exe` 执行代码签名。
- 新增打包文件复制自动检查，验证历史 exe、config 和 dll 不会进入暂存目录。
- 更新版本至 `2026.9.4.0a0`，同步程序集版本和开发文档。

## 验证结果

- `python -m unittest Test.test_build_package -v`：通过。
- `python -m py_compile build_package.py Test/test_build_package.py`：通过。
- `1_编译打包.bat`：Release x64 编译、签名、wheel 构建成功。
- 新 wheel 不含 `DlcvDemo.exe` 与 `DlcvDemo.exe.config`。
- wheel 中 `C# 测试程序.exe` 与 `AIModelRPC.exe` 的 Authenticode 状态均为 `Valid`。