### PR TITLE
fix: 允许DVS归档复用相同模型

### DIFF
--- a/C# API文档.md
+++ b/C# API文档.md
@@ -270,7 +270,7 @@ public class DvsModel : FlowGraphModel
 **`Load` 行为**：
 1. 打开 `.dvst`/`.dvso` 文件，校验头部 `DV\n`；`.dvsp` 当前不支持。
 2. 读取 JSON 头行，解析 `file_list` 和 `file_size` 数组。
-3. 将 `pipeline.json` 和归档内子模型二进制读入内存，不写入模型文件。
+3. 将 `pipeline.json` 和归档内子模型二进制读入内存，不写入模型文件；同名成员内容完全相同时保留第一份并复用，内容不同时抛出 `InvalidDataException`。
 4. 按模型节点编号建立内存模型来源表，并保留 `model_path_original` 和 `model_name`。
 5. 调用带内存模型来源表的 `LoadFromRoot` 完成加载。
 6. 加载期间不创建模型临时文件。

--- a/DlcvCsharpApi/flow/DvsModel.cs
+++ b/DlcvCsharpApi/flow/DvsModel.cs
@@ -73,6 +73,7 @@ namespace DlcvModules
                 throw new InvalidDataException("文件头信息损坏：file_list 或 file_size 缺失或数量不一致");
 
             pipelineJson = null;
+            byte[] pipelineData = null;
             entries = new Dictionary<string, ArchiveEntry>(StringComparer.OrdinalIgnoreCase);
             for (int i = 0; i < fileList.Count; i++)
             {
@@ -87,10 +88,15 @@ namespace DlcvModules
                 if (string.Equals(normalizedName, "pipeline.json", StringComparison.OrdinalIgnoreCase))
                 {
                     if (pipelineJson != null)
-                        throw new InvalidDataException("归档中存在多个 pipeline.json");
+                    {
+                        if (!ByteArraysEqual(pipelineData, data))
+                            throw new InvalidDataException("归档中存在同名但内容不同的文件：pipeline.json");
+                        continue;
+                    }
                     try
                     {
                         pipelineJson = JObject.Parse(Encoding.UTF8.GetString(data));
+                        pipelineData = data;
                     }
                     catch (Exception ex)
                     {
@@ -99,8 +105,12 @@ namespace DlcvModules
                     continue;
                 }
 
-                if (entries.ContainsKey(normalizedName))
-                    throw new InvalidDataException($"归档中存在重复文件：{entryName}");
+                if (entries.TryGetValue(normalizedName, out ArchiveEntry existingEntry))
+                {
+                    if (!ByteArraysEqual(existingEntry.Data, data))
+                        throw new InvalidDataException($"归档中存在同名但内容不同的文件：{entryName}");
+                    continue;
+                }
                 entries[normalizedName] = new ArchiveEntry(normalizedName, data);
             }
 
@@ -158,6 +168,21 @@ namespace DlcvModules
                 offset += read;
             }
             return data;
+        }
+
+        private static bool ByteArraysEqual(byte[] left, byte[] right)
+        {
+            if (ReferenceEquals(left, right))
+                return true;
+            if (left == null || right == null || left.Length != right.Length)
+                return false;
+
+            for (int i = 0; i < left.Length; i++)
+            {
+                if (left[i] != right[i])
+                    return false;
+            }
+            return true;
         }
 
         private static Dictionary<int, FlowModelSource> BuildModelSources(

--- a/Test/DlcvCSharpTest/DlcvCSharpTest.csproj
+++ b/Test/DlcvCSharpTest/DlcvCSharpTest.csproj
@@ -70,6 +70,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DvsArchiveDuplicateSelfTest.cs" />
     <Compile Include="DvsTempArtifactMonitor.cs" />
     <Compile Include="ModelRegressionCases.cs" />
     <Compile Include="Program.cs" />

--- a/Test/DlcvCSharpTest/DvsArchiveDuplicateSelfTest.cs
+++ b/Test/DlcvCSharpTest/DvsArchiveDuplicateSelfTest.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using DlcvModules;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace DlcvCSharpTest
+{
+    internal static class DvsArchiveDuplicateSelfTest
+    {
+        public static int Run()
+        {
+            try
+            {
+                VerifyIdenticalModelDataIsReused();
+                VerifyDifferentModelDataIsRejected();
+                VerifyIdenticalPipelineDataIsReused();
+                VerifyDifferentPipelineDataIsRejected();
+                Console.WriteLine("DVS 同名模型内容检查通过");
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("DVS 同名模型内容检查失败：" + ex.Message);
+                return 1;
+            }
+        }
+
+        private static void VerifyIdenticalModelDataIsReused()
+        {
+            byte[] modelData = Encoding.ASCII.GetBytes("same-model");
+            byte[] archive = BuildArchive(
+                new[] { "pipeline.json", "model.dvt", "./MODEL.DVT" },
+                new[] { Encoding.UTF8.GetBytes("{\"nodes\":[]}"), modelData, modelData });
+            IDictionary entries = ReadArchiveEntries(archive);
+            if (entries.Count != 1)
+                throw new InvalidOperationException("相同内容未复用为一份模型数据");
+        }
+
+        private static void VerifyDifferentModelDataIsRejected()
+        {
+            byte[] archive = BuildArchive(
+                new[] { "pipeline.json", "model.dvt", "./MODEL.DVT" },
+                new[]
+                {
+                    Encoding.UTF8.GetBytes("{\"nodes\":[]}"),
+                    Encoding.ASCII.GetBytes("model-a"),
+                    Encoding.ASCII.GetBytes("model-b"),
+                });
+            try
+            {
+                ReadArchiveEntries(archive);
+            }
+            catch (InvalidDataException ex)
+            {
+                if (ex.Message.Contains("同名但内容不同"))
+                    return;
+                throw;
+            }
+            throw new InvalidOperationException("同名但内容不同的模型未报错");
+        }
+
+        private static void VerifyIdenticalPipelineDataIsReused()
+        {
+            byte[] pipeline = Encoding.UTF8.GetBytes("{\"nodes\":[]}");
+            byte[] archive = BuildArchive(
+                new[] { "pipeline.json", "./PIPELINE.JSON", "model.dvt" },
+                new[] { pipeline, pipeline, Encoding.ASCII.GetBytes("model") });
+            IDictionary entries = ReadArchiveEntries(archive);
+            if (entries.Count != 1)
+                throw new InvalidOperationException("相同流程内容未正确加载");
+        }
+
+        private static void VerifyDifferentPipelineDataIsRejected()
+        {
+            byte[] archive = BuildArchive(
+                new[] { "pipeline.json", "./PIPELINE.JSON" },
+                new[]
+                {
+                    Encoding.UTF8.GetBytes("{\"nodes\":[]}"),
+                    Encoding.UTF8.GetBytes("{\"nodes\":[{}]}"),
+                });
+            try
+            {
+                ReadArchiveEntries(archive);
+            }
+            catch (InvalidDataException ex)
+            {
+                if (ex.Message.Contains("同名但内容不同"))
+                    return;
+                throw;
+            }
+            throw new InvalidOperationException("同名但内容不同的流程文件未报错");
+        }
+
+        private static byte[] BuildArchive(string[] fileNames, byte[][] fileData)
+        {
+            if (fileNames.Length != fileData.Length)
+                throw new ArgumentException("文件名与数据数量不一致");
+
+            var fileSizes = new JArray();
+            foreach (byte[] data in fileData)
+                fileSizes.Add(data.Length);
+            var header = new JObject
+            {
+                ["file_list"] = new JArray(fileNames),
+                ["file_size"] = fileSizes,
+            };
+
+            using (var stream = new MemoryStream())
+            {
+                WriteBytes(stream, Encoding.ASCII.GetBytes("DV\n"));
+                WriteBytes(stream, Encoding.UTF8.GetBytes(header.ToString(Formatting.None) + "\n"));
+                foreach (byte[] data in fileData)
+                    WriteBytes(stream, data);
+                return stream.ToArray();
+            }
+        }
+
+        private static IDictionary ReadArchiveEntries(byte[] archive)
+        {
+            MethodInfo readArchive = typeof(DvsModel).GetMethod(
+                "ReadArchive",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            if (readArchive == null)
+                throw new MissingMethodException(typeof(DvsModel).FullName, "ReadArchive");
+
+            using (var stream = new MemoryStream(archive, false))
+            {
+                object[] arguments = { stream, null, null };
+                try
+                {
+                    readArchive.Invoke(null, arguments);
+                }
+                catch (TargetInvocationException ex) when (ex.InnerException != null)
+                {
+                    throw ex.InnerException;
+                }
+                return (IDictionary)arguments[2];
+            }
+        }
+
+        private static void WriteBytes(Stream stream, byte[] data)
+        {
+            stream.Write(data, 0, data.Length);
+        }
+    }
+}

--- a/Test/DlcvCSharpTest/Program.cs
+++ b/Test/DlcvCSharpTest/Program.cs
@@ -101,6 +101,11 @@ namespace DlcvCSharpTest
                     return RunDvsMemoryLoadingSelfTest(args);
                 }
 
+                if (args != null && args.Length >= 1 && string.Equals(args[0], "dvs-duplicate-entry-selftest", StringComparison.OrdinalIgnoreCase))
+                {
+                    return DvsArchiveDuplicateSelfTest.Run();
+                }
+
                 if (args != null && args.Length >= 1 && string.Equals(args[0], "dvsp-reject-selftest", StringComparison.OrdinalIgnoreCase))
                 {
                     return RunDvspRejectSelfTest(args);
@@ -254,6 +259,7 @@ namespace DlcvCSharpTest
             var tests = new List<UnifiedTestCase>
             {
                 new UnifiedTestCase("模型通道顺序", RunModelChannelOrderSelfTest),
+                new UnifiedTestCase("DVS 同名成员内容", DvsArchiveDuplicateSelfTest.Run),
                 new UnifiedTestCase("掩膜旋转框", RunMaskToRBoxSelfTest),
                 new UnifiedTestCase("曲线文字仿射变换", RunCurveTextAffineSelfTest),
                 new UnifiedTestCase("AI方向仿射变换", RunAiOrientationAffineSelfTest),


### PR DESCRIPTION
## 问题描述

C# API 读取 DVS 归档时，只要规范化后的成员名称重复就会报错。多个流程节点引用同一模型且归档内重复保存了相同二进制时，模型无法加载。

## 修改内容

- 重复成员名称和二进制内容均相同时，保留第一份并继续加载。
- 重复成员名称相同但二进制内容不同时，抛出 InvalidDataException。
- pipeline.json 使用相同的内容检查规则。
- 增加独立自检，覆盖模型成员、pipeline.json、大小写和 ./ 前缀场景。
- 更新 C# API 文档。

## 测试验证

- DlcvCSharpTest.csproj 使用 Debug、x64、Build、minimal 构建成功。
- dvs-duplicate-entry-selftest 退出码为 0。
- 相同内容复用测试通过，不同内容报错测试通过。
